### PR TITLE
Take into account hazard and exposure projections #1009

### DIFF
--- a/safe/common/qgis_vector_tools.py
+++ b/safe/common/qgis_vector_tools.py
@@ -24,7 +24,9 @@ if qgis_imported:   # Import QgsRasterLayer if qgis is available
         QgsPoint,
         QgsGeometry,
         QgsFeatureRequest,
-        QgsVectorFileWriter
+        QgsVectorFileWriter,
+        QgsCoordinateReferenceSystem,
+        QgsCoordinateTransform
     )
 
 
@@ -553,3 +555,60 @@ def split_by_polygon2(
     result_layer.commitChanges()
     result_layer.updateExtents()
     return result_layer
+
+
+def extent_to_geo_array(extent, source_crs, dest_crs=None):
+    """Convert the supplied extent to geographic and return as an array.
+
+    :param extent: Rectangle defining a spatial extent in any CRS.
+    :type extent: QgsRectangle
+
+    :param source_crs: Coordinate system used for extent.
+    :type source_crs: QgsCoordinateReferenceSystem
+
+    :returns: a list in the form [xmin, ymin, xmax, ymax] where all
+            coordinates provided are in Geographic / EPSG:4326.
+    :rtype: list
+
+    """
+
+    if (dest_crs == None):
+        geo_crs = QgsCoordinateReferenceSystem()
+        geo_crs.createFromSrid(4326)
+    else:
+        geo_crs = dest_crs
+
+    transform = QgsCoordinateTransform(source_crs, geo_crs)
+
+    # Get the clip area in the layer's crs
+    transformed_extent = transform.transformBoundingBox(extent)
+
+    geo_extent = [
+        transformed_extent.xMinimum(),
+        transformed_extent.yMinimum(),
+        transformed_extent.xMaximum(),
+        transformed_extent.yMaximum()]
+    return geo_extent
+
+
+def reproject_vector_layer(layer, crs):
+    """Reproject a vector layer to given CRS
+
+    :param layer: Vector layer
+    :type extent: QgsVectorLayer
+
+    :param crs: Coordinate system for reprojection.
+    :type crs: QgsCoordinateReferenceSystem
+
+    :returns: a vector layer with the specified projection
+    :rtype: QgsVectorLayer
+
+    """
+
+    base_name = unique_filename()
+    file_name = base_name + '.shp'
+    print "reprojected layer1 %s" % file_name
+    QgsVectorFileWriter.writeAsVectorFormat(
+        layer, file_name, "utf-8", crs, "ESRI Shapefile")
+
+    return QgsVectorLayer(file_name, base_name, "ogr")

--- a/safe/impact_functions/inundation/flood_raster_roads_experimental_optimized.py
+++ b/safe/impact_functions/inundation/flood_raster_roads_experimental_optimized.py
@@ -32,7 +32,8 @@ from safe.common.utilities import get_utm_epsg
 from safe.common.exceptions import GetDataError
 from safe.common.qgis_raster_tools import (
     clip_raster, polygonize_gdal)
-from safe.common.qgis_vector_tools import split_by_polygon_in_out
+from safe.common.qgis_vector_tools import split_by_polygon_in_out, extent_to_geo_array,  reproject_vector_layer
+
 
 
 class FloodRasterRoadsExperimentalFunction2(FunctionProvider):
@@ -101,7 +102,7 @@ class FloodRasterRoadsExperimentalFunction2(FunctionProvider):
             }
             return dict_meta
 
