### PR TITLE
Display a rubber band indicating the analysis area

### DIFF
--- a/safe_qgis/widgets/dock.py
+++ b/safe_qgis/widgets/dock.py
@@ -116,7 +116,7 @@ SMALL_ICON_STYLE = styles.SMALL_ICON_STYLE
 LOGO_ELEMENT = m.Image('qrc:/plugins/inasafe/inasafe-logo.png', 'InaSAFE Logo')
 LOGGER = logging.getLogger('InaSAFE')
 
-from pydev import pydevd  # pylint: disable=F0401
+# from pydev import pydevd  # pylint: disable=F0401
 
 
 #noinspection PyArgumentList
@@ -141,9 +141,9 @@ class Dock(QtGui.QDockWidget, Ui_DockBase):
             http://doc.qt.nokia.com/4.7-snapshot/designer-using-a-ui-file.html
         """
         # Enable remote debugging - should normally be commented out.
-        pydevd.settrace(
-           'localhost', port=5678, stdoutToServer=True,
-           stderrToServer=True)
+        # pydevd.settrace(
+        #    'localhost', port=5678, stdoutToServer=True,
+        #    stderrToServer=True)
 
         QtGui.QDockWidget.__init__(self, None)
         self.setupUi(self)


### PR DESCRIPTION
This is useful in debugging to ensure that the correct extents were used and is good user feedback to indicate to them where the analysis was actually carried out after clipping.
