### PR TITLE
Dont warn about impact_report missing element

### DIFF
--- a/safe_qgis/widgets/dock.py
+++ b/safe_qgis/widgets/dock.py
@@ -1980,7 +1980,7 @@ class Dock(QtGui.QDockWidget, Ui_DockBase):
 
         print_map.set_template(template_path)
         component_ids = ['safe-logo', 'north-arrow', 'organisation-logo',
-                         'impact-report', 'impact-map', 'impact-legend']
+                         'impact-map', 'impact-legend']
         print_map.set_component_ids(component_ids)
 
         LOGGER.debug('Map Title: %s' % print_map.map_title())


### PR DESCRIPTION
Hi @timlinux, I suggest that the map.py should extend the functionalities to any reporting needs (anyway I started to refactor the reporting modules but haven't finished yet). So, assigning all the element-ids is done outside of the map.py..