-    title = tr('Be flooded in given thresholds')
+    title = tr('Be flooded in given thresholds-MINE')
 
     parameters = OrderedDict([
         # This field of impact layer marks inundated roads by '1' value
@@ -163,6 +164,17 @@ class FloodRasterRoadsExperimentalFunction2(FunctionProvider):
         H = H.get_layer()
         E = E.get_layer()
 
+        #reproject self.extent to the hazard projection
+        hazard_crs = H.crs()
+        hazard_srsid = hazard_crs.srsid()
+        
+        if (hazard_srsid == 4326):
+            viewport_extent = self.extent
+        else:
+            geo_crs = QgsCoordinateReferenceSystem()
+            geo_crs.createFromSrid(4326)
+            viewport_extent = extent_to_geo_array(QgsRectangle(*self.extent), geo_crs, hazard_crs)
+        
         # Align raster extent and self.extent
         #assuming they are both in the same projection
         raster_extent = H.dataProvider().extent()
@@ -170,14 +182,14 @@ class FloodRasterRoadsExperimentalFunction2(FunctionProvider):
         clip_xmax = raster_extent.xMaximum()
         clip_ymin = raster_extent.yMinimum()
         clip_ymax = raster_extent.yMaximum()
-        if (self.extent[0] > clip_xmin):
-            clip_xmin = self.extent[0]
-        if (self.extent[1] > clip_ymin):
-            clip_ymin = self.extent[1]
-        if (self.extent[2] < clip_xmax):
-            clip_xmax = self.extent[2]
-        if (self.extent[3] < clip_ymax):
-            clip_ymax = self.extent[3]
+        if (viewport_extent[0] > clip_xmin):
+            clip_xmin = viewport_extent[0]
+        if (viewport_extent[1] > clip_ymin):
+            clip_ymin = viewport_extent[1]
+        if (viewport_extent[2] < clip_xmax):
+            clip_xmax = viewport_extent[2]
+        if (viewport_extent[3] < clip_ymax):
+            clip_ymax = viewport_extent[3]
 
         raster_extent = H.dataProvider().extent()
         x_full_delta = raster_extent.xMaximum() - raster_extent.xMinimum()
@@ -198,6 +210,7 @@ class FloodRasterRoadsExperimentalFunction2(FunctionProvider):
         (flooded_polygon_inside, flooded_polygon_outside) = polygonize_gdal(
             small_raster, threshold_min, threshold_max)
 
+
         # Filter geometry and data using the extent
         extent = QgsRectangle(*self.extent)
         request = QgsFeatureRequest()
@@ -210,6 +223,14 @@ class FloodRasterRoadsExperimentalFunction2(FunctionProvider):
                     threshold_min, ))
             raise GetDataError(message)
 
+        #reproject the flood polygons to exposure projection
+        exposure_crs = E.crs()
+        exposure_srsid = exposure_crs.srsid()
+
+        if (hazard_srsid != exposure_srsid):
+            flooded_polygon_inside = reproject_vector_layer(flooded_polygon_inside, E.crs())        
+            flooded_polygon_outside = reproject_vector_layer(flooded_polygon_outside, E.crs())
+        
         # Clip exposure by the extent
         #extent_as_polygon = QgsGeometry().fromRect(extent)
         #no need to clip since It is using a bbox request

--- a/safe_qgis/utilities/utilities.py
+++ b/safe_qgis/utilities/utilities.py
@@ -568,7 +568,7 @@ def is_raster_layer(layer):
         return False
 
 
-def extent_to_geo_array(extent, source_crs):
+def extent_to_geo_array(extent, source_crs, dest_crs=None):
     """Convert the supplied extent to geographic and return as an array.
 
     :param extent: Rectangle defining a spatial extent in any CRS.
@@ -583,8 +583,12 @@ def extent_to_geo_array(extent, source_crs):
 
     """
 
-    geo_crs = QgsCoordinateReferenceSystem()
-    geo_crs.createFromSrid(4326)
+    if (dest_crs == None):
+        geo_crs = QgsCoordinateReferenceSystem()
+        geo_crs.createFromSrid(4326)
+    else:
+        geo_crs = dest_crs
+
     transform = QgsCoordinateTransform(source_crs, geo_crs)
 
     # Get the clip area in the layer's crs


### PR DESCRIPTION
This reflects the changes I did to take into account the projections. 
Without this change the clip extents used for the raster would not be correct. Plus after the polygonization process on the hazard data, the resulting polygons need to be re-projected to the exposure projection before clipping the roads
