### PR TITLE
Fix Volcano Issue #920

### DIFF
--- a/safe/impact_functions/volcanic/volcano_population_evacuation_polygon_hazard.py
+++ b/safe/impact_functions/volcanic/volcano_population_evacuation_polygon_hazard.py
@@ -246,7 +246,7 @@ class VolcanoPolygonHazardPopulation(FunctionProvider):
         # from input polygon and a population count of zero
         new_attributes = my_hazard.get_data()
 
-        # Delete the attribute that has the name (insensitive case) with
+        # Delete the attribute that has the same name (insensitive case) with
         # target field
         for datum in new_attributes:
             attribute_names = datum.keys()


### PR DESCRIPTION
At first, I only want to fix this: https://github.com/AIFDR/inasafe/issues/920. The problem is that, on hazard layer there's an attribute's name that is the same as target field on that IF (population - insensitive).

Should I make this change to all IF @timlinux? or do you have any other proposed solution to this issue?
