### PR TITLE
Fix #2504

### DIFF
--- a/safe/messaging/item/table.py
+++ b/safe/messaging/item/table.py
@@ -60,8 +60,14 @@ class Table(MessageElement):
         else:
             raise InvalidMessageItemError(item, item.__class__)
 
-    def to_html(self):
+    def to_html(self, wrap_slash=False):
         """Render a Table MessageElement as html
+
+        :param wrap_slash: Whether to replace slashes with the slash plus the
+            html <wbr> tag which will help to e.g. wrap html in small cells if
+            it contains a long filename. Disabled by default as it may cause
+            side effects if the text contains html markup.
+        :type wrap_slash: bool
 
         :returns: The html representation of the Table MessageElement
         :rtype: basestring
@@ -73,6 +79,11 @@ class Table(MessageElement):
         for row in self.rows:
             table += row.to_html()
         table += '</tbody>\n</table>\n'
+
+        if wrap_slash:
+            # This is a hack to make text wrappable with long filenames TS 3.3
+            text = text.replace('/', '/<wbr>')
+            text = text.replace('\\', '\\<wbr>')
 
         return table
 


### PR DESCRIPTION
This is an dirty and easy fix of #2504 - see my comment there.

The code is just copied from safe.messaging.item.text.Text.html(). As the table contains html tags with slashes, the parameter is definitely not meant to be set to True. However, Maybe the parameter should take no action in this class, and the docstring should say this parameter is abstract?  @timlinux could you please decide which solution is less bad? :)