### PR TITLE
This PR adds data source and CRS to the keywords list in dock

### DIFF
--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -636,12 +636,12 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             'valid inputs for a given risk function.'))
         hazard_heading = m.Heading(
             self.tr('Hazard keywords'), **INFO_STYLE)
-        hazard_keywords = self.keyword_io.to_message(
-            hazard_keywords, show_header=False)
+        hazard_keywords = KeywordIO(self.get_hazard_layer()).to_message(
+            show_header=False)
         exposure_heading = m.Heading(
             self.tr('Exposure keywords'), **INFO_STYLE)
-        exposure_keywords = self.keyword_io.to_message(
-            exposure_keywords, show_header=False)
+        exposure_keywords = KeywordIO(self.get_exposure_layer()).to_message(
+            show_header=False)
         message = m.Message(
             heading,
             notes,
@@ -1580,17 +1580,22 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         self.grpQuestion.setEnabled(True)
         self.grpQuestion.setVisible(False)
 
-    def show_generic_keywords(self, keywords):
+    def show_generic_keywords(self, layer):
         """Show the keywords defined for the active layer.
 
         .. note:: The print button will be disabled if this method is called.
 
-        :param keywords: A keywords dictionary.
-        :type keywords: dict
+        .. versionchanged:: 3.3 - changed parameter from keywords object
+            to a layer object so that we can show extra stuff like CRS and
+            data source in the keywords.
+
+        :param layer: A QGIS layer.
+        :type layer: QgsMapLayer
         """
+        keywords = KeywordIO(layer)
         LOGGER.debug('Showing Generic Keywords')
         self.pbnPrint.setEnabled(False)
-        message = self.keyword_io.to_message(keywords)
+        message = keywords.to_message()
         # noinspection PyTypeChecker
         self.show_static_message(message)
 
@@ -1695,7 +1700,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
                     compare_result = compare_version(
                         keyword_version, self.inasafe_version)
                     if compare_result == 0:
-                        self.show_generic_keywords(keywords)
+                        self.show_generic_keywords(layer)
                     elif compare_result > 0:
                         # Layer has older version
                         self.show_keyword_version_message(

--- a/safe/messaging/item/cell.py
+++ b/safe/messaging/item/cell.py
@@ -39,6 +39,14 @@ class Cell(MessageElement):
         :param align: A flag to indicate if special alignment should
             be given to cells if supported in the output renderer.
             Valid options are: None, 'left', 'right', 'center'
+        :type align: basestring
+
+        :param wrap_slash: Whether to replace slashes with the slash plus the
+            html <wbr> tag which will help to e.g. wrap html in small cells if
+            it contains a long filename. Disabled by default as it may cause
+            side effects if the text contains html markup. Only affects
+            to_html calls.
+        :type wrap_slash: bool
 
         We pass the kwargs on to the base class after first removing the
         kwargs that we explicitly expect here so an exception is raised
@@ -52,13 +60,23 @@ class Cell(MessageElement):
         self.header_flag = False
         if 'header' in kwargs:
             self.header_flag = kwargs['header']
+            # dont pass the kw on to the base class as we handled it here
             kwargs.pop('header')
+
         # Also check if align parameter is called before calling the ABC
         self.align = None
         if 'align' in kwargs:
             if kwargs['align'] in [None, 'left', 'right', 'center']:
                 self.align = kwargs['align']
+            # dont pass the kw on to the base class as we handled it here
             kwargs.pop('align')
+
+        # Check if slashes should be wrapped for html
+        self.wrap_slash = False
+        if 'wrap_slash' in kwargs:
+            self.wrap_slash = kwargs['wrap_slash']
+            # dont pass the kw on to the base class as we handled it here
+            kwargs.pop('wrap_slash')
 
         super(Cell, self).__init__(**kwargs)
 
@@ -86,7 +104,7 @@ class Cell(MessageElement):
             if self.style_class is None:
                 self.style_class = 'text-right'
             else:
-                self.style_classs += ' text-right'
+                self.style_class += ' text-right'
         elif self.align is 'center':
             if self.style_class is None:
                 self.style_class = 'text-center'
@@ -95,10 +113,12 @@ class Cell(MessageElement):
         # Check if we have a header or not then render
         if self.header_flag is True:
             return '<th%s>%s</th>\n' % (
-                self.html_attributes(), self.content.to_html())
+                self.html_attributes(), self.content.to_html(
+                    wrap_slash=self.wrap_slash))
         else:
             return '<td%s>%s</td>\n' % (
-                self.html_attributes(), self.content.to_html())
+                self.html_attributes(), self.content.to_html(
+                    wrap_slash=self.wrap_slash))
 
     def to_text(self):
         """Render a Cell MessageElement as plain text

--- a/safe/messaging/item/text.py
+++ b/safe/messaging/item/text.py
@@ -69,8 +69,14 @@ class Text(MessageElement):
         else:
             raise InvalidMessageItemError(text, text.__class__)
 
-    def to_html(self):
+    def to_html(self, wrap_slash=False):
         """Render a Text MessageElement as html.
