### PR TITLE
Fixed issue with QGIS 2.4 support

### DIFF
--- a/safe_qgis/widgets/dock.py
+++ b/safe_qgis/widgets/dock.py
@@ -1563,6 +1563,8 @@ class Dock(QtGui.QDockWidget, Ui_DockBase):
             layers_to_add.append(self.aggregator.layer)
         layers_to_add.append(qgis_impact_layer)
         QgsMapLayerRegistry.instance().addMapLayers(layers_to_add)
+        # make sure it is active in the legend - needed since QGIS 2.4
+        self.iface.setActiveLayer(qgis_impact_layer)
         # then zoom to it
         if self.zoom_to_impact_flag:
             self.iface.zoomToActiveLayer()


### PR DESCRIPTION
Legend layer not focussed by default any more meant impact layer was not selected and results were not showing in dock.
