### PR TITLE
Backport to  3.2.5

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -15,7 +15,7 @@ qgisMaximumVersion=2.99
 description=InaSAFE is free software that allows disaster managers to study realistic natural hazard impact scenarios for better planning, preparedness and response activities.
 about=Developed for the Indonesian Government - BNPB, Australian Government - AIFDR and DMInnovation and, and World Bank - GFDRR
 
-version=3.2.4
+version=3.2.5
 # alpha, beta, rc or final
 status=final
 
@@ -25,12 +25,18 @@ status=final
 # Optional items:
 
 changelog=
-        3.2.4
-        Working implementation of on-the-fly-projection for polygon flood on building points/polys. fix #2475
-        [Wizard] Add Keywords Creation Wizard confirmation step. Fixes #2422
-        [IFCW] After registering keywords in the KW sub-thread, don't display again the step from where it was called. Fixes #2347
-        Fix some translation issues
-        Added windows installer files
+        3.2.5
+        Adds data source and CRS to the keywords list in dock
+        Wizard: ged rid of eval() statements #2329
+        Use Date Picker in Keywords Wizard #2499
+        Fix Keywords Wizard crashes on repeated use #2514
+        Fix Crash Minidump when try to use InaSAFE keyword editor twice #2467
+        Fix #2515 BUG : Can Not Use the Wizard (because No module named qgsdatetimeedit)
+        Fix serializing classified raster values    
+        Fix #2504 - exception raised when messaging cell contains nested table or bullet list due to slashes param not being accepted by table class to_html() method.
+        Fix Python error in PDF generator and Open in Composer using IFCW #2532
+        Fix Python bug when creating a pdf map #2523
+
 
 # tags are comma separated with spaces allowed
 tags=contingency planning, impact assessments, disaster scenarios, natural hazards

--- a/safe/gui/tools/test/test_wizard_dialog.py
+++ b/safe/gui/tools/test/test_wizard_dialog.py
@@ -499,7 +499,7 @@ class WizardDialogTest(unittest.TestCase):
         message = 'Source Url should be empty'
         self.assertEqual(dialog.leSource_url.text(), '', message)
         message = 'Source Date should be empty'
-        self.assertEqual(dialog.leSource_date.text(), '', message)
+        self.assertTrue(dialog.dtSource_date.dateTime().isNull(), message)
         message = 'Source Scale should be empty'
         self.assertEqual(dialog.leSource_scale.text(), '', message)
         dialog.pbnNext.click()
@@ -582,13 +582,15 @@ class WizardDialogTest(unittest.TestCase):
         source = 'Source'
         source_scale = 'Source Scale'
         source_url = 'Source Url'
-        source_date = 'Source Date'
+        source_date = QtCore.QDateTime.fromString(
+            '06-12-2015 12:30',
+            'dd-MM-yyyy HH:mm')
         source_license = 'Source License'
 
         dialog.leSource.setText(source)
         dialog.leSource_scale.setText(source_scale)
         dialog.leSource_url.setText(source_url)
-        dialog.leSource_date.setText(source_date)
+        dialog.dtSource_date.setDateTime(source_date)
         dialog.leSource_license.setText(source_license)
         dialog.pbnNext.click()  # next
         dialog.pbnNext.click()  # next
@@ -670,8 +672,9 @@ class WizardDialogTest(unittest.TestCase):
         self.assertEqual(dialog.leSource_url.text(), source_url, message)
         message = 'Source Scale should be %s' % source_scale
         self.assertEqual(dialog.leSource_scale.text(), source_scale, message)
-        message = 'Source Date should be %s' % source_date
-        self.assertEqual(dialog.leSource_date.text(), source_date, message)
+        message = 'Source Date should be %s' % source_date.toString(
+            'dd-MM-yyyy HH:mm')
+        self.assertEqual(dialog.dtSource_date.dateTime(), source_date, message)
         message = 'Source License should be %s' % source_license
         self.assertEqual(dialog.leSource_license.text(),
                          source_license, message)

--- a/safe/gui/tools/test/test_wizard_dialog.py
+++ b/safe/gui/tools/test/test_wizard_dialog.py
@@ -487,8 +487,8 @@ class WizardDialogTest(unittest.TestCase):
         self.assertEqual(dialog.leSource.text(), '', message)
         message = 'Source Url should be empty'
         self.assertEqual(dialog.leSource_url.text(), '', message)
-        message = 'Source Date should be empty'
-        self.assertTrue(dialog.dtSource_date.dateTime().isNull(), message)
+        message = 'Source Date checkbox should be toggled off'
+        self.assertFalse(dialog.ckbSource_date.isChecked(), message)
         message = 'Source Scale should be empty'
         self.assertEqual(dialog.leSource_scale.text(), '', message)
         dialog.pbnNext.click()
@@ -579,6 +579,7 @@ class WizardDialogTest(unittest.TestCase):
         dialog.leSource.setText(source)
         dialog.leSource_scale.setText(source_scale)
         dialog.leSource_url.setText(source_url)
+        dialog.ckbSource_date.setChecked(True)
         dialog.dtSource_date.setDateTime(source_date)
         dialog.leSource_license.setText(source_license)
         dialog.pbnNext.click()  # next
@@ -655,18 +656,11 @@ class WizardDialogTest(unittest.TestCase):
                    'source is optional')
         self.assertTrue(dialog.pbnNext.isEnabled(), message)
 
-        message = 'Source should be %s' % source
-        self.assertEqual(dialog.leSource.text(), source, message)
-        message = 'Source Url should be %s' % source_url
-        self.assertEqual(dialog.leSource_url.text(), source_url, message)
-        message = 'Source Scale should be %s' % source_scale
-        self.assertEqual(dialog.leSource_scale.text(), source_scale, message)
-        message = 'Source Date should be %s' % source_date.toString(
-            'dd-MM-yyyy HH:mm')
-        self.assertEqual(dialog.dtSource_date.dateTime(), source_date, message)
-        message = 'Source License should be %s' % source_license
-        self.assertEqual(dialog.leSource_license.text(),
-                         source_license, message)
+        self.assertEqual(dialog.leSource.text(), source)
+        self.assertEqual(dialog.leSource_url.text(), source_url)
+        self.assertEqual(dialog.leSource_scale.text(), source_scale)
+        self.assertEqual(dialog.dtSource_date.dateTime(), source_date)
+        self.assertEqual(dialog.leSource_license.text(), source_license)
         dialog.pbnNext.click()
 
         dialog.pbnCancel.click()

--- a/safe/gui/tools/test/test_wizard_dialog.py
+++ b/safe/gui/tools/test/test_wizard_dialog.py
@@ -252,7 +252,8 @@ class WizardDialogTest(unittest.TestCase):
         subcategories = []
         tsunami_index = -1
         for i in range(expected_subcategory_count):
-            subcategory_name = dialog.lstSubcategories.item(i).data(Qt.UserRole)
+            subcategory_name = dialog.lstSubcategories.item(i).data(
+                    Qt.UserRole)
             subcategories.append(subcategory_name)
             if subcategory_name == chosen_subcategory:
                 tsunami_index = i

--- a/safe/gui/tools/test/test_wizard_dialog.py
+++ b/safe/gui/tools/test/test_wizard_dialog.py
@@ -217,10 +217,7 @@ class WizardDialogTest(unittest.TestCase):
         categories = []
         hazard_index = -1
         for i in range(expected_category_count):
-            # pylint: disable=eval-used
-            category_name = eval(
-                dialog.lstCategories.item(i).data(Qt.UserRole))['key']
-            # pylint: enable=eval-used
+            category_name = dialog.lstCategories.item(i).data(Qt.UserRole)
             categories.append(category_name)
             if category_name == chosen_category:
                 hazard_index = i