+
+        :param wrap_slash: Whether to replace slashes with the slash plus the
+            html <wbr> tag which will help to e.g. wrap html in small cells if
+            it contains a long filename. Disabled by default as it may cause
+            side effects if the text contains html markup.
+        :type wrap_slash: bool
 
         :returns: Html representation of the Text MessageElement.
         :rtype: str
@@ -82,7 +88,12 @@ class Text(MessageElement):
             text = ''
             for t in self.text:
                 text += t.to_html() + ' '
-            return ' '.join(text.split())
+            text = ' '.join(text.split())
+        if wrap_slash:
+            # This is a hack to make text wrappable with long filenames TS 3.3
+            text = text.replace('/', '/<wbr>')
+            text = text.replace('\\', '\\<wbr>')
+        return text
 
     def to_text(self):
         """Render a Text MessageElement as plain text

--- a/safe/utilities/keyword_io.py
+++ b/safe/utilities/keyword_io.py
@@ -795,7 +795,7 @@ class KeywordIO(QObject):
             # Next the data source
             keyword = self.tr('Layer source')
             value = self.layer.source()
-            row = self._keyword_to_row(keyword, value)
+            row = self._keyword_to_row(keyword, value, wrap_slash=True)
             table.add(row)
 
         # Finalise the report

--- a/safe/utilities/keyword_io.py
+++ b/safe/utilities/keyword_io.py
@@ -62,13 +62,18 @@ class KeywordIO(QObject):
     .keywords file and this plugins implementation of keyword caching in a
     local sqlite db used for supporting keywords for remote datasources."""
 
-    def __init__(self):
-        """Constructor for the KeywordIO object."""
+    def __init__(self, layer=None):
+        """Constructor for the KeywordIO object.
+
+        .. versionchanged:: 3.3 added optional layer parameter.
+
+        """
         QObject.__init__(self)
         # path to sqlite db path
         self.keyword_db_path = None
         self.setup_keyword_db_path()
         self.connection = None
+        self.layer = layer
 
     def set_keyword_db_path(self, path):
         """Set the path for the keyword database (sqlite).
@@ -706,15 +711,18 @@ class KeywordIO(QObject):
                         return var
         return None
 
-    def to_message(self, keywords, show_header=True):
+    def to_message(self, keywords=None, show_header=True):
         """Format keywords as a message object.
 
         .. versionadded:: 3.2
 
+        .. versionchanged:: 3.3 - default keywords to None
+
         The message object can then be rendered to html, plain text etc.
 
-
-        :param keywords: Keywords to be converted to a message.
+        :param keywords: Keywords to be converted to a message. Optional. If
+            not passed then we will attempt to get keywords from self.layer
+            if it is not None.
         :type keywords: dict
 
         :param show_header: Flag indicating if InaSAFE logo etc. should be
