### PR TITLE
Remove layers from canvas before they get deleted

### DIFF
--- a/safe/common/qgis_interface.py
+++ b/safe/common/qgis_interface.py
@@ -53,6 +53,8 @@ class QgisInterface(QObject):
         QgsMapLayerRegistry.instance().layersAdded.connect(self.addLayers)
         # noinspection PyArgumentList
         QgsMapLayerRegistry.instance().layerWasAdded.connect(self.addLayer)
+        # noinspection PyArgumentList
+        QgsMapLayerRegistry.instance().removeAll.connect(self.removeAllLayers)
 
     @pyqtSlot('QStringList')
     def addLayers(self, theLayers):
@@ -87,6 +89,12 @@ class QgisInterface(QObject):
                  not need this method much.
         """
         pass
+
+    @pyqtSlot()
+    def removeAllLayers(self):
+        """Remove layers from the canvas before they get deleted.
+        """
+        self.canvas.setLayerSet([])
 
     def newProject(self):
         """Create new project


### PR DESCRIPTION
I was running into an error message when running some of the tests: Object::disconnect: Unexpected null parameter

example:
#244 Generated layers are not added to the map registry. ... Object::disconnect: Unexpected null parameter
#245 Check that the post processor does not add spurious report rows. ... Object::disconnect: Unexpected null parameter

From my basic understanding this happens when the canvas tries to use some stored layer pointers but the layers have  already been deleted (in the test cases we load/delete a series of test layers)
Would it make sense to reset the canvas layer list when all layers are removed (which is the what we do in the tests)?  
The current patch seems to fix the "error", but I am not sure if it is the appropriate patch to do.
