### PR TITLE
Use Date Picker in Keywords Wizard. Get rid of eval() statements.

### DIFF
--- a/safe/gui/tools/test/test_wizard_dialog.py
+++ b/safe/gui/tools/test/test_wizard_dialog.py
@@ -499,7 +499,7 @@ class WizardDialogTest(unittest.TestCase):
         message = 'Source Url should be empty'
         self.assertEqual(dialog.leSource_url.text(), '', message)
         message = 'Source Date should be empty'
-        self.assertEqual(dialog.leSource_date.text(), '', message)
+        self.assertTrue(dialog.dtSource_date.dateTime().isNull(), message)
         message = 'Source Scale should be empty'
         self.assertEqual(dialog.leSource_scale.text(), '', message)
         dialog.pbnNext.click()
@@ -582,13 +582,15 @@ class WizardDialogTest(unittest.TestCase):
         source = 'Source'
         source_scale = 'Source Scale'
         source_url = 'Source Url'
-        source_date = 'Source Date'
+        source_date = QtCore.QDateTime.fromString(
+            '06-12-2015 12:30',
+            'dd-MM-yyyy HH:mm')
         source_license = 'Source License'
 
         dialog.leSource.setText(source)
         dialog.leSource_scale.setText(source_scale)
         dialog.leSource_url.setText(source_url)
-        dialog.leSource_date.setText(source_date)
+        dialog.dtSource_date.setDateTime(source_date)
         dialog.leSource_license.setText(source_license)
         dialog.pbnNext.click()  # next
         dialog.pbnNext.click()  # next
@@ -670,8 +672,9 @@ class WizardDialogTest(unittest.TestCase):
         self.assertEqual(dialog.leSource_url.text(), source_url, message)
         message = 'Source Scale should be %s' % source_scale
         self.assertEqual(dialog.leSource_scale.text(), source_scale, message)
-        message = 'Source Date should be %s' % source_date
-        self.assertEqual(dialog.leSource_date.text(), source_date, message)
+        message = 'Source Date should be %s' % source_date.toString(
+            'dd-MM-yyyy HH:mm')
+        self.assertEqual(dialog.dtSource_date.dateTime(), source_date, message)
         message = 'Source License should be %s' % source_license
         self.assertEqual(dialog.leSource_license.text(),
                          source_license, message)

--- a/safe/gui/tools/test/test_wizard_dialog.py
+++ b/safe/gui/tools/test/test_wizard_dialog.py
@@ -217,10 +217,7 @@ class WizardDialogTest(unittest.TestCase):
         categories = []
         hazard_index = -1
         for i in range(expected_category_count):
-            # pylint: disable=eval-used
-            category_name = eval(
-                dialog.lstCategories.item(i).data(Qt.UserRole))['key']
-            # pylint: enable=eval-used
+            category_name = dialog.lstCategories.item(i).data(Qt.UserRole)
             categories.append(category_name)
             if category_name == chosen_category:
                 hazard_index = i
@@ -255,10 +252,7 @@ class WizardDialogTest(unittest.TestCase):
         subcategories = []
         tsunami_index = -1
         for i in range(expected_subcategory_count):
-            # pylint: disable=eval-used
-            subcategory_name = eval(
-                dialog.lstSubcategories.item(i).data(Qt.UserRole))['key']
-            # pylint: enable=eval-used
+            subcategory_name = dialog.lstSubcategories.item(i).data(Qt.UserRole)
             subcategories.append(subcategory_name)
             if subcategory_name == chosen_subcategory:
                 tsunami_index = i
@@ -291,10 +285,8 @@ class WizardDialogTest(unittest.TestCase):
         hazard_categories = []
         scenario_index = -1
         for i in range(expected_hazard_category_count):
-            # pylint: disable=eval-used
-            hazard_category_name = eval(
-                dialog.lstHazardCategories.item(i).data(Qt.UserRole))['name']
-            # pylint: enable=eval-used
+            key = dialog.lstHazardCategories.item(i).data(Qt.UserRole)
+            hazard_category_name = KeywordIO.definition(key)['name']
             hazard_categories.append(hazard_category_name)
             if hazard_category_name == chosen_hazard_category:
                 scenario_index = i
@@ -329,10 +321,7 @@ class WizardDialogTest(unittest.TestCase):
         # Get all the modes given and save the classified index
         modes = []
         for i in range(expected_mode_count):