@@ -255,10 +252,7 @@ class WizardDialogTest(unittest.TestCase):
         subcategories = []
         tsunami_index = -1
         for i in range(expected_subcategory_count):
-            # pylint: disable=eval-used
-            subcategory_name = eval(
-                dialog.lstSubcategories.item(i).data(Qt.UserRole))['key']
-            # pylint: enable=eval-used
+            subcategory_name = dialog.lstSubcategories.item(i).data(Qt.UserRole)
             subcategories.append(subcategory_name)
             if subcategory_name == chosen_subcategory:
                 tsunami_index = i
@@ -291,10 +285,8 @@ class WizardDialogTest(unittest.TestCase):
         hazard_categories = []
         scenario_index = -1
         for i in range(expected_hazard_category_count):
-            # pylint: disable=eval-used
-            hazard_category_name = eval(
-                dialog.lstHazardCategories.item(i).data(Qt.UserRole))['name']
-            # pylint: enable=eval-used
+            key = dialog.lstHazardCategories.item(i).data(Qt.UserRole)
+            hazard_category_name = KeywordIO.definition(key)['name']
             hazard_categories.append(hazard_category_name)
             if hazard_category_name == chosen_hazard_category:
                 scenario_index = i
@@ -329,10 +321,7 @@ class WizardDialogTest(unittest.TestCase):
         # Get all the modes given and save the classified index
         modes = []
         for i in range(expected_mode_count):
