### PR TITLE
Better fix for #2504 - exception when calling Table.to_html() method

### DIFF
--- a/safe/messaging/item/cell.py
+++ b/safe/messaging/item/cell.py
@@ -110,15 +110,22 @@ class Cell(MessageElement):
                 self.style_class = 'text-center'
             else:
                 self.style_class += ' text-center'
+
+        # Special case for when we want to put a nested table in a cell
+        # We don't use isinstance because of recursive imports with table
+        class_name = self.content.__class__.__name__
+        if class_name in ['BulletedList', 'Table']:
+            html = self.content.to_html()
+        else:
+            html = self.content.to_html(wrap_slash=self.wrap_slash)
+
         # Check if we have a header or not then render
         if self.header_flag is True:
             return '<th%s>%s</th>\n' % (
-                self.html_attributes(), self.content.to_html(
-                    wrap_slash=self.wrap_slash))
+                self.html_attributes(), html)
         else:
             return '<td%s>%s</td>\n' % (
-                self.html_attributes(), self.content.to_html(
-                    wrap_slash=self.wrap_slash))
+                self.html_attributes(), html)
 
     def to_text(self):
         """Render a Cell MessageElement as plain text


### PR DESCRIPTION
Fix #2504 - exception raised when messaging cell contains nested table or bullet list due to slashes param not being accepted by table class to_html() method.

See also #2494 and #2506 