-            # pylint: disable=eval-used
-            mode_name = eval(
-                dialog.lstLayerModes.item(i).data(Qt.UserRole))['key']
-            # pylint: enable=eval-used
+            mode_name = dialog.lstLayerModes.item(i).data(Qt.UserRole)
             modes.append(mode_name)
         # Check if units is the same with expected_units
         message = ('Invalid modes! It should be "%s" while it was '

--- a/safe/gui/tools/test/test_wizard_dialog_locale.py
+++ b/safe/gui/tools/test/test_wizard_dialog_locale.py
@@ -19,6 +19,7 @@ __copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
 import unittest
 import os
 import sys
+from PyQt4.QtCore import QDateTime
 
 skipped_reason = (
     'These tests are skipped because it will make a segmentation fault. Just '
@@ -179,12 +180,14 @@ class TestWizardDialogLocale(unittest.TestCase):
         source = 'Source'
         source_scale = 'Source Scale'
         source_url = 'Source Url'
-        source_date = 'Source Date'
+        source_date = QDateTime.fromString(
+            '06-12-2015 12:30',
+            'dd-MM-yyyy HH:mm')
 
         dialog.leSource.setText(source)
         dialog.leSource_scale.setText(source_scale)
         dialog.leSource_url.setText(source_url)
-        dialog.leSource_date.setText(source_date)
+        dialog.leSource_date.seDateTime(source_date)
         dialog.pbnNext.click()  # next
         dialog.pbnNext.click()  # finish
 
@@ -239,8 +242,9 @@ class TestWizardDialogLocale(unittest.TestCase):
         self.assertEqual(dialog.leSource.text(), source, message)
         message = 'Source Url should be %s' % source_url
         self.assertEqual(dialog.leSource_url.text(), source_url, message)
-        message = 'Source Date should be %s' % source_date
-        self.assertEqual(dialog.leSource_date.text(), source_date, message)
+        message = 'Source Date should be %s' % source_date.toString(
+            'dd-MM-yyyy HH:mm')
+        self.assertEqual(dialog.leSource_date.dateTime(), source_date, message)
         message = 'Source Scale should be %s' % source_scale
         self.assertEqual(dialog.leSource_scale.text(), source_scale, message)
         dialog.pbnNext.click()

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -98,6 +98,7 @@ from safe.gui.tools.function_options_dialog import (
     FunctionOptionsDialog)
 from safe.utilities.unicode import get_unicode
 from safe.utilities.i18n import tr
+import safe.gui.tools.wizard_strings
 from safe.gui.tools.wizard_strings import (
     category_question,
     category_question_hazard,
@@ -123,27 +124,6 @@ from safe.gui.tools.wizard_strings import (
     select_explayer_from_canvas_question,
     select_explayer_from_browser_question,
     create_postGIS_connection_first)
-
-# TODO(Ismail): We need a better way to import all of these string
-# pylint: disable=unused-import
-from safe.gui.tools.wizard_strings import (
-    earthquake_mmi_question,
-    exposure_question,
-    flood_feet_depth_question,
-    flood_metres_depth_question,
-    flood_wetdry_question,
-    hazard_question,
-    population_density_question,
-    population_number_question,
-    road_road_type_question,
-    structure_building_type_question,
-    tephra_kgm2_question,
-    tsunami_feet_depth_question,
-    tsunami_metres_depth_question,
-    tsunami_wetdry_question,
-    volcano_volcano_categorical_question
-)
-# pylint: enable=unused-import
 
 LOGGER = logging.getLogger('InaSAFE')
 
@@ -214,10 +194,9 @@ def get_question_text(constant):
     :returns: The value of the constant or red error message.
     :rtype: string
     """
-    try:
-        # TODO Eval = bad
-        return eval(constant)  # pylint: disable=eval-used
-    except NameError:
+    if constant in dir(safe.gui.tools.wizard_strings):
+        return getattr(safe.gui.tools.wizard_strings, constant)
+    else:
         return '<b>MISSING CONSTANT: %s</b>' % constant
 
 

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -41,7 +41,7 @@ from qgis.core import (
 # noinspection PyPackageRequirements
 from PyQt4 import QtGui, QtCore
 # noinspection PyPackageRequirements
-from PyQt4.QtCore import pyqtSignature, QSettings, QPyNullVariant
+from PyQt4.QtCore import pyqtSignature, QSettings, QPyNullVariant, QDateTime
 # noinspection PyPackageRequirements
 from PyQt4.QtGui import (
     QDialog,
@@ -1902,9 +1902,12 @@ class WizardDialog(QDialog, FORM_CLASS):
             self.leSource_scale.setText(get_unicode(source_scale))
 
         source_date = self.get_existing_keyword('date')
-        if source_date or source_date == 0:
-            self.leSource_date.setText(get_unicode(source_date))
-
+        if source_date:
+            self.dtSource_date.setDateTime(
+                QDateTime.fromString(get_unicode(source_date),
+                                     'dd-MM-yyyy HH:mm'))
+        else:
+            self.dtSource_date.clear()
         source_url = self.get_existing_keyword('url')
         if source_url or source_url == 0:
             self.leSource_url.setText(get_unicode(source_url))
@@ -4513,8 +4516,9 @@ class WizardDialog(QDialog, FORM_CLASS):
             keywords['url'] = get_unicode(self.leSource_url.text())
         if self.leSource_scale.text():
             keywords['scale'] = get_unicode(self.leSource_scale.text())
-        if self.leSource_date.text():
-            keywords['date'] = get_unicode(self.leSource_date.text())
+        if self.dtSource_date.dateTime():
+            keywords['date'] = get_unicode(
+                self.dtSource_date.dateTime().toString('dd-MM-yyyy HH:mm'))
         if self.leSource_license.text():
             keywords['license'] = get_unicode(self.leSource_license.text())
         if self.leTitle.text():
@@ -4576,6 +4580,6 @@ class WizardDialog(QDialog, FORM_CLASS):
 
         self.leTitle.setToolTip(title_tooltip)
         self.leSource.setToolTip(source_tooltip)
-        self.leSource_date.setToolTip(date_tooltip)
+        self.dtSource_date.setToolTip(date_tooltip)
         self.leSource_scale.setToolTip(scale_tooltip)
         self.leSource_url.setToolTip(url_tooltip)

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -53,11 +53,6 @@ from PyQt4.QtGui import (
 from db_manager.db_plugins.postgis.connector import PostGisDBConnector
 # pylint: enable=F0401
 
-# pylint: disable=unused-import
-# TODO: to get rid of the following import,
-# TODO: we need to get rid of all those evals...TS
-from safe import definitions
-# pylint: enable=unused-import
 from safe.definitions import (
     inasafe_keyword_version,
     inasafe_keyword_version_key,
@@ -666,11 +661,8 @@ class WizardDialog(QDialog, FORM_CLASS):
         :rtype: dict, None
         """
         item = self.lstCategories.currentItem()
-
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -694,11 +686,9 @@ class WizardDialog(QDialog, FORM_CLASS):
             categories += ['aggregation']
         for category in categories:
             if not isinstance(category, dict):
-                # pylint: disable=eval-used
-                category = eval('definitions.layer_purpose_%s' % category)
-                # pylint: enable=eval-used
+                category = KeywordIO().definition(category)
             item = QListWidgetItem(category['name'], self.lstCategories)
-            item.setData(QtCore.Qt.UserRole, unicode(category))
+            item.setData(QtCore.Qt.UserRole, category['key'])
             self.lstCategories.addItem(item)
 
         # Check if layer keywords are already assigned
@@ -713,10 +703,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             categories = []
             for index in xrange(self.lstCategories.count()):
                 item = self.lstCategories.item(index)
-                # pylint: disable=eval-used
-                category = eval(item.data(QtCore.Qt.UserRole))
-                # pylint: enable=eval-used
-                categories.append(category['key'])
+                categories.append(item.data(QtCore.Qt.UserRole))
             if category_keyword in categories:
                 self.lstCategories.setCurrentRow(
                     categories.index(category_keyword))
@@ -768,9 +755,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         """
         item = self.lstSubcategories.currentItem()
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -791,7 +776,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             get_question_text('%s_question' % category['key']))
         for i in self.subcategories_for_layer():
             item = QListWidgetItem(i['name'], self.lstSubcategories)
-            item.setData(QtCore.Qt.UserRole, unicode(i))
+            item.setData(QtCore.Qt.UserRole, i['key'])
             self.lstSubcategories.addItem(item)
 
         # Check if layer keywords are already assigned
@@ -807,10 +792,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             subcategories = []
             for index in xrange(self.lstSubcategories.count()):
                 item = self.lstSubcategories.item(index)
-                # pylint: disable=eval-used
-                subcategory = eval(item.data(QtCore.Qt.UserRole))
-                # pylint: enable=eval-used
-                subcategories.append(subcategory['key'])
+                subcategories.append(item.data(QtCore.Qt.UserRole))
             if keyword in subcategories:
                 self.lstSubcategories.setCurrentRow(
                     subcategories.index(keyword))
@@ -852,11 +834,8 @@ class WizardDialog(QDialog, FORM_CLASS):
         :rtype: dict, None
         """
         item = self.lstHazardCategories.currentItem()
-
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -875,13 +854,10 @@ class WizardDialog(QDialog, FORM_CLASS):
         hazard_categories = self.hazard_categories_for_layer()
         for hazard_category in hazard_categories:
             if not isinstance(hazard_category, dict):
-                # pylint: disable=eval-used
-                hazard_category = eval('definitions.hazard_category_%s'
-                                       % hazard_category)
-                # pylint: enable=eval-used
+                hazard_category = KeywordIO().definition(hazard_category)
             item = QListWidgetItem(hazard_category['name'],
                                    self.lstHazardCategories)
-            item.setData(QtCore.Qt.UserRole, unicode(hazard_category))
+            item.setData(QtCore.Qt.UserRole, hazard_category['key'])
             self.lstHazardCategories.addItem(item)
 
         # Set values based on existing keywords (if already assigned)
@@ -890,10 +866,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             categories = []
             for index in xrange(self.lstHazardCategories.count()):
                 item = self.lstHazardCategories.item(index)
-                # pylint: disable=eval-used
-                hazard_category = eval(item.data(QtCore.Qt.UserRole))
-                # pylint: enable=eval-used
-                categories.append(hazard_category['key'])
+                categories.append(item.data(QtCore.Qt.UserRole))
             if category_keyword in categories:
                 self.lstHazardCategories.setCurrentRow(
                     categories.index(category_keyword))
@@ -933,9 +906,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         """
         item = self.lstLayerModes.currentItem()
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -961,7 +932,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         layer_modes = self.layermodes_for_layer()
         for layer_mode in layer_modes:
             item = QListWidgetItem(layer_mode['name'], self.lstLayerModes)
-            item.setData(QtCore.Qt.UserRole, unicode(layer_mode))
+            item.setData(QtCore.Qt.UserRole, layer_mode['key'])
             self.lstUnits.addItem(item)
 
         # Set value to existing keyword or default value
@@ -1009,9 +980,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         """
         item = self.lstUnits.currentItem()
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -1046,7 +1015,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             #     continue
             # else:
             item = QListWidgetItem(unit_for_layer['name'], self.lstUnits)
-            item.setData(QtCore.Qt.UserRole, unicode(unit_for_layer))
+            item.setData(QtCore.Qt.UserRole, unit_for_layer['key'])
             self.lstUnits.addItem(item)
 
         # Set values based on existing keywords (if already assigned)
@@ -1060,10 +1029,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             units = []
             for index in xrange(self.lstUnits.count()):
                 item = self.lstUnits.item(index)
-                # pylint: disable=eval-used
-                unit = eval(item.data(QtCore.Qt.UserRole))
-                # pylint: enable=eval-used
-                units.append(unit['key'])
+                units.append(item.data(QtCore.Qt.UserRole))
             if unit_id in units:
                 self.lstUnits.setCurrentRow(units.index(unit_id))
 
@@ -1098,9 +1064,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         """
         item = self.lstClassifications.currentItem()
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -1117,12 +1081,10 @@ class WizardDialog(QDialog, FORM_CLASS):
         classifications = self.classifications_for_layer()
         for classification in classifications:
             if not isinstance(classification, dict):
-                # pylint: disable=eval-used
-                classification = eval('definitions.%s' % classification)
-                # pylint: enable=eval-used
+                classification = KeywordIO.definition(classification)
             item = QListWidgetItem(classification['name'],
                                    self.lstClassifications)
-            item.setData(QtCore.Qt.UserRole, unicode(classification))
+            item.setData(QtCore.Qt.UserRole, classification['key'])
             self.lstClassifications.addItem(item)
 
         # Set values based on existing keywords (if already assigned)
@@ -1133,10 +1095,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             classifications = []
             for index in xrange(self.lstClassifications.count()):
                 item = self.lstClassifications.item(index)
-                # pylint: disable=eval-used
-                classification = eval(item.data(QtCore.Qt.UserRole))
-                # pylint: enable=eval-used
-                classifications.append(classification['key'])
+                classifications.append(item.data(QtCore.Qt.UserRole))
             if classification_keyword in classifications:
                 self.lstClassifications.setCurrentRow(
                     classifications.index(classification_keyword))
@@ -1171,7 +1130,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         desc = '<br/>%s: %s<br/><br/>' % (self.tr('Field type'), field_type)
         desc += self.tr('Unique values: %s') % ', '.join(unique_values_str)
         self.lblDescribeField.setText(desc)
-        # Enable the next button
+        # Enable the next buttonlayer_purpose_aggregation
         self.pbnNext.setEnabled(True)
 
     def selected_field(self):

--- a/safe/gui/ui/wizard_dialog_base.ui
+++ b/safe/gui/ui/wizard_dialog_base.ui
@@ -1541,13 +1541,6 @@
                </property>
               </widget>
              </item>
-             <item row="3" column="1">
-              <widget class="QLineEdit" name="leSource_date">
-               <property name="styleSheet">
-                <string notr="true">font: 11pt &quot;Ubuntu&quot;;</string>
-               </property>
-              </widget>
-             </item>
              <item row="1" column="1">
               <widget class="QLineEdit" name="leSource_url">
                <property name="styleSheet">
@@ -1564,7 +1557,7 @@
                 <string>Date</string>
                </property>
                <property name="buddy">
-                <cstring>leSource_date</cstring>
+                <cstring>dtSource_date</cstring>
                </property>
               </widget>
              </item>
@@ -1578,6 +1571,16 @@
                </property>
                <property name="buddy">
                 <cstring>leSource_license</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QgsDateTimeEdit" name="dtSource_date">
+               <property name="displayFormat">
+                <string>dd.MM.yyyy HH:mm</string>
+               </property>
+               <property name="calendarPopup">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -3827,6 +3830,11 @@ Please step back and select another layer.</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>qgsdatetimeedit.h</header>
+  </customwidget>
+  <customwidget>
    <class>MessageViewer</class>
    <extends>QWidget</extends>
    <header>safe.gui.widgets.message_viewer</header>
@@ -3851,7 +3859,7 @@ Please step back and select another layer.</string>
   <tabstop>leSource</tabstop>
   <tabstop>leSource_url</tabstop>
   <tabstop>leSource_scale</tabstop>
-  <tabstop>leSource_date</tabstop>
+  <tabstop>dtSource_date</tabstop>
   <tabstop>leSource_license</tabstop>
   <tabstop>leTitle</tabstop>
   <tabstop>dsbFemaleRatioDefault</tabstop>

--- a/safe/messaging/item/table.py
+++ b/safe/messaging/item/table.py
@@ -60,14 +60,8 @@ class Table(MessageElement):
         else:
             raise InvalidMessageItemError(item, item.__class__)
 
-    def to_html(self, wrap_slash=False):
+    def to_html(self):
         """Render a Table MessageElement as html
-
-        :param wrap_slash: Whether to replace slashes with the slash plus the
-            html <wbr> tag which will help to e.g. wrap html in small cells if
-            it contains a long filename. Disabled by default as it may cause
-            side effects if the text contains html markup.
-        :type wrap_slash: bool
 
         :returns: The html representation of the Table MessageElement
         :rtype: basestring
@@ -79,11 +73,6 @@ class Table(MessageElement):
         for row in self.rows:
             table += row.to_html()
         table += '</tbody>\n</table>\n'
-
-        if wrap_slash:
-            # This is a hack to make text wrappable with long filenames TS 3.3
-            text = text.replace('/', '/<wbr>')
-            text = text.replace('\\', '\\<wbr>')
 
         return table
 

--- a/safe/messaging/item/table.py
+++ b/safe/messaging/item/table.py
@@ -60,8 +60,14 @@ class Table(MessageElement):
         else:
             raise InvalidMessageItemError(item, item.__class__)
 
-    def to_html(self):
+    def to_html(self, wrap_slash=False):
         """Render a Table MessageElement as html
+
+        :param wrap_slash: Whether to replace slashes with the slash plus the
+            html <wbr> tag which will help to e.g. wrap html in small cells if
+            it contains a long filename. Disabled by default as it may cause
+            side effects if the text contains html markup.
+        :type wrap_slash: bool
 
         :returns: The html representation of the Table MessageElement
         :rtype: basestring
@@ -73,6 +79,11 @@ class Table(MessageElement):
         for row in self.rows:
             table += row.to_html()
         table += '</tbody>\n</table>\n'
+
+        if wrap_slash:
+            # This is a hack to make text wrappable with long filenames TS 3.3
+            text = text.replace('/', '/<wbr>')
+            text = text.replace('\\', '\\<wbr>')
 
         return table
 


### PR DESCRIPTION
1. Get rid of eval() statements. Fixes #2329
2. Use QgsDateTimeEdit for the `date` keyword. Fixes for #2499. 

In the existing test dataset I found the date keyword is usually missing, but when present, it's always stored as 'dd-MM-yyyy HH:mm'. So I made the wizard always using that format (no localisation!). I hope it's ok.

Please ignore the other reverted commits - I just didn't know how to squash commits that are already not on the top of the stack.