@@ -724,6 +732,8 @@ class KeywordIO(QObject):
         :returns: A safe message object containing a table.
         :rtype: safe.messaging.message
         """
+        if keywords is None and self.layer is not None:
+            keywords = self.read_keywords(self.layer)
         # This order was determined in issue #2313
         preferred_order = [
             'title',
@@ -772,10 +782,27 @@ class KeywordIO(QObject):
             value = keywords[keyword]
             row = self._keyword_to_row(keyword, value)
             table.add(row)
+
+        # If the keywords class was instantiated with a layer object
+        # we can add some context info not stored in the keywords themselves
+        # but that is still useful to see...
+        if self.layer:
+            # First the CRS
+            keyword = self.tr('Reference system')
+            value = self.layer.crs().authid()
+            row = self._keyword_to_row(keyword, value)
+            table.add(row)
+            # Next the data source
+            keyword = self.tr('Layer source')
+            value = self.layer.source()
+            row = self._keyword_to_row(keyword, value)
+            table.add(row)
+
+        # Finalise the report
         report.add(table)
         return report
 
-    def _keyword_to_row(self, keyword, value):
+    def _keyword_to_row(self, keyword, value, wrap_slash=False):
         """Helper to make a message row from a keyword.
 
         .. versionadded:: 3.2
@@ -788,6 +815,12 @@ class KeywordIO(QObject):
 
         :param value: Value of the keyword to be rendered.
         :type value: basestring
+
+        :param wrap_slash: Whether to replace slashes with the slash plus the
+            html <wbr> tag which will help to e.g. wrap html in small cells if
+            it contains a long filename. Disabled by default as it may cause
+            side effects if the text contains html markup.
+        :type wrap_slash: bool
 
         :returns: A row to be added to a messaging table.
         :rtype: safe.messaging.items.row.Row
@@ -841,7 +874,7 @@ class KeywordIO(QObject):
 
         key = m.ImportantText(definition)
         row.add(m.Cell(key))
-        row.add(m.Cell(value))
+        row.add(m.Cell(value, wrap_slash=wrap_slash))
         return row
 
     def _dict_to_row(self, keyword_value):

--- a/safe/utilities/test/test_keyword_io.py
+++ b/safe/utilities/test/test_keyword_io.py
@@ -273,7 +273,7 @@ class KeywordIOTest(unittest.TestCase):
         .. versionadded:: 3.3
         """
         keywords = KeywordIO(self.vector_layer)
-        message = keywords.to_message(keywords).to_text()
+        message = keywords.to_message().to_text()
         self.assertIn('*Reference system*, ', message)
 
     def test_dict_to_row(self):

--- a/safe/utilities/test/test_keyword_io.py
+++ b/safe/utilities/test/test_keyword_io.py
@@ -267,6 +267,15 @@ class KeywordIOTest(unittest.TestCase):
         message = self.keyword_io.to_message(keywords).to_text()
         self.assertIn('*Exposure*, structure------', message)
 
+    def test_layer_to_message(self):
+        """Test to show augmented keywords if KeywordsIO ctor passed a layer.
+
+        .. versionadded:: 3.3
+        """
+        keywords = KeywordIO(self.vector_layer)
+        message = keywords.to_message(keywords).to_text()
+        self.assertIn('*Reference system*, ', message)
+
     def test_dict_to_row(self):
         """Test the dict to row helper works.
 


### PR DESCRIPTION
<img width="369" alt="screen shot 2015-11-30 at 07 42 31" src="https://cloud.githubusercontent.com/assets/178003/11461453/f9cba176-9735-11e5-8b76-f2516b7e0589.png">

It takes care to wrap long filenames nicely (needs testing on Windows).

This was added to make it easier to know what CRS and file path a dataset has.