### PR TITLE
Fixes for Pep8 Pylint violation and failing test of realtime.

### DIFF
--- a/realtime/sftp_client.py
+++ b/realtime/sftp_client.py
@@ -27,6 +27,7 @@ import paramiko
 
 from realtime.utilities import (
     make_directory,
+    get_path_tail,
     realtime_logger_name)
 from realtime.server_config import (
     BASE_URL,

--- a/safe_qgis/tools/keywords_dialog.py
+++ b/safe_qgis/tools/keywords_dialog.py
@@ -1150,10 +1150,8 @@ class KeywordsDialog(QtGui.QDialog, Ui_KeywordsDialogBase):
             ratio do not use global default, the summation is set to 0.
         :rtype: tuple
         """
-        if not self.radPostprocessing.isChecked():
-            return
         if keywords['category'] != 'postprocessing':
-            return True, 0
+            return True, 0 
         if (keywords.get(youth_ratio_attribute_key, '') !=
                 self.global_default_string):
             return True, 0


### PR DESCRIPTION
@ismailsunni: Note that we will do the age ratio validation if it's an postprocessing layer (already checked in accept method, no need to check it on this function again - it violates pylint as it should return tuple)
