### PR TITLE
Log debug messages to syslog instead of a file

### DIFF
--- a/safe/common/utilities.py
+++ b/safe/common/utilities.py
@@ -76,12 +76,10 @@ def setupLogger():
     """
     myLogger = logging.getLogger('InaSAFE')
     myLogger.setLevel(logging.DEBUG)
-    # create file handler which logs even debug messages
-    # shamelessly harcoding for now
-    # TODO: put logs in <inasafe tmp>/logs/safe.log
-    myLogFile = os.path.join('/tmp', 'safe.log')
-    myFileHandler = logging.FileHandler(myLogFile)
-    myFileHandler.setLevel(logging.DEBUG)
+    # create syslog handler which logs even debug messages
+    #FIXME(ariel): Make this log to /var/log/safe.log instead of /var/log/syslog
+    mySysHandler = logging.handlers.SysLogHandler(address='/dev/log')
+    mySysHandler.setLevel(logging.DEBUG)
     # create console handler with a higher log level
     myConsoleHandler = logging.StreamHandler()
     myConsoleHandler.setLevel(logging.ERROR)
@@ -100,11 +98,11 @@ def setupLogger():
     # create formatter and add it to the handlers
     myFormatter = logging.Formatter(
         '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    myFileHandler.setFormatter(myFormatter)
+    mySysHandler.setFormatter(myFormatter)
     myConsoleHandler.setFormatter(myFormatter)
     myEmailHandler.setFormatter(myFormatter)
     # add the handlers to the logger
-    myLogger.addHandler(myFileHandler)
+    myLogger.addHandler(mySysHandler)
     myLogger.addHandler(myConsoleHandler)
     myLogger.info('Safe Logger Module Loaded')
     myLogger.info('----------------------')


### PR DESCRIPTION
I found an IO error when deploying this on apache (for use with Django).

It introduces logging to syslog (/var/log/syslog) instead of a random file, leaves a note saying we should try to put logs elsewhere, for example in:

```
/var/log/inasafe
```

More or less related, is the fact that I think the applications calling `safe` should deal with setting up the logging, instead of the common module. In `django`, I have logging already set in settings.py and the current implementation interferes with it. My suggestion would be to move the setup logging code to the GUI initialization instead, and leave the core with no default handler, it should be up to the user of the library to define that. 
