### PR TITLE
Using compiled resource on impact merge tools.

### DIFF
--- a/safe_qgis/tools/impact_merge_dialog.py
+++ b/safe_qgis/tools/impact_merge_dialog.py
@@ -80,30 +80,13 @@ class ImpactMergeDialog(QDialog, Ui_ImpactMergeDialogBase):
         self.keyword_io = KeywordIO()
 
         # Template Path for composer
-        self.template_path = os.path.join(
-            os.path.dirname(__file__),
-            os.path.pardir,
-            'resources',
-            'qgis-composer-templates',
-            'merged_report.qpt')
+        self.template_path = ':/plugins/inasafe/merged_report.qpt'
 
         # Safe Logo Path
-        self.safe_logo_path = os.path.join(
-            os.path.dirname(__file__),
-            os.path.pardir,
-            'resources',
-            'img',
-            'logos',
-            'inasafe-logo-url.png')
+        self.safe_logo_path = ':/plugins/inasafe/inasafe-logo-url.png'
 
         # Organisation Logo Path
-        self.organisation_logo_path = os.path.join(
-            os.path.dirname(__file__),
-            os.path.pardir,
-            'resources',
-            'img',
-            'logos',
-            'supporters.png')
+        self.organisation_logo_path = ':/plugins/inasafe/supporters.png'
 
         # Disclaimer text
         self.disclaimer = disclaimer()


### PR DESCRIPTION
Regarding this issue: https://github.com/AIFDR/inasafe/issues/832 I changed the use of direct resources to the compiled ones.

It is working and the tests on safe_qgis are passing. The only problem remains: After some experiments by deleting the resources folder, the table on the merged impact report does not get formatted correctly related to the map_qrc_to_file function (https://github.com/AIFDR/inasafe/blob/develop/safe_qgis/utilities/utilities.py#L744). Basically the same underlying problem of the unformatted panel on the dock (https://github.com/AIFDR/inasafe/issues/831)

I will work on that issue on another PR
