### PR TITLE
add flood prone to the OSM downloader

### DIFF
--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -301,6 +301,8 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
             feature_types.append('buildings')
         if self.building_points_flag.isChecked():
             feature_types.append('building-points')
+        if self.flood_prone_flag.isChecked():
+            feature_types.append('flood-prone')
         if self.potential_idp_flag.isChecked():
             feature_types.append('potential-idp')
         if self.boundary_flag.isChecked():

--- a/safe/gui/tools/test/test_osm_downloader_dialog.py
+++ b/safe/gui/tools/test/test_osm_downloader_dialog.py
@@ -49,6 +49,7 @@ class OsmDownloaderDialogTest(unittest.TestCase):
         self.dialog.roads_flag.setChecked(False)
         self.dialog.buildings_flag.setChecked(False)
         self.dialog.building_points_flag.setChecked(False)
+        self.dialog.flood_prone_flag.setChecked(False)
         self.dialog.potential_idp_flag.setChecked(False)
         self.dialog.boundary_flag.setChecked(False)
         expected = []
@@ -58,6 +59,7 @@ class OsmDownloaderDialogTest(unittest.TestCase):
         self.dialog.roads_flag.setChecked(True)
         self.dialog.buildings_flag.setChecked(True)
         self.dialog.building_points_flag.setChecked(True)
+        self.dialog.flood_prone_flag.setChecked(False)
         self.dialog.potential_idp_flag.setChecked(True)
         self.dialog.boundary_flag.setChecked(False)
         expected = ['roads', 'buildings', 'building-points', 'potential-idp']
@@ -69,10 +71,15 @@ class OsmDownloaderDialogTest(unittest.TestCase):
         self.dialog.roads_flag.setChecked(False)
         self.dialog.buildings_flag.setChecked(True)
         self.dialog.building_points_flag.setChecked(True)
+        self.dialog.flood_prone_flag.setChecked(True)
         self.dialog.potential_idp_flag.setChecked(True)
         self.dialog.boundary_flag.setChecked(True)
         expected = [
-            'buildings', 'building-points', 'potential-idp', 'boundary-6']
+            'buildings',
+            'building-points',
+            'flood-prone',
+            'potential-idp',
+            'boundary-6']
         get = self.dialog.get_checked_features()
         self.assertItemsEqual(expected, get)
 

--- a/safe/gui/ui/osm_downloader_dialog_base.ui
+++ b/safe/gui/ui/osm_downloader_dialog_base.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>642</width>
-    <height>471</height>
+    <height>494</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -123,7 +123,7 @@
           <item row="3" column="0">
            <widget class="QCheckBox" name="flood_prone_flag">
             <property name="text">
-             <string>Flood prone</string>
+             <string>Flood prone areas</string>
             </property>
            </widget>
           </item>

--- a/safe/gui/ui/osm_downloader_dialog_base.ui
+++ b/safe/gui/ui/osm_downloader_dialog_base.ui
@@ -6,24 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>627</width>
-    <height>440</height>
+    <width>642</width>
+    <height>471</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>OSM Downloader</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_5">
-   <property name="leftMargin">
-    <number>12</number>
-   </property>
-   <property name="topMargin">
-    <number>12</number>
-   </property>
-   <property name="rightMargin">
-    <number>12</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>12</number>
    </property>
    <item row="0" column="0">
@@ -33,20 +24,11 @@
      </property>
      <widget class="QWidget" name="page">
       <layout class="QGridLayout" name="gridLayout_8">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
        <item row="0" column="0">
-        <widget class="QWebView" name="help_web_view">
+        <widget class="QWebView" name="help_web_view" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>
@@ -59,7 +41,7 @@
            <height>100</height>
           </size>
          </property>
-         <property name="url">
+         <property name="url" stdset="0">
           <url>
            <string>about:blank</string>
           </url>
@@ -70,16 +52,7 @@
      </widget>
      <widget class="QWidget" name="page_1">
       <layout class="QGridLayout" name="gridLayout_2">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
        <item row="0" column="0">
@@ -130,7 +103,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QCheckBox" name="potential_idp_flag">
             <property name="text">
              <string extracomment="Internally displaced person">Potential internally displaced person camps</string>
@@ -140,10 +113,17 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QCheckBox" name="boundary_flag">
             <property name="text">
              <string>Political boundaries</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="flood_prone_flag">
+            <property name="text">
+             <string>Flood prone</string>
             </property>
            </widget>
           </item>
@@ -267,16 +247,7 @@
             <property name="sizeConstraint">
              <enum>QLayout::SetDefaultConstraint</enum>
             </property>
-            <property name="leftMargin">
-             <number>1</number>
-            </property>
-            <property name="topMargin">
-             <number>1</number>
-            </property>
-            <property name="rightMargin">
-             <number>1</number>
-            </property>
-            <property name="bottomMargin">
+            <property name="margin">
              <number>1</number>
             </property>
             <property name="spacing">


### PR DESCRIPTION
Ticket : https://github.com/inasafe/inasafe/issues/2469
- [x] Flood prone areas

![osm_downloader](https://cloud.githubusercontent.com/assets/1609292/11585115/e509c61e-9a69-11e5-8ed3-da30a60ded90.png)

## Attribute table
* flood_prone as floodprone
* flood_rain
* flood_send
* flood_depth
* flood_duration
* flood_latest
* fire_hazard
* kab_name
* kec_name
* kel_name
* rt_number
* rw_number

The last 5 fields are not documented in OSM but I think they are linked to flood prone areas.