-            # pylint: disable=eval-used
-            mode_name = eval(
-                dialog.lstLayerModes.item(i).data(Qt.UserRole))['key']
-            # pylint: enable=eval-used
+            mode_name = dialog.lstLayerModes.item(i).data(Qt.UserRole)
             modes.append(mode_name)
         # Check if units is the same with expected_units
         message = ('Invalid modes! It should be "%s" while it was '

--- a/safe/gui/tools/test/test_wizard_dialog_locale.py
+++ b/safe/gui/tools/test/test_wizard_dialog_locale.py
@@ -19,6 +19,7 @@ __copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
 import unittest
 import os
 import sys
+from PyQt4.QtCore import QDateTime
 
 skipped_reason = (
     'These tests are skipped because it will make a segmentation fault. Just '
@@ -179,12 +180,14 @@ class TestWizardDialogLocale(unittest.TestCase):
         source = 'Source'
         source_scale = 'Source Scale'
         source_url = 'Source Url'
-        source_date = 'Source Date'
+        source_date = QDateTime.fromString(
+            '06-12-2015 12:30',
+            'dd-MM-yyyy HH:mm')
 
         dialog.leSource.setText(source)
         dialog.leSource_scale.setText(source_scale)
         dialog.leSource_url.setText(source_url)
-        dialog.leSource_date.setText(source_date)
+        dialog.leSource_date.seDateTime(source_date)
         dialog.pbnNext.click()  # next
         dialog.pbnNext.click()  # finish
 
@@ -239,8 +242,9 @@ class TestWizardDialogLocale(unittest.TestCase):
         self.assertEqual(dialog.leSource.text(), source, message)
         message = 'Source Url should be %s' % source_url
         self.assertEqual(dialog.leSource_url.text(), source_url, message)
-        message = 'Source Date should be %s' % source_date
-        self.assertEqual(dialog.leSource_date.text(), source_date, message)
+        message = 'Source Date should be %s' % source_date.toString(
+            'dd-MM-yyyy HH:mm')
+        self.assertEqual(dialog.leSource_date.dateTime(), source_date, message)
         message = 'Source Scale should be %s' % source_scale
         self.assertEqual(dialog.leSource_scale.text(), source_scale, message)
         dialog.pbnNext.click()

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -53,6 +53,7 @@ from PyQt4.QtGui import (
 from db_manager.db_plugins.postgis.connector import PostGisDBConnector
 # pylint: enable=F0401
 
+import safe.definitions
 from safe.definitions import (
     inasafe_keyword_version,
     inasafe_keyword_version_key,
@@ -2880,11 +2881,11 @@ class WizardDialog(QDialog, FORM_CLASS):
         imfunc = self.selected_function()
         lay_req = imfunc['layer_requirements'][layer_purpose]
 
-        if layer_purpose == 'hazard':
+        if layer_purpose == layer_purpose_hazard['key']:
             layer_purpose_key_name = layer_purpose_hazard['name']
             req_subcategory = h['key']
             req_geometry = hc['key']
-        elif layer_purpose == 'exposure':
+        elif layer_purpose == layer_purpose_exposure['key']:
             layer_purpose_key_name = layer_purpose_exposure['name']
             req_subcategory = e['key']
             req_geometry = ec['key']
@@ -2892,7 +2893,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             layer_purpose_key_name = layer_purpose_aggregation['name']
             req_subcategory = ''
             # For aggregation layers, only accept polygons
-            req_geometry = 'polygon'
+            req_geometry = layer_geometry_polygon['key']
         req_layer_mode = lay_req['layer_mode']['key']
 
         lay_geometry = self.get_layer_geometry_id(layer)
@@ -2918,7 +2919,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         # Classification
         classification_row = ''
         if (lay_req['layer_mode'] == layer_mode_classified and
-                layer_purpose == 'hazard'):
+                layer_purpose == layer_purpose_hazard['key']):
             # Determine the keyword key for the classification
             classification_obj = (raster_hazard_classification
                                   if is_raster_layer(layer)
@@ -2988,10 +2989,13 @@ class WizardDialog(QDialog, FORM_CLASS):
                 %s
             </table>
         ''' % (self.tr('Layer'), self.tr('Required'),
-               self.tr('Geometry'), lay_geometry, req_geometry,
-               self.tr('Purpose'), lay_purpose, layer_purpose,
+               safe.definitions.layer_geometry['name'],
+               lay_geometry, req_geometry,
+               safe.definitions.layer_purpose['name'],
+               lay_purpose, layer_purpose,
                layer_purpose_key_name, lay_subcategory, req_subcategory,
-               self.tr('Layer mode'), lay_layer_mode, req_layer_mode,
+               safe.definitions.layer_mode['name'],
+               lay_layer_mode, req_layer_mode,
                classification_row,
                units_row)
         return html

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -98,6 +98,7 @@ from safe.gui.tools.function_options_dialog import (
     FunctionOptionsDialog)
 from safe.utilities.unicode import get_unicode
 from safe.utilities.i18n import tr
+import safe.gui.tools.wizard_strings
 from safe.gui.tools.wizard_strings import (
     category_question,
     category_question_hazard,
@@ -123,27 +124,6 @@ from safe.gui.tools.wizard_strings import (
     select_explayer_from_canvas_question,
     select_explayer_from_browser_question,
     create_postGIS_connection_first)
-
-# TODO(Ismail): We need a better way to import all of these string
-# pylint: disable=unused-import
-from safe.gui.tools.wizard_strings import (
-    earthquake_mmi_question,
-    exposure_question,
-    flood_feet_depth_question,
-    flood_metres_depth_question,
-    flood_wetdry_question,
-    hazard_question,
-    population_density_question,
-    population_number_question,
-    road_road_type_question,
-    structure_building_type_question,
-    tephra_kgm2_question,
-    tsunami_feet_depth_question,
-    tsunami_metres_depth_question,
-    tsunami_wetdry_question,
-    volcano_volcano_categorical_question
-)
-# pylint: enable=unused-import
 
 LOGGER = logging.getLogger('InaSAFE')
 
@@ -214,10 +194,9 @@ def get_question_text(constant):
     :returns: The value of the constant or red error message.
     :rtype: string
     """
-    try:
-        # TODO Eval = bad
-        return eval(constant)  # pylint: disable=eval-used
-    except NameError:
+    if constant in dir(safe.gui.tools.wizard_strings):
+        return getattr(safe.gui.tools.wizard_strings, constant)
+    else:
         return '<b>MISSING CONSTANT: %s</b>' % constant
 
 

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -1098,7 +1098,6 @@ class WizardDialog(QDialog, FORM_CLASS):
         # Exit if no selection
         if not field:
             return
-
         fields = self.layer.dataProvider().fields()
         field_index = fields.indexFromName(field)
         # Exit if the selected field comes from a previous wizard run
@@ -1837,6 +1836,15 @@ class WizardDialog(QDialog, FORM_CLASS):
     # STEP_KW_SOURCE
     # ===========================
 
+    # noinspection PyPep8Naming
+    def on_ckbSource_date_toggled(self, state):
+        """This is an automatic Qt slot executed when the checkbox is toggled
+
+        :param state: the new state
+        :type state: boolean
+        """
+        self.dtSource_date.setEnabled(state)
+
     def set_widgets_step_kw_source(self):
         """Set widgets on the Source tab."""
         # Just set values based on existing keywords
@@ -1854,10 +1862,12 @@ class WizardDialog(QDialog, FORM_CLASS):
 
         source_date = self.get_existing_keyword('date')
         if source_date:
+            self.ckbSource_date.setChecked(True)
             self.dtSource_date.setDateTime(
                 QDateTime.fromString(get_unicode(source_date),
                                      'dd-MM-yyyy HH:mm'))
         else:
+            self.ckbSource_date.setChecked(False)
             self.dtSource_date.clear()
 
         source_url = self.get_existing_keyword('url')
@@ -4475,7 +4485,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             keywords['url'] = get_unicode(self.leSource_url.text())
         if self.leSource_scale.text():
             keywords['scale'] = get_unicode(self.leSource_scale.text())
-        if self.dtSource_date.dateTime():
+        if self.ckbSource_date.isChecked():
             keywords['date'] = get_unicode(
                 self.dtSource_date.dateTime().toString('dd-MM-yyyy HH:mm'))
         if self.leSource_license.text():

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -1099,8 +1099,11 @@ class WizardDialog(QDialog, FORM_CLASS):
             return
 
         fields = self.layer.dataProvider().fields()
+        field_index = fields.indexFromName(field)
+        # Exit if the selected field comes from a previous wizard run
+        if field_index < 0:
+            return
         field_type = fields.field(field).typeName()
-        field_index = fields.indexFromName(self.selected_field())
         unique_values = self.layer.uniqueValues(field_index)[0:48]
         unique_values_str = [i is not None and unicode(i) or 'NULL'
                              for i in unique_values]
@@ -1834,10 +1837,14 @@ class WizardDialog(QDialog, FORM_CLASS):
         source = self.get_existing_keyword('source')
         if source or source == 0:
             self.leSource.setText(get_unicode(source))
+        else:
+            self.leSource.clear()
 
         source_scale = self.get_existing_keyword('scale')
         if source_scale or source_scale == 0:
             self.leSource_scale.setText(get_unicode(source_scale))
+        else:
+            self.leSource_scale.clear()
 
         source_date = self.get_existing_keyword('date')
         if source_date:
@@ -1846,13 +1853,18 @@ class WizardDialog(QDialog, FORM_CLASS):
                                      'dd-MM-yyyy HH:mm'))
         else:
             self.dtSource_date.clear()
+
         source_url = self.get_existing_keyword('url')
         if source_url or source_url == 0:
             self.leSource_url.setText(get_unicode(source_url))
+        else:
+            self.leSource_url.clear()
 
         source_license = self.get_existing_keyword('license')
         if source_license or source_license == 0:
             self.leSource_license.setText(get_unicode(source_license))
+        else:
+            self.leSource_license.clear()
 
     # ===========================
     # STEP_KW_TITLE

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -41,7 +41,7 @@ from qgis.core import (
 # noinspection PyPackageRequirements
 from PyQt4 import QtGui, QtCore
 # noinspection PyPackageRequirements
-from PyQt4.QtCore import pyqtSignature, QSettings, QPyNullVariant
+from PyQt4.QtCore import pyqtSignature, QSettings, QPyNullVariant, QDateTime
 # noinspection PyPackageRequirements
 from PyQt4.QtGui import (
     QDialog,
@@ -1902,9 +1902,12 @@ class WizardDialog(QDialog, FORM_CLASS):
             self.leSource_scale.setText(get_unicode(source_scale))
 
         source_date = self.get_existing_keyword('date')
-        if source_date or source_date == 0:
-            self.leSource_date.setText(get_unicode(source_date))
-
+        if source_date:
+            self.dtSource_date.setDateTime(
+                QDateTime.fromString(get_unicode(source_date),
+                                     'dd-MM-yyyy HH:mm'))
+        else:
+            self.dtSource_date.clear()
         source_url = self.get_existing_keyword('url')
         if source_url or source_url == 0:
             self.leSource_url.setText(get_unicode(source_url))
@@ -4513,8 +4516,9 @@ class WizardDialog(QDialog, FORM_CLASS):
             keywords['url'] = get_unicode(self.leSource_url.text())
         if self.leSource_scale.text():
             keywords['scale'] = get_unicode(self.leSource_scale.text())
-        if self.leSource_date.text():
-            keywords['date'] = get_unicode(self.leSource_date.text())
+        if self.dtSource_date.dateTime():
+            keywords['date'] = get_unicode(
+                self.dtSource_date.dateTime().toString('dd-MM-yyyy HH:mm'))
         if self.leSource_license.text():
             keywords['license'] = get_unicode(self.leSource_license.text())
         if self.leTitle.text():
@@ -4576,6 +4580,6 @@ class WizardDialog(QDialog, FORM_CLASS):
 
         self.leTitle.setToolTip(title_tooltip)
         self.leSource.setToolTip(source_tooltip)
-        self.leSource_date.setToolTip(date_tooltip)
+        self.dtSource_date.setToolTip(date_tooltip)
         self.leSource_scale.setToolTip(scale_tooltip)
         self.leSource_url.setToolTip(url_tooltip)

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -53,11 +53,6 @@ from PyQt4.QtGui import (
 from db_manager.db_plugins.postgis.connector import PostGisDBConnector
 # pylint: enable=F0401
 
-# pylint: disable=unused-import
-# TODO: to get rid of the following import,
-# TODO: we need to get rid of all those evals...TS
-from safe import definitions
-# pylint: enable=unused-import
 from safe.definitions import (
     inasafe_keyword_version,
     inasafe_keyword_version_key,
@@ -666,11 +661,8 @@ class WizardDialog(QDialog, FORM_CLASS):
         :rtype: dict, None
         """
         item = self.lstCategories.currentItem()
-
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -694,11 +686,9 @@ class WizardDialog(QDialog, FORM_CLASS):
             categories += ['aggregation']
         for category in categories:
             if not isinstance(category, dict):
-                # pylint: disable=eval-used
-                category = eval('definitions.layer_purpose_%s' % category)
-                # pylint: enable=eval-used
+                category = KeywordIO().definition(category)
             item = QListWidgetItem(category['name'], self.lstCategories)
-            item.setData(QtCore.Qt.UserRole, unicode(category))
+            item.setData(QtCore.Qt.UserRole, category['key'])
             self.lstCategories.addItem(item)
 
         # Check if layer keywords are already assigned
@@ -713,10 +703,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             categories = []
             for index in xrange(self.lstCategories.count()):
                 item = self.lstCategories.item(index)
-                # pylint: disable=eval-used
-                category = eval(item.data(QtCore.Qt.UserRole))
-                # pylint: enable=eval-used
-                categories.append(category['key'])
+                categories.append(item.data(QtCore.Qt.UserRole))
             if category_keyword in categories:
                 self.lstCategories.setCurrentRow(
                     categories.index(category_keyword))
@@ -768,9 +755,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         """
         item = self.lstSubcategories.currentItem()
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -791,7 +776,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             get_question_text('%s_question' % category['key']))
         for i in self.subcategories_for_layer():
             item = QListWidgetItem(i['name'], self.lstSubcategories)
-            item.setData(QtCore.Qt.UserRole, unicode(i))
+            item.setData(QtCore.Qt.UserRole, i['key'])
             self.lstSubcategories.addItem(item)
 
         # Check if layer keywords are already assigned
@@ -807,10 +792,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             subcategories = []
             for index in xrange(self.lstSubcategories.count()):
                 item = self.lstSubcategories.item(index)
-                # pylint: disable=eval-used
-                subcategory = eval(item.data(QtCore.Qt.UserRole))
-                # pylint: enable=eval-used
-                subcategories.append(subcategory['key'])
+                subcategories.append(item.data(QtCore.Qt.UserRole))
             if keyword in subcategories:
                 self.lstSubcategories.setCurrentRow(
                     subcategories.index(keyword))
@@ -852,11 +834,8 @@ class WizardDialog(QDialog, FORM_CLASS):
         :rtype: dict, None
         """
         item = self.lstHazardCategories.currentItem()
-
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -875,13 +854,10 @@ class WizardDialog(QDialog, FORM_CLASS):
         hazard_categories = self.hazard_categories_for_layer()
         for hazard_category in hazard_categories:
             if not isinstance(hazard_category, dict):
-                # pylint: disable=eval-used
-                hazard_category = eval('definitions.hazard_category_%s'
-                                       % hazard_category)
-                # pylint: enable=eval-used
+                hazard_category = KeywordIO().definition(hazard_category)
             item = QListWidgetItem(hazard_category['name'],
                                    self.lstHazardCategories)
-            item.setData(QtCore.Qt.UserRole, unicode(hazard_category))
+            item.setData(QtCore.Qt.UserRole, hazard_category['key'])
             self.lstHazardCategories.addItem(item)
 
         # Set values based on existing keywords (if already assigned)
@@ -890,10 +866,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             categories = []
             for index in xrange(self.lstHazardCategories.count()):
                 item = self.lstHazardCategories.item(index)
-                # pylint: disable=eval-used
-                hazard_category = eval(item.data(QtCore.Qt.UserRole))
-                # pylint: enable=eval-used
-                categories.append(hazard_category['key'])
+                categories.append(item.data(QtCore.Qt.UserRole))
             if category_keyword in categories:
                 self.lstHazardCategories.setCurrentRow(
                     categories.index(category_keyword))
@@ -933,9 +906,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         """
         item = self.lstLayerModes.currentItem()
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -961,7 +932,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         layer_modes = self.layermodes_for_layer()
         for layer_mode in layer_modes:
             item = QListWidgetItem(layer_mode['name'], self.lstLayerModes)
-            item.setData(QtCore.Qt.UserRole, unicode(layer_mode))
+            item.setData(QtCore.Qt.UserRole, layer_mode['key'])
             self.lstUnits.addItem(item)
 
         # Set value to existing keyword or default value
@@ -1009,9 +980,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         """
         item = self.lstUnits.currentItem()
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -1046,7 +1015,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             #     continue
             # else:
             item = QListWidgetItem(unit_for_layer['name'], self.lstUnits)
-            item.setData(QtCore.Qt.UserRole, unicode(unit_for_layer))
+            item.setData(QtCore.Qt.UserRole, unit_for_layer['key'])
             self.lstUnits.addItem(item)
 
         # Set values based on existing keywords (if already assigned)
@@ -1060,10 +1029,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             units = []
             for index in xrange(self.lstUnits.count()):
                 item = self.lstUnits.item(index)
-                # pylint: disable=eval-used
-                unit = eval(item.data(QtCore.Qt.UserRole))
-                # pylint: enable=eval-used
-                units.append(unit['key'])
+                units.append(item.data(QtCore.Qt.UserRole))
             if unit_id in units:
                 self.lstUnits.setCurrentRow(units.index(unit_id))
 
@@ -1098,9 +1064,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         """
         item = self.lstClassifications.currentItem()
         try:
-            # pylint: disable=eval-used
-            return eval(item.data(QtCore.Qt.UserRole))
-            # pylint: enable=eval-used
+            return KeywordIO().definition(item.data(QtCore.Qt.UserRole))
         except (AttributeError, NameError):
             return None
 
@@ -1117,12 +1081,10 @@ class WizardDialog(QDialog, FORM_CLASS):
         classifications = self.classifications_for_layer()
         for classification in classifications:
             if not isinstance(classification, dict):
-                # pylint: disable=eval-used
-                classification = eval('definitions.%s' % classification)
-                # pylint: enable=eval-used
+                classification = KeywordIO.definition(classification)
             item = QListWidgetItem(classification['name'],
                                    self.lstClassifications)
-            item.setData(QtCore.Qt.UserRole, unicode(classification))
+            item.setData(QtCore.Qt.UserRole, classification['key'])
             self.lstClassifications.addItem(item)
 
         # Set values based on existing keywords (if already assigned)
@@ -1133,10 +1095,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             classifications = []
             for index in xrange(self.lstClassifications.count()):
                 item = self.lstClassifications.item(index)
-                # pylint: disable=eval-used
-                classification = eval(item.data(QtCore.Qt.UserRole))
-                # pylint: enable=eval-used
-                classifications.append(classification['key'])
+                classifications.append(item.data(QtCore.Qt.UserRole))
             if classification_keyword in classifications:
                 self.lstClassifications.setCurrentRow(
                     classifications.index(classification_keyword))
@@ -1171,7 +1130,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         desc = '<br/>%s: %s<br/><br/>' % (self.tr('Field type'), field_type)
         desc += self.tr('Unique values: %s') % ', '.join(unique_values_str)
         self.lblDescribeField.setText(desc)
-        # Enable the next button
+        # Enable the next buttonlayer_purpose_aggregation
         self.pbnNext.setEnabled(True)
 
     def selected_field(self):

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -1270,6 +1270,11 @@ class WizardDialog(QDialog, FORM_CLASS):
             unique_values = numpy.unique(numpy.array(
                 ds.GetRasterBand(1).ReadAsArray()))
             field_type = 0
+            # Convert datatype to a json serializable type
+            if numpy.issubdtype(unique_values.dtype, float):
+                unique_values = [float(i) for i in unique_values]
+            else:
+                unique_values = [int(i) for i in unique_values]
         else:
             field = self.selected_field()
             field_index = self.layer.dataProvider().fields().indexFromName(

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -1098,6 +1098,9 @@ class WizardDialog(QDialog, FORM_CLASS):
         # Exit if no selection
         if not field:
             return
+        # Exit if the selected field comes from a previous wizard run (vector)
+        if is_raster_layer(self.layer):
+            return
         fields = self.layer.dataProvider().fields()
         field_index = fields.indexFromName(field)
         # Exit if the selected field comes from a previous wizard run

--- a/safe/gui/ui/wizard_dialog_base.ui
+++ b/safe/gui/ui/wizard_dialog_base.ui
@@ -1541,13 +1541,6 @@
                </property>
               </widget>
              </item>
-             <item row="3" column="1">
-              <widget class="QLineEdit" name="leSource_date">
-               <property name="styleSheet">
-                <string notr="true">font: 11pt &quot;Ubuntu&quot;;</string>
-               </property>
-              </widget>
-             </item>
              <item row="1" column="1">
               <widget class="QLineEdit" name="leSource_url">
                <property name="styleSheet">
@@ -1564,7 +1557,7 @@
                 <string>Date</string>
                </property>
                <property name="buddy">
-                <cstring>leSource_date</cstring>
+                <cstring>dtSource_date</cstring>
                </property>
               </widget>
              </item>
@@ -1578,6 +1571,16 @@
                </property>
                <property name="buddy">
                 <cstring>leSource_license</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QgsDateTimeEdit" name="dtSource_date">
+               <property name="displayFormat">
+                <string>dd.MM.yyyy HH:mm</string>
+               </property>
+               <property name="calendarPopup">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -3827,6 +3830,11 @@ Please step back and select another layer.</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>qgsdatetimeedit.h</header>
+  </customwidget>
+  <customwidget>
    <class>MessageViewer</class>
    <extends>QWidget</extends>
    <header>safe.gui.widgets.message_viewer</header>
@@ -3851,7 +3859,7 @@ Please step back and select another layer.</string>
   <tabstop>leSource</tabstop>
   <tabstop>leSource_url</tabstop>
   <tabstop>leSource_scale</tabstop>
-  <tabstop>leSource_date</tabstop>
+  <tabstop>dtSource_date</tabstop>
   <tabstop>leSource_license</tabstop>
   <tabstop>leTitle</tabstop>
   <tabstop>dsbFemaleRatioDefault</tabstop>

--- a/safe/gui/ui/wizard_dialog_base.ui
+++ b/safe/gui/ui/wizard_dialog_base.ui
@@ -177,7 +177,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1003</width>
+        <width>1014</width>
         <height>400</height>
        </rect>
       </property>
@@ -218,7 +218,7 @@
           <string notr="true">font: 11pt &quot;Ubuntu&quot;;</string>
          </property>
          <property name="currentIndex">
-          <number>14</number>
+          <number>11</number>
          </property>
          <widget class="QWidget" name="pg1Category">
           <property name="sizePolicy">
@@ -1488,7 +1488,46 @@
              <property name="verticalSpacing">
               <number>13</number>
              </property>
-             <item row="2" column="1">
+             <item row="3" column="0">
+              <widget class="QLabel" name="lblDate">
+               <property name="styleSheet">
+                <string notr="true">font: 11pt &quot;Ubuntu&quot;;</string>
+               </property>
+               <property name="text">
+                <string>Date</string>
+               </property>
+               <property name="buddy">
+                <cstring>ckbSource_date</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1" colspan="2">
+              <widget class="QLineEdit" name="leSource">
+               <property name="styleSheet">
+                <string notr="true">font: 11pt &quot;Ubuntu&quot;;</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1" colspan="2">
+              <widget class="QLineEdit" name="leSource_license"/>
+             </item>
+             <item row="3" column="2">
+              <widget class="QDateTimeEdit" name="dtSource_date">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="calendarPopup">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1" colspan="2">
               <widget class="QLineEdit" name="leSource_scale">
                <property name="styleSheet">
                 <string notr="true">font: 11pt &quot;Ubuntu&quot;;</string>
@@ -1505,13 +1544,6 @@
                </property>
                <property name="buddy">
                 <cstring>leSource_scale</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="leSource">
-               <property name="styleSheet">
-                <string notr="true">font: 11pt &quot;Ubuntu&quot;;</string>
                </property>
               </widget>
              </item>
@@ -1541,28 +1573,12 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="1">
+             <item row="1" column="1" colspan="2">
               <widget class="QLineEdit" name="leSource_url">
                <property name="styleSheet">
                 <string notr="true">font: 11pt &quot;Ubuntu&quot;;</string>
                </property>
               </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="lblDate">
-               <property name="styleSheet">
-                <string notr="true">font: 11pt &quot;Ubuntu&quot;;</string>
-               </property>
-               <property name="text">
-                <string>Date</string>
-               </property>
-               <property name="buddy">
-                <cstring>dtSource_date</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <widget class="QLineEdit" name="leSource_license"/>
              </item>
              <item row="4" column="0">
               <widget class="QLabel" name="lblLicense">
@@ -1575,12 +1591,15 @@
               </widget>
              </item>
              <item row="3" column="1">
-              <widget class="QgsDateTimeEdit" name="dtSource_date">
-               <property name="displayFormat">
-                <string>dd.MM.yyyy HH:mm</string>
+              <widget class="QCheckBox" name="ckbSource_date">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
-               <property name="calendarPopup">
-                <bool>true</bool>
+               <property name="text">
+                <string/>
                </property>
               </widget>
              </item>
@@ -3647,8 +3666,8 @@ Please step back and select another layer.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>95</width>
-                <height>65</height>
+                <width>91</width>
+                <height>60</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -3830,11 +3849,6 @@ Please step back and select another layer.</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsDateTimeEdit</class>
-   <extends>QDateTimeEdit</extends>
-   <header>qgsdatetimeedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>MessageViewer</class>
    <extends>QWidget</extends>
    <header>safe.gui.widgets.message_viewer</header>
@@ -3859,6 +3873,7 @@ Please step back and select another layer.</string>
   <tabstop>leSource</tabstop>
   <tabstop>leSource_url</tabstop>
   <tabstop>leSource_scale</tabstop>
+  <tabstop>ckbSource_date</tabstop>
   <tabstop>dtSource_date</tabstop>
   <tabstop>leSource_license</tabstop>
   <tabstop>leTitle</tabstop>

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -636,12 +636,12 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             'valid inputs for a given risk function.'))
         hazard_heading = m.Heading(
             self.tr('Hazard keywords'), **INFO_STYLE)
-        hazard_keywords = self.keyword_io.to_message(
-            hazard_keywords, show_header=False)
+        hazard_keywords = KeywordIO(self.get_hazard_layer()).to_message(
+            show_header=False)
         exposure_heading = m.Heading(
             self.tr('Exposure keywords'), **INFO_STYLE)
-        exposure_keywords = self.keyword_io.to_message(
-            exposure_keywords, show_header=False)
+        exposure_keywords = KeywordIO(self.get_exposure_layer()).to_message(
+            show_header=False)
         message = m.Message(
             heading,
             notes,
@@ -1580,17 +1580,22 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         self.grpQuestion.setEnabled(True)
         self.grpQuestion.setVisible(False)
 
-    def show_generic_keywords(self, keywords):
+    def show_generic_keywords(self, layer):
         """Show the keywords defined for the active layer.
 
         .. note:: The print button will be disabled if this method is called.
 
-        :param keywords: A keywords dictionary.
-        :type keywords: dict
+        .. versionchanged:: 3.3 - changed parameter from keywords object
+            to a layer object so that we can show extra stuff like CRS and
+            data source in the keywords.
+
+        :param layer: A QGIS layer.
+        :type layer: QgsMapLayer
         """
+        keywords = KeywordIO(layer)
         LOGGER.debug('Showing Generic Keywords')
         self.pbnPrint.setEnabled(False)
-        message = self.keyword_io.to_message(keywords)
+        message = keywords.to_message()
         # noinspection PyTypeChecker
         self.show_static_message(message)
 
@@ -1695,7 +1700,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
                     compare_result = compare_version(
                         keyword_version, self.inasafe_version)
                     if compare_result == 0:
-                        self.show_generic_keywords(keywords)
+                        self.show_generic_keywords(layer)
                     elif compare_result > 0:
                         # Layer has older version
                         self.show_keyword_version_message(

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -97,6 +97,7 @@ from safe_extras.pydispatch import dispatcher
 from safe.utilities.analysis import Analysis
 from safe.utilities.extent import Extent
 from safe.impact_functions.impact_function_manager import ImpactFunctionManager
+from safe.utilities.unicode import get_unicode
 
 PROGRESS_UPDATE_STYLE = styles.PROGRESS_UPDATE_STYLE
 INFO_STYLE = styles.INFO_STYLE
@@ -1918,7 +1919,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             self.tr('Write to PDF'),
             os.path.join(temp_dir(), default_file_name),
             self.tr('Pdf File (*.pdf)'))
-        output_path = str(output_path)
+        output_path = get_unicode(output_path)
 
         if output_path is None or output_path == '':
             # noinspection PyTypeChecker

--- a/safe/gui/widgets/test/test_dock.py
+++ b/safe/gui/widgets/test/test_dock.py
@@ -197,18 +197,20 @@ class TestDock(TestCase):
     # disabled this test until further coding
     def xtest_print_map(self):
         """Test print map, especially on Windows."""
-
+        settings = QtCore.QSettings()
+        settings.setValue('inasafe/analysis_extents_mode', 'HazardExposure')
         result, message = setup_scenario(
             self.dock,
-            hazard='Flood in Jakarta',
-            exposure='Essential buildings',
-            function='Be affected',
-            function_id='Categorised Hazard Building Impact Function')
-        self.assertTrue(result, message)
+            hazard='Classified Flood',
+            exposure='Buildings',
+            function='Be impacted in each hazard class',
+            function_id='ClassifiedRasterHazardBuildingFunction')
 
         # Enable on-the-fly reprojection
         set_canvas_crs(GEOCRS, True)
         set_jakarta_extent(self.dock)
+
+        self.assertTrue(result, message)
 
         # Press RUN
         button = self.dock.pbnRunStop
@@ -228,10 +230,8 @@ class TestDock(TestCase):
     def test_result_styling(self):
         """Test that colours and opacity from a model are correctly styled."""
 
-        # Push OK with the left mouse button
-
-        print '--------------------'
-        print combos_to_string(self.dock)
+        settings = QtCore.QSettings()
+        settings.setValue('inasafe/analysis_extents_mode', 'HazardExposure')
 
         result, message = setup_scenario(
             self.dock,
@@ -254,8 +254,8 @@ class TestDock(TestCase):
         # simple test for now - we could test explicity for style state
         # later if needed.
         message = (
-            'Raster layer was not assigned a Singleband pseudocolor'
-            ' renderer as expected.')
+            'Raster layer was not assigned a Singleband pseudocolor '
+            'renderer as expected.')
         self.assertTrue(
             qgis_layer.renderer().type() == 'singlebandpseudocolor', message)
 
@@ -272,7 +272,11 @@ class TestDock(TestCase):
     def test_issue47(self):
         """Issue47: Hazard & exposure data are in different proj to viewport.
 
-        See https://github.com/AIFDR/inasafe/issues/47"""
+        See https://github.com/AIFDR/inasafe/issues/47
+        """
+
+        settings = QtCore.QSettings()
+        settings.setValue('inasafe/analysis_extents_mode', 'HazardExposure')
 
         result, message = setup_scenario(
             self.dock,
@@ -298,7 +302,11 @@ class TestDock(TestCase):
     def test_issue306(self):
         """Issue306: CANVAS doesnt add generated layers in tests.
 
-        See https://github.com/AIFDR/inasafe/issues/306"""
+        See https://github.com/AIFDR/inasafe/issues/306
+        """
+
+        settings = QtCore.QSettings()
+        settings.setValue('inasafe/analysis_extents_mode', 'HazardExposure')
 
         result, message = setup_scenario(
             self.dock,
@@ -312,7 +320,6 @@ class TestDock(TestCase):
         set_canvas_crs(GOOGLECRS, True)
         set_jakarta_google_extent(self.dock)
         before_count = len(CANVAS.layers())
-        # print 'Before count %s' % before_count
 
         # Press RUN
         self.dock.accept()
@@ -323,7 +330,7 @@ class TestDock(TestCase):
         message = ('Layer was not added to canvas (%s before, %s after)' % (
             before_count, after_count))
         # print 'After count %s' % after_count
-        self.assertTrue(before_count == after_count - 1, message)
+        self.assertEqual(before_count, after_count - 1, message)
 
     def test_layer_legend_index(self):
         """Test we can get the legend index for a layer.
@@ -340,7 +347,7 @@ class TestDock(TestCase):
             function_id='FloodEvacuationRasterHazardFunction')
         layer = self.dock.get_exposure_layer()
         index = self.dock.layer_legend_index(layer)
-        self.assertTrue(index == 8)
+        self.assertEqual(index, 8)
 
     def test_add_above_layer(self):
         """Test we can add one layer above another - see #2322
@@ -363,7 +370,7 @@ class TestDock(TestCase):
         self.assertIn(new_layer.id(), id_list)
         new_layer_position = id_list.index(new_layer.id())
         existing_layer_position = id_list.index(exposure_layer.id())
-        self.assertTrue(new_layer_position, existing_layer_position)
+        self.assertEqual(new_layer_position, existing_layer_position - 1)
 
     def test_load_layers(self):
         """Layers can be loaded and list widget was updated appropriately
@@ -373,28 +380,26 @@ class TestDock(TestCase):
         message = 'Expect %s layer(s) in hazard list widget but got %s' % (
             hazard_layer_count, self.dock.cboHazard.count())
         # pylint: disable=W0106
-        self.assertEqual(self.dock.cboHazard.count(),
-                         hazard_layer_count), message
+        self.assertEqual(
+                self.dock.cboHazard.count(), hazard_layer_count, message)
         message = 'Expect %s layer(s) in exposure list widget but got %s' % (
             exposure_layer_count, self.dock.cboExposure.count())
-        self.assertEqual(self.dock.cboExposure.count(),
-                         exposure_layer_count), message
+        self.assertEqual(
+                self.dock.cboExposure.count(), exposure_layer_count, message)
         # pylint: disable=W0106
 
     def test_issue71(self):
         """Test issue #71 in github - cbo changes should update ok button."""
         # See https://github.com/AIFDR/inasafe/issues/71
-        # Push OK with the left mouse button
-        print 'Using QGIS: %s' % qgis_version()
         settings = QtCore.QSettings()
-        settings.setValue(
-            'inasafe/analysis_extents_mode', 'HazardExposure')
+        settings.setValue('inasafe/analysis_extents_mode', 'HazardExposure')
         self.tearDown()
         button = self.dock.pbnRunStop
         # First part of scenario should have enabled run
         file_list = [
             test_data_path('hazard', 'continuous_flood_20_20.asc'),
-            test_data_path('exposure', 'pop_binary_raster_20_20.asc')]
+            test_data_path('exposure', 'pop_binary_raster_20_20.asc')
+        ]
         hazard_layer_count, exposure_layer_count = load_layers(file_list)
 
         message = (
@@ -419,7 +424,7 @@ class TestDock(TestCase):
         # set exposure to : Population Count (5kmx5km)
         # by moving one down
         self.dock.cboExposure.setCurrentIndex(
-            self.dock.cboExposure.currentIndex() + 1)
+                self.dock.cboExposure.currentIndex() + 1)
         actual_dict = get_ui_state(self.dock)
         expected_dict = {
             'Run Button Enabled': False,
@@ -462,9 +467,6 @@ class TestDock(TestCase):
         exposure_path = exposure_layer.source()
         hazard_path = hazard_layer.source()
 
-        # See https://github.com/AIFDR/inasafe/issues/71
-        # Push OK with the left mouse button
-        # print 'Using QGIS: %s' % qgis_version()
         self.tearDown()
         button = self.dock.pbnRunStop
         # First part of scenario should have enabled run
@@ -945,6 +947,9 @@ class TestDock(TestCase):
 
     def test_rubber_bands(self):
         """Test that the rubber bands get updated."""
+        settings = QtCore.QSettings()
+        settings.setValue('inasafe/analysis_extents_mode', 'HazardExposure')
+
         setup_scenario(
             self.dock,
             hazard='Continuous Flood',
@@ -1046,8 +1051,7 @@ class TestDock(TestCase):
     def test_issue1191(self):
         """Test setting a layer's title in the kw directly from qgis api"""
         settings = QtCore.QSettings()
-        settings.setValue(
-            'inasafe/analysis_extents_mode', 'HazardExposure')
+        settings.setValue('inasafe/analysis_extents_mode', 'HazardExposure')
         self.dock.set_layer_from_title_flag = True
         set_canvas_crs(GEOCRS, True)
         set_yogya_extent(self.dock)

--- a/safe/messaging/item/cell.py
+++ b/safe/messaging/item/cell.py
@@ -110,15 +110,22 @@ class Cell(MessageElement):
                 self.style_class = 'text-center'
             else:
                 self.style_class += ' text-center'
+
+        # Special case for when we want to put a nested table in a cell
+        # We don't use isinstance because of recursive imports with table
+        class_name = self.content.__class__.__name__
+        if class_name in ['BulletedList', 'Table']:
+            html = self.content.to_html()
+        else:
+            html = self.content.to_html(wrap_slash=self.wrap_slash)
+
         # Check if we have a header or not then render
         if self.header_flag is True:
             return '<th%s>%s</th>\n' % (
-                self.html_attributes(), self.content.to_html(
-                    wrap_slash=self.wrap_slash))
+                self.html_attributes(), html)
         else:
             return '<td%s>%s</td>\n' % (
-                self.html_attributes(), self.content.to_html(
-                    wrap_slash=self.wrap_slash))
+                self.html_attributes(), html)
 
     def to_text(self):
         """Render a Cell MessageElement as plain text

--- a/safe/messaging/item/cell.py
+++ b/safe/messaging/item/cell.py
@@ -39,6 +39,14 @@ class Cell(MessageElement):
         :param align: A flag to indicate if special alignment should
             be given to cells if supported in the output renderer.
             Valid options are: None, 'left', 'right', 'center'
+        :type align: basestring
+
+        :param wrap_slash: Whether to replace slashes with the slash plus the
+            html <wbr> tag which will help to e.g. wrap html in small cells if
+            it contains a long filename. Disabled by default as it may cause
+            side effects if the text contains html markup. Only affects
+            to_html calls.
+        :type wrap_slash: bool
 
         We pass the kwargs on to the base class after first removing the
         kwargs that we explicitly expect here so an exception is raised
@@ -52,13 +60,23 @@ class Cell(MessageElement):
         self.header_flag = False
         if 'header' in kwargs:
             self.header_flag = kwargs['header']
+            # dont pass the kw on to the base class as we handled it here
             kwargs.pop('header')
+
         # Also check if align parameter is called before calling the ABC
         self.align = None
         if 'align' in kwargs:
             if kwargs['align'] in [None, 'left', 'right', 'center']:
                 self.align = kwargs['align']
+            # dont pass the kw on to the base class as we handled it here
             kwargs.pop('align')
+
+        # Check if slashes should be wrapped for html
+        self.wrap_slash = False
+        if 'wrap_slash' in kwargs:
+            self.wrap_slash = kwargs['wrap_slash']
+            # dont pass the kw on to the base class as we handled it here
+            kwargs.pop('wrap_slash')
 
         super(Cell, self).__init__(**kwargs)
 
@@ -86,7 +104,7 @@ class Cell(MessageElement):
             if self.style_class is None:
                 self.style_class = 'text-right'
             else:
-                self.style_classs += ' text-right'
+                self.style_class += ' text-right'
         elif self.align is 'center':
             if self.style_class is None:
                 self.style_class = 'text-center'
@@ -95,10 +113,12 @@ class Cell(MessageElement):
         # Check if we have a header or not then render
         if self.header_flag is True:
             return '<th%s>%s</th>\n' % (
-                self.html_attributes(), self.content.to_html())
+                self.html_attributes(), self.content.to_html(
+                    wrap_slash=self.wrap_slash))
         else:
             return '<td%s>%s</td>\n' % (
-                self.html_attributes(), self.content.to_html())
+                self.html_attributes(), self.content.to_html(
+                    wrap_slash=self.wrap_slash))
 
     def to_text(self):
         """Render a Cell MessageElement as plain text

--- a/safe/messaging/item/table.py
+++ b/safe/messaging/item/table.py
@@ -60,14 +60,8 @@ class Table(MessageElement):
         else:
             raise InvalidMessageItemError(item, item.__class__)
 
-    def to_html(self, wrap_slash=False):
+    def to_html(self):
         """Render a Table MessageElement as html
-
-        :param wrap_slash: Whether to replace slashes with the slash plus the
-            html <wbr> tag which will help to e.g. wrap html in small cells if
-            it contains a long filename. Disabled by default as it may cause
-            side effects if the text contains html markup.
-        :type wrap_slash: bool
 
         :returns: The html representation of the Table MessageElement
         :rtype: basestring
@@ -79,11 +73,6 @@ class Table(MessageElement):
         for row in self.rows:
             table += row.to_html()
         table += '</tbody>\n</table>\n'
-
-        if wrap_slash:
-            # This is a hack to make text wrappable with long filenames TS 3.3
-            text = text.replace('/', '/<wbr>')
-            text = text.replace('\\', '\\<wbr>')
 
         return table
 

--- a/safe/messaging/item/table.py
+++ b/safe/messaging/item/table.py
@@ -60,8 +60,14 @@ class Table(MessageElement):
         else:
             raise InvalidMessageItemError(item, item.__class__)
 
-    def to_html(self):
+    def to_html(self, wrap_slash=False):
         """Render a Table MessageElement as html
+
+        :param wrap_slash: Whether to replace slashes with the slash plus the
+            html <wbr> tag which will help to e.g. wrap html in small cells if
+            it contains a long filename. Disabled by default as it may cause
+            side effects if the text contains html markup.
+        :type wrap_slash: bool
 
         :returns: The html representation of the Table MessageElement
         :rtype: basestring
@@ -73,6 +79,11 @@ class Table(MessageElement):
         for row in self.rows:
             table += row.to_html()
         table += '</tbody>\n</table>\n'
+
+        if wrap_slash:
+            # This is a hack to make text wrappable with long filenames TS 3.3
+            text = text.replace('/', '/<wbr>')
+            text = text.replace('\\', '\\<wbr>')
 
         return table
 

--- a/safe/messaging/item/text.py
+++ b/safe/messaging/item/text.py
@@ -69,8 +69,14 @@ class Text(MessageElement):
         else:
             raise InvalidMessageItemError(text, text.__class__)
 
-    def to_html(self):
+    def to_html(self, wrap_slash=False):
         """Render a Text MessageElement as html.
+
+        :param wrap_slash: Whether to replace slashes with the slash plus the
+            html <wbr> tag which will help to e.g. wrap html in small cells if
+            it contains a long filename. Disabled by default as it may cause
+            side effects if the text contains html markup.
+        :type wrap_slash: bool
 
         :returns: Html representation of the Text MessageElement.
         :rtype: str
@@ -82,7 +88,12 @@ class Text(MessageElement):
             text = ''
             for t in self.text:
                 text += t.to_html() + ' '
-            return ' '.join(text.split())
+            text = ' '.join(text.split())
+        if wrap_slash:
+            # This is a hack to make text wrappable with long filenames TS 3.3
+            text = text.replace('/', '/<wbr>')
+            text = text.replace('\\', '\\<wbr>')
+        return text
 
     def to_text(self):
         """Render a Text MessageElement as plain text

--- a/safe/plugin.py
+++ b/safe/plugin.py
@@ -612,7 +612,7 @@ class Plugin(object):
         self.wizard.exec_()  # modal
 
     def show_function_centric_wizard(self):
-        """Show the keywords creation wizard."""
+        """Show the function centric wizard."""
         # import here only so that it is AFTER i18n set up
         from safe.gui.tools.wizard_dialog import WizardDialog
 

--- a/safe/report/impact_report.py
+++ b/safe/report/impact_report.py
@@ -494,7 +494,7 @@ class ImpactReport(object):
         :param output_path: Path on the file system to which the pdf should
             be saved. If None, a generated file name will be used. Note that
             the table will be prefixed with '_table'.
-        :type output_path: str
+        :type output_path: str, unicode
 
         :returns: The map path and the table path to the pdfs generated.
         :rtype: tuple

--- a/safe/utilities/analysis_handler.py
+++ b/safe/utilities/analysis_handler.py
@@ -536,7 +536,7 @@ class AnalysisHandler(QObject):
         # Open Impact Report Dialog
         print_dialog = ImpactReportDialog(self.iface)
         print_dialog.button_ok = QtGui.QPushButton(self.tr('OK'))
-        print_dialog.buttonBox.addButton(
+        print_dialog.button_Box.addButton(
             print_dialog.button_ok,
             QtGui.QDialogButtonBox.ActionRole)
 

--- a/safe/utilities/analysis_handler.py
+++ b/safe/utilities/analysis_handler.py
@@ -536,7 +536,7 @@ class AnalysisHandler(QObject):
         # Open Impact Report Dialog
         print_dialog = ImpactReportDialog(self.iface)
         print_dialog.button_ok = QtGui.QPushButton(self.tr('OK'))
-        print_dialog.button_Box.addButton(
+        print_dialog.button_box.addButton(
             print_dialog.button_ok,
             QtGui.QDialogButtonBox.ActionRole)
 

--- a/safe/utilities/keyword_io.py
+++ b/safe/utilities/keyword_io.py
@@ -795,7 +795,7 @@ class KeywordIO(QObject):
             # Next the data source
             keyword = self.tr('Layer source')
             value = self.layer.source()
-            row = self._keyword_to_row(keyword, value)
+            row = self._keyword_to_row(keyword, value, wrap_slash=True)
             table.add(row)
 
         # Finalise the report

--- a/safe/utilities/keyword_io.py
+++ b/safe/utilities/keyword_io.py
@@ -62,13 +62,18 @@ class KeywordIO(QObject):
     .keywords file and this plugins implementation of keyword caching in a
     local sqlite db used for supporting keywords for remote datasources."""
 
-    def __init__(self):
-        """Constructor for the KeywordIO object."""
+    def __init__(self, layer=None):
+        """Constructor for the KeywordIO object.
+
+        .. versionchanged:: 3.3 added optional layer parameter.
+
+        """
         QObject.__init__(self)
         # path to sqlite db path
         self.keyword_db_path = None
         self.setup_keyword_db_path()
         self.connection = None
+        self.layer = layer
 
     def set_keyword_db_path(self, path):
         """Set the path for the keyword database (sqlite).
@@ -706,15 +711,18 @@ class KeywordIO(QObject):
                         return var
         return None
 
-    def to_message(self, keywords, show_header=True):
+    def to_message(self, keywords=None, show_header=True):
         """Format keywords as a message object.
 
         .. versionadded:: 3.2
 
+        .. versionchanged:: 3.3 - default keywords to None
+
         The message object can then be rendered to html, plain text etc.
 
-
-        :param keywords: Keywords to be converted to a message.
+        :param keywords: Keywords to be converted to a message. Optional. If
+            not passed then we will attempt to get keywords from self.layer
+            if it is not None.
         :type keywords: dict
 
         :param show_header: Flag indicating if InaSAFE logo etc. should be
@@ -724,6 +732,8 @@ class KeywordIO(QObject):
         :returns: A safe message object containing a table.
         :rtype: safe.messaging.message
         """
+        if keywords is None and self.layer is not None:
+            keywords = self.read_keywords(self.layer)
         # This order was determined in issue #2313
         preferred_order = [
             'title',
@@ -772,10 +782,27 @@ class KeywordIO(QObject):
             value = keywords[keyword]
             row = self._keyword_to_row(keyword, value)
             table.add(row)
+
+        # If the keywords class was instantiated with a layer object
+        # we can add some context info not stored in the keywords themselves
+        # but that is still useful to see...
+        if self.layer:
+            # First the CRS
+            keyword = self.tr('Reference system')
+            value = self.layer.crs().authid()
+            row = self._keyword_to_row(keyword, value)
+            table.add(row)
+            # Next the data source
+            keyword = self.tr('Layer source')
+            value = self.layer.source()
+            row = self._keyword_to_row(keyword, value)
+            table.add(row)
+
+        # Finalise the report
         report.add(table)
         return report
 
-    def _keyword_to_row(self, keyword, value):
+    def _keyword_to_row(self, keyword, value, wrap_slash=False):
         """Helper to make a message row from a keyword.
 
         .. versionadded:: 3.2
@@ -788,6 +815,12 @@ class KeywordIO(QObject):
 
         :param value: Value of the keyword to be rendered.
         :type value: basestring
+
+        :param wrap_slash: Whether to replace slashes with the slash plus the
+            html <wbr> tag which will help to e.g. wrap html in small cells if
+            it contains a long filename. Disabled by default as it may cause
+            side effects if the text contains html markup.
+        :type wrap_slash: bool
 
         :returns: A row to be added to a messaging table.
         :rtype: safe.messaging.items.row.Row
@@ -841,7 +874,7 @@ class KeywordIO(QObject):
 
         key = m.ImportantText(definition)
         row.add(m.Cell(key))
-        row.add(m.Cell(value))
+        row.add(m.Cell(value, wrap_slash=wrap_slash))
         return row
 
     def _dict_to_row(self, keyword_value):

--- a/safe/utilities/test/test_keyword_io.py
+++ b/safe/utilities/test/test_keyword_io.py
@@ -273,7 +273,7 @@ class KeywordIOTest(unittest.TestCase):
         .. versionadded:: 3.3
         """
         keywords = KeywordIO(self.vector_layer)
-        message = keywords.to_message(keywords).to_text()
+        message = keywords.to_message().to_text()
         self.assertIn('*Reference system*, ', message)
 
     def test_dict_to_row(self):

--- a/safe/utilities/test/test_keyword_io.py
+++ b/safe/utilities/test/test_keyword_io.py
@@ -267,6 +267,15 @@ class KeywordIOTest(unittest.TestCase):
         message = self.keyword_io.to_message(keywords).to_text()
         self.assertIn('*Exposure*, structure------', message)
 
+    def test_layer_to_message(self):
+        """Test to show augmented keywords if KeywordsIO ctor passed a layer.
+
+        .. versionadded:: 3.3
+        """
+        keywords = KeywordIO(self.vector_layer)
+        message = keywords.to_message(keywords).to_text()
+        self.assertIn('*Reference system*, ', message)
+
     def test_dict_to_row(self):
         """Test the dict to row helper works.
 


### PR DESCRIPTION
Backport from develop branch. Contains from PR #2483, #2517, #2509, #2504, #2534, #2535, and #2525 
Fix some issues and small enhancements:
- adds data source and CRS to the keywords list in dock
- Keywords Wizard crashes on repeated use #2514 
- Crash Minidump when try to use InaSAFE keyword editor twice #2467
- Fix #2515 
- Fix serializing classified raster values
- Wizard: ged rid of eval() statements #2329
- Use Date Picker in Keywords Wizard #2499
- Fix #2504 - exception raised when messaging cell contains nested table or bullet list due to slashes param not being accepted by table class to_html() method.
- [BUG] Python error in PDF generator and Open in Composer using IFCW #2532
- Python bug when creating a pdf map #2523