### PR TITLE
Dont warn about impact_report missing element

### DIFF
--- a/safe_qgis/report/map.py
+++ b/safe_qgis/report/map.py
@@ -237,7 +237,11 @@ class Map():
         :rtype: list
         """
         missing_elements = []
+        # see issue #994 - some missing elements may be ok
+        allowed_missing_elements = ['impact-report']
         for component_id in self.component_ids:
+            if component_id in allowed_missing_elements:
+                continue
             component = self.composition.getComposerItemById(component_id)
             if component is None:
                 missing_elements.append(component_id)


### PR DESCRIPTION
@akbargumbira I suggest we do not warn for this element (see issue #994).
