### PR TITLE
[Keyword Wizard] Add structure and road classification (#2673)

### DIFF
--- a/safe/gui/tools/test/test_wizard_dialog.py
+++ b/safe/gui/tools/test/test_wizard_dialog.py
@@ -33,7 +33,6 @@ pardir = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '../../..///'))
 sys.path.append(pardir)
 
-from safe.impact_functions import register_impact_functions
 from safe.common.utilities import temp_dir
 from safe.test.utilities import (
     clone_raster_layer,
@@ -45,6 +44,7 @@ from safe.test.utilities import (
 # safe.gui.tools.wizard_dialog
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 
+from safe.impact_functions import register_impact_functions
 from safe.definitions import inasafe_keyword_version
 from safe.gui.tools.wizard_dialog import (
     WizardDialog,

--- a/safe/gui/tools/test/test_wizard_dialog.py
+++ b/safe/gui/tools/test/test_wizard_dialog.py
@@ -730,6 +730,10 @@ class WizardDialogTest(unittest.TestCase):
         dialog.pbnNext.click()  # go to field
 
         self.check_current_step(step_kw_field, dialog)
+        dialog.pbnNext.click()  # go to classify
+
+        # check if in step classify
+        self.check_current_step(step_kw_classify, dialog)
         dialog.pbnNext.click()  # go to source
 
         # check if in step source
@@ -1114,6 +1118,11 @@ class WizardDialogTest(unittest.TestCase):
         self.check_list(expected_fields, dialog.lstFields)
         self.select_from_list_widget('TYPE', dialog.lstFields)
 
+        dialog.pbnNext.click()  # go to classify
+
+        # check if in step classify
+        self.check_current_step(step_kw_classify, dialog)
+
         dialog.pbnNext.click()  # go to source
 
         # check if in step source
@@ -1167,6 +1176,11 @@ class WizardDialogTest(unittest.TestCase):
         # check if in step extrakeywords
         self.check_current_step(step_kw_field, dialog)
         self.select_from_list_widget('FLOODPRONE', dialog.lstFields)
+
+        dialog.pbnNext.click()  # go to classify
+
+        # check if in step classify
+        self.check_current_step(step_kw_classify, dialog)
 
         dialog.pbnNext.click()  # Go to source
 

--- a/safe/gui/tools/test/test_wizard_dialog.py
+++ b/safe/gui/tools/test/test_wizard_dialog.py
@@ -1187,6 +1187,7 @@ class WizardDialogTest(unittest.TestCase):
         # check if in source step
         self.check_current_step(step_kw_source, dialog)
 
+        dialog.pbnBack.click()  # back to classify step
         dialog.pbnBack.click()  # back to field step
         dialog.pbnBack.click()  # back to layer_mode step
         dialog.pbnBack.click()  # back to subcategory step

--- a/safe/gui/tools/wizard_metadata.py
+++ b/safe/gui/tools/wizard_metadata.py
@@ -1,0 +1,108 @@
+# coding=utf-8
+"""
+InaSAFE Disaster risk assessment tool by AusAid **GUI InaSAFE Wizard Metadata.**
+
+ ** NOTE This file meant for temporary storing metadata to be later moved
+         to proper places.
+
+
+Contact : ole.moller.nielsen@gmail.com
+
+.. note:: This program is free software; you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation; either version 2 of the License, or
+     (at your option) any later version.
+
+"""
+__author__ = 'qgis@borysjurgiel.pl'
+__revision__ = '$Format:%H$'
+__date__ = '12/04/2016'
+__copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
+                 'Disaster Reduction')
+
+
+road_class_mapping = [{
+    'key': 'Motorway / highway',
+    'string_defaults': ['Motorway or highway']
+}, {
+    'key': 'Motorway link',
+    'string_defaults': ['Motorway link']
+}, {
+    'key': 'Primary road',
+    'string_defaults': ['Primary road']
+}, {
+    'key': 'Primary link',
+    'string_defaults': ['Primary link']
+}, {
+    'key': 'Tertiary',
+    'string_defaults': ['Tertiary']
+}, {
+    'key': 'Tertiary link',
+    'string_defaults': ['Tertiary link']
+}, {
+    'key': 'Secondary',
+    'string_defaults': ['Secondary']
+}, {
+    'key': 'Secondary link',
+    'string_defaults': ['Secondary link']
+}, {
+    'key': 'Road, residential, living street, etc.',
+    'string_defaults': ['Road, residential, living street, etc.']
+}, {
+    'key': 'Track',
+    'string_defaults': ['Track']
+}, {
+    'key': 'Cycleway, footpath, etc.',
+    'string_defaults': ['Cycleway, footpath, etc.']
+}, {
+    'key': 'Other',
+    'string_defaults': []
+}]
+
+
+structure_class_mapping = [{
+    'key': 'Medical',
+    'string_defaults': ['Clinic/Doctor', 'Hospital']
+}, {
+    'key': 'Schools',
+    'string_defaults': ['School', 'University/College']
+}, {
+    'key': 'Places of worship',
+    'string_defaults': ['Place of Worship - Unitarian',
+                        'Place of Worship - Islam',
+                        'Place of Worship - Buddhist',
+                        'Place of Worship']
+}, {
+    'key': 'Residential',
+    'string_defaults': ['Residential']
+}, {
+    'key': 'Government',
+    'string_defaults': ['Government']
+}, {
+    'key': 'Public Building',
+    'string_defaults': ['Public Building']
+}, {
+    'key': 'Fire Station',
+    'string_defaults': ['Fire Station']
+}, {
+    'key': 'Police Station',
+    'string_defaults': ['Police Station']
+}, {
+    'key': 'Supermarket',
+    'string_defaults': ['Supermarket']
+}, {
+    'key': 'Commercial',
+    'string_defaults': ['Commercial']
+}, {
+    'key': 'Industrial',
+    'string_defaults': ['Industrial']
+}, {
+    'key': 'Utility',
+    'string_defaults': ['Utility']
+}, {
+    'key': 'Sports Facility',
+    'string_defaults': ['Sports Facility']
+}, {
+    'key': 'Other',
+    'string_defaults': []
+}]

--- a/safe/gui/tools/wizard_strings.py
+++ b/safe/gui/tools/wizard_strings.py
@@ -140,6 +140,13 @@ classify_raster_question = tr(
     'Please drag unique values from the list on the left '
     'into the panel on the right and place them in the appropriate categories.'
 )  # (subcategory, category, classification)
+classify_vector_for_postprocessor_question = tr(
+    'You have selected <b>%s %s</b>, and the attribute is <b>%s</b>. The '
+    'aggregation postprocessor will need to know mapping of the attribute '
+    'values to known categories. Please drag unique values from the list '
+    'on the left into the panel on the right and place them in the '
+    'appropriate categories.'
+)      # (subcategory, category, field)
 select_function_constraints2_question = tr(
     'You selected <b>%s</b> hazard and <b>%s</b> exposure. Now, select the '
     '<b>geometry types</b> for the hazard and exposure layers you want to '

--- a/safe/metadata/exposure_layer_metadata.py
+++ b/safe/metadata/exposure_layer_metadata.py
@@ -99,6 +99,20 @@ class ExposureLayerMetadata(GenericLayerMetadata):
             'inasafe/'
             'allow_resampling/'
             'gco:CharacterString'),
+        'structure_class_mapping': (
+            'gmd:identificationInfo/'
+            'gmd:MD_DataIdentification/'
+            'gmd:supplementalInformation/'
+            'inasafe/'
+            'structure_class_mapping/'
+            'gco:Dictionary'),
+        'road_class_mapping': (
+            'gmd:identificationInfo/'
+            'gmd:MD_DataIdentification/'
+            'gmd:supplementalInformation/'
+            'inasafe/'
+            'road_class_mapping/'
+            'gco:Dictionary'),
     }
     _standard_properties = merge_dictionaries(
             GenericLayerMetadata._standard_properties, _standard_properties)

--- a/safe/utilities/keyword_io.py
+++ b/safe/utilities/keyword_io.py
@@ -728,6 +728,8 @@ class KeywordIO(QObject):
             'structure_class_field',
             'field',
             'value_map',  # attribute values
+            'road_class_mapping',
+            'structure_class_mapping',
             'resample',
             'source',
             'url',
@@ -827,7 +829,10 @@ class KeywordIO(QObject):
         # We deal with some special cases first:
 
         # In this case the value contains a DICT that we want to present nicely
-        if keyword == 'value_map':
+        if keyword in [
+                'value_map',
+                'road_class_mapping',
+                'structure_class_mapping']:
             value = self._dict_to_row(value)
         # In these KEYWORD cases we show the DESCRIPTION for
         # the VALUE keyword_definition


### PR DESCRIPTION
This PR makes the wizard showing the mapping (classify) step also for classified roads and structures. The default mapping is read from BuildingTypePostprocessor and RoadTypePostprocessor (unlike  hazard classifications, which are read from ImpactFunctionManager), and the result is put to the keywords as 'exposure_value_map' (I'm not sure if it should be the final name).

Finally, the result is ignored by KeywordIO.write_keywords(), as ExposureLayerMetadata doesn't handle the keyword 'exposure_value_map'. @ismailsunni @timlinux @Gustry could someone decide how this keyword should be stored, please?