### PR TITLE
Correct typo error in check_image

### DIFF
--- a/safe_qgis/utilities/utilities_for_testing.py
+++ b/safe_qgis/utilities/utilities_for_testing.py
@@ -363,7 +363,7 @@ def check_image(control_image_path, test_image_path, tolerance=1000):
             test_pixel = test_image.pixel(x, y)
             if control_pixel != test_pixel:
                 mismatch_count += 1
-                difference_image.setPixel(y, y, QtGui.qRgb(255, 0, 0))
+                difference_image.setPixel(x, y, QtGui.qRgb(255, 0, 0))
     difference_path = unique_filename(
         prefix='difference-%s' % os.path.basename(control_image_path),
         suffix='.png',


### PR DESCRIPTION
Correct typo error in check_image: this was causing image comparing failure when running some of the tests in safe_qgis 
