### PR TITLE
Fix use native zonal stats checkbox

### DIFF
--- a/safe_qgis/tools/options_dialog.py
+++ b/safe_qgis/tools/options_dialog.py
@@ -197,7 +197,7 @@ class OptionsDialog(QtGui.QDialog, Ui_OptionsDialogBase):
             'inasafe/developer_mode',
             self.cbxDevMode.isChecked())
         settings.setValue(
-            'inasafe/useNativeZonalStats',
+            'inasafe/use_native_zonal_stats',
             self.cbxNativeZonalStats.isChecked())
 
     @staticmethod


### PR DESCRIPTION
due to the wrong settings name the check box was always initialized to false (unchecked)
