### PR TITLE
[HOTFIX] Fix #855

### DIFF
--- a/safe_qgis/report/map.py
+++ b/safe_qgis/report/map.py
@@ -80,13 +80,13 @@ class Map():
         """
         self.layer = layer
 
-    def set_north_arrow_image(self, logo_path):
+    def set_north_arrow_image(self, north_arrow_path):
         """Set image that will be used as organisation logo in reports.
 
-        :param logo_path: Path to image file
-        :type logo_path: str
+        :param north_arrow_path: Path to image file
+        :type north_arrow_path: str
         """
-        self.north_arrow = logo_path
+        self.north_arrow = north_arrow_path
 
     def set_organisation_logo(self, logo):
         """Set image that will be used as organisation logo in reports.

--- a/safe_qgis/widgets/dock.py
+++ b/safe_qgis/widgets/dock.py
@@ -1960,6 +1960,11 @@ class Dock(QtGui.QDockWidget, Ui_DockBase):
         if disclaimer_text != '':
             print_map.set_disclaimer(disclaimer_text)
 
+        north_arrow_path = settings.value(
+            'inasafe/northArrowPath', '', type=str)
+        if north_arrow_path != '':
+            print_map.set_north_arrow_image(north_arrow_path)
+
         print_map.set_template(template_path)
 
         LOGGER.debug('Map Title: %s' % print_map.map_title())


### PR DESCRIPTION
I remember that Tim has made a code for setting north arrow. So I traced it back, I found this commit that still has the 'north arrow code':
https://github.com/AIFDR/inasafe/blob/8a99a2d13c3876141ca8652c0c00177aa385ee42/safe_qgis/widgets/dock.py#L1904

```
north_arrow_path = settings.value(
            'inasafe/northArrowPath', '', type=str)
        if north_arrow_path != '':
            print_map.set_organisation_logo(north_arrow_path)
```

That code won't work anyway (it sets the organisation_logo not the arrow image)

A commit after that (exactly a commit), that code is gone:
https://github.com/AIFDR/inasafe/blob/b1684ac69978ec95a1c0286391e6342b6dbcdb3c/safe_qgis/widgets/dock.py

The strange thing is if we see this commit diff, that commit does not delete the 'north arrow' code:
https://github.com/AIFDR/inasafe/commit/8a99a2d13c3876141ca8652c0c00177aa385ee42
