### PR TITLE
Use temp dir to generate temp report on impact merge dialog.

### DIFF
--- a/safe/common/utilities.py
+++ b/safe/common/utilities.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 """Utilities for InaSAFE
 """
 import os
@@ -104,15 +105,14 @@ def temp_dir(sub_dir='work'):
     If you specify INASAFE_WORK_DIR as an environment var, it will be
     used in preference to the system temp directory.
 
-    Args:
-        sub_dir str - optional argument which will cause an additional
-                subdirectory to be created e.g. /tmp/inasafe/foo/
+    :param sub_dir: Optional argument which will cause an additional
+        subdirectory to be created e.g. /tmp/inasafe/foo/
+    :type sub_dir: str
 
-    Returns:
-        Path to the output clipped layer (placed in the system temp dir).
+    :return: Path to the output clipped layer (placed in the system temp dir).
+    :rtype: str
 
-    Raises:
-       Any errors from the underlying system calls.
+    :raises: Any errors from the underlying system calls.
     """
     user = getpass.getuser().replace(' ', '_')
     current_date = date.today()

--- a/safe_qgis/tools/impact_merge_dialog.py
+++ b/safe_qgis/tools/impact_merge_dialog.py
@@ -33,8 +33,8 @@ from qgis.core import (
     QgsRectangle,
     QgsAtlasComposition)
 
+from safe.common.utilities import temp_dir
 from safe_qgis.ui.impact_merge_dialog_base import Ui_ImpactMergeDialogBase
-
 from safe_qgis.exceptions import (
     InvalidLayerError,
     EmptyDirectoryError,
@@ -776,7 +776,7 @@ class ImpactMergeDialog(QDialog, Ui_ImpactMergeDialogBase):
             html += html_footer()
 
             file_path = '%s.html' % aggregation_area
-            path = os.path.join(self.out_dir, file_path)
+            path = os.path.join(temp_dir(), file_path)
             html_to_file(html, path)
             self.html_reports[aggregation_area.lower()] = path
 


### PR DESCRIPTION
Regarding resources issue https://github.com/AIFDR/inasafe/pull/861, it will generate the resources needed for impact merge tools on the output directory that is selected by user. I changed it to use temp dir instead.

And some coding standards on temp_dir function itself.

Functionally tested
