### PR TITLE
Do not depend on the third_party module for the nongui code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ dependency_test:
 	@grep -R "geonode" $(NONGUI) || true
 	@grep -R "geoserver" $(NONGUI) || true
 	@grep -R "owslib" $(NONGUI) || true
+	@grep -R "third_party" $(NONGUI) || true
 
 list_gpackages:
 	@echo

--- a/safe/common/utilities.py
+++ b/safe/common/utilities.py
@@ -510,3 +510,14 @@ def create_label(my_tuple, extra_label=None):
         return '[' + ' - '.join(my_tuple) + '] ' + str(extra_label)
     else:
         return '[' + ' - '.join(my_tuple) + ']'
+
+
+# Prefer python's own OrderedDict if it exists
+try:
+    from collections import OrderedDict
+except ImportError:
+    try:
+        from third_party.odict import OrderedDict
+    except ImportError:
+        raise RuntimeError(("Could not find an"
+                            "available OrderedDict implementation"))

--- a/safe/engine/impact_functions_for_testing/categorised_hazard_building_impact.py
+++ b/safe/engine/impact_functions_for_testing/categorised_hazard_building_impact.py
@@ -7,7 +7,7 @@ from safe.common.utilities import (ugettext as tr,
 from safe.storage.vector import Vector
 from safe.common.tables import Table, TableRow
 from safe.engine.interpolation import assign_hazard_values_to_exposure_data
-from third_party.odict import OrderedDict
+from safe.common.utilities import OrderedDict
 
 
 #FIXME: need to normalise all raster data Ole/Kristy

--- a/safe/engine/impact_functions_for_testing/itb_fatality_model_configurable.py
+++ b/safe/engine/impact_functions_for_testing/itb_fatality_model_configurable.py
@@ -6,7 +6,7 @@ from safe.common.utilities import (ugettext as tr,
                                    get_defaults)
 from safe.common.tables import Table, TableRow
 from safe.common.exceptions import InaSAFEError
-from third_party.odict import OrderedDict
+from safe.common.utilities import OrderedDict
 
 import numpy
 

--- a/safe/impact_functions/core.py
+++ b/safe/impact_functions/core.py
@@ -13,7 +13,7 @@ from safe.common.polygon import inside_polygon
 from safe.common.utilities import ugettext as tr
 from safe.common.tables import Table, TableCell, TableRow
 from utilities import pretty_string, remove_double_spaces
-from third_party.odict import OrderedDict
+from safe.common.utilities import OrderedDict
 
 LOGGER = logging.getLogger('InaSAFE')
 

--- a/safe/impact_functions/earthquake/earthquake_building_impact.py
+++ b/safe/impact_functions/earthquake/earthquake_building_impact.py
@@ -1,4 +1,4 @@
-from third_party.odict import OrderedDict
+from safe.common.utilities import OrderedDict
 from safe.impact_functions.core import (
     FunctionProvider, get_hazard_layer, get_exposure_layer, get_question)
 from safe.storage.vector import Vector

--- a/safe/impact_functions/earthquake/itb_earthquake_fatality_model.py
+++ b/safe/impact_functions/earthquake/itb_earthquake_fatality_model.py
@@ -1,5 +1,5 @@
 import numpy
-from third_party.odict import OrderedDict
+from safe.common.utilities import OrderedDict
 import logging
 from safe.impact_functions.core import (
     FunctionProvider,

--- a/safe/impact_functions/generic/categorised_hazard_population.py
+++ b/safe/impact_functions/generic/categorised_hazard_population.py
@@ -11,7 +11,7 @@ from safe.common.utilities import (ugettext as tr,
                                    get_defaults,
                                    round_thousand)
 from safe.common.tables import Table, TableRow
-from third_party.odict import OrderedDict
+from safe.common.utilities import OrderedDict
 
 
 class CategorisedHazardPopulationImpactFunction(FunctionProvider):

--- a/safe/impact_functions/inundation/flood_OSM_building_impact.py
+++ b/safe/impact_functions/inundation/flood_OSM_building_impact.py
@@ -1,4 +1,4 @@
-from third_party.odict import OrderedDict
+from safe.common.utilities import OrderedDict
 
 from safe.impact_functions.core import (
     FunctionProvider, get_hazard_layer, get_exposure_layer, get_question)

--- a/safe/impact_functions/inundation/flood_population_evacuation.py
+++ b/safe/impact_functions/inundation/flood_population_evacuation.py
@@ -1,5 +1,5 @@
 import numpy
-from third_party.odict import OrderedDict
+from safe.common.utilities import OrderedDict
 from safe.impact_functions.core import (
     FunctionProvider,
     get_hazard_layer,

--- a/safe/impact_functions/inundation/flood_population_evacuation_polygon_hazard.py
+++ b/safe/impact_functions/inundation/flood_population_evacuation_polygon_hazard.py
@@ -1,5 +1,5 @@
 import numpy
-from third_party.odict import OrderedDict
+from safe.common.utilities import OrderedDict
 from safe.impact_functions.core import (
     FunctionProvider, get_hazard_layer, get_exposure_layer, get_question)
 from safe.storage.vector import Vector

--- a/safe/impact_functions/volcanic/volcano_building_impact.py
+++ b/safe/impact_functions/volcanic/volcano_building_impact.py
@@ -1,4 +1,4 @@
-from third_party.odict import OrderedDict
+from safe.common.utilities import OrderedDict
 from safe.impact_functions.core import (
     FunctionProvider, get_hazard_layer, get_exposure_layer, get_question)
 from safe.storage.vector import Vector

--- a/safe/postprocessors/abstract_postprocessor.py
+++ b/safe/postprocessors/abstract_postprocessor.py
@@ -16,7 +16,7 @@ from safe.common.exceptions import PostProcessorError
 from safe.common.utilities import (get_defaults,
                                    format_int)
 
-from third_party.odict import OrderedDict
+from safe.common.utilities import OrderedDict
 
 LOGGER = logging.getLogger('InaSAFE')
 


### PR DESCRIPTION
This presents a problem when packaging python-safe for distribution in PyPi.

Ran all tests and they pass in OSX after the change. I also added checks in the Makefile to avoid similar problems in the future.
