### PR TITLE
Value mapping key

### DIFF
--- a/safe/gui/tools/test/test_wizard_dialog.py
+++ b/safe/gui/tools/test/test_wizard_dialog.py
@@ -541,9 +541,9 @@ class WizardDialogTest(unittest.TestCase):
         default_classes = classification['classes']
         unassigned_values = []  # no need to check actually, not save in file
         assigned_values = {
-            'Low Hazard Zone': ['Kawasan Rawan Bencana I'],
-            'Medium Hazard Zone': ['Kawasan Rawan Bencana II'],
-            'High Hazard Zone': ['Kawasan Rawan Bencana III']
+            'low': ['Kawasan Rawan Bencana I'],
+            'medium': ['Kawasan Rawan Bencana II'],
+            'high': ['Kawasan Rawan Bencana III']
         }
         dialog.populate_classified_values(
             unassigned_values, assigned_values, default_classes)

--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -1260,7 +1260,7 @@ class WizardDialog(QDialog, FORM_CLASS):
             for tree_leaf in tree_branch.takeChildren():
                 value_list += [tree_leaf.data(0, QtCore.Qt.UserRole)]
             if value_list:
-                value_map[tree_branch.text(0)] = value_list
+                value_map[tree_branch.data(0, QtCore.Qt.UserRole)] = value_list
         return value_map
 
     def set_widgets_step_kw_classify(self):
@@ -1291,11 +1291,11 @@ class WizardDialog(QDialog, FORM_CLASS):
                 classification['name'], field.upper()))
             unique_values = self.layer.uniqueValues(field_index)
 
-        # Assign unique values to classes (according to defauls)
+        # Assign unique values to classes (according to default)
         unassigned_values = list()
         assigned_values = dict()
         for default_class in default_classes:
-            assigned_values[default_class['name']] = list()
+            assigned_values[default_class['key']] = list()
         for unique_value in unique_values:
             if unique_value is None or isinstance(
                     unique_value, QPyNullVariant):
@@ -1313,7 +1313,7 @@ class WizardDialog(QDialog, FORM_CLASS):
                         default_class['numeric_default_min'] <= unique_value <=
                         default_class['numeric_default_max']))
                 if condition_1 or condition_2:
-                    assigned_values[default_class['name']] += [unique_value]
+                    assigned_values[default_class['key']] += [unique_value]
                     assigned = True
             if not assigned:
                 # add to unassigned values list otherwise
@@ -1338,7 +1338,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         unassigned_values = list()
         assigned_values = dict()
         for default_class in default_classes:
-            assigned_values[default_class['name']] = list()
+            assigned_values[default_class['key']] = list()
         if isinstance(value_map, str):
             try:
                 value_map = json.loads(value_map)
@@ -1403,10 +1403,11 @@ class WizardDialog(QDialog, FORM_CLASS):
             tree_branch.setExpanded(True)
             tree_branch.setFont(0, bold_font)
             tree_branch.setText(0, default_class['name'])
+            tree_branch.setData(0, QtCore.Qt.UserRole, default_class['key'])
             if 'description' in default_class:
                 tree_branch.setToolTip(0, default_class['description'])
             # Assign known values
-            for value in assigned_values[default_class['name']]:
+            for value in assigned_values[default_class['key']]:
                 string_value = value is not None and unicode(value) or 'NULL'
                 tree_leaf = QtGui.QTreeWidgetItem(tree_branch)
                 tree_leaf.setFlags(QtCore.Qt.ItemIsEnabled |


### PR DESCRIPTION
Previously, we use `name` from definition to store the value mapping. This PR use the `key`. The `name` is human friendly thing, and can be replaced several times, if needed.