### PR TITLE
Fix for Peta Jakarta Python error windows

### DIFF
--- a/safe/gui/tools/peta_jakarta_dialog.py
+++ b/safe/gui/tools/peta_jakarta_dialog.py
@@ -195,7 +195,7 @@ class PetaJakartaDialog(QDialog, FORM_CLASS):
         source = (
             'https://rem.petajakarta.org/banjir/data/api/v2/rem/flooded')
         layer = QgsVectorLayer(source, 'flood', 'ogr', False)
-        self.time_stamp = time.strftime('%d-%b-%G %H:%M:%S')
+        self.time_stamp = time.strftime('%d-%b-%Y %H:%M:%S')
         # Now save as shp
         name = 'jakarta_flood.shp'
         output_directory = self.output_directory.text()


### PR DESCRIPTION
### Problem  …
Peta Jakarta delivering python error

ValueError: Invalid format string
Traceback (most recent call last):
  File "C:/Users/PCUSER/.qgis2/python/plugins\inasafe\safe\gui\tools\peta_jakarta_dialog.py", line 198, in accept
    self.time_stamp = time.strftime('%d-%b-%G %H:%M:%S')
ValueError: Invalid format string

### Environment
Windows

### Solution
Changed ```self.time_stamp = time.strftime('%d-%b-%G %H:%M:%S')``` to ```self.time_stamp = time.strftime('%d-%b-%Y %H:%M:%S')```

### cc

@timlinux