### PR TITLE
Fix #2724.

### DIFF
--- a/safe/impact_statistics/aggregator.py
+++ b/safe/impact_statistics/aggregator.py
@@ -1329,7 +1329,6 @@ class Aggregator(QtCore.QObject):
         temporary_dir = temp_dir(sub_dir='pre-process')
         out_filename = unique_filename(suffix='.shp', dir=temporary_dir)
 
-        self.copy_keywords(layer, out_filename)
         shape_writer = QgsVectorFileWriter(
             out_filename,
             'UTF-8',
@@ -1338,6 +1337,11 @@ class Aggregator(QtCore.QObject):
             polygons_provider.crs())
         if shape_writer.hasError():
             raise InvalidParameterError(shape_writer.errorMessage())
+        # Notes (Ismail) for issue #2724
+        # Copy keyword after creating the layer file.
+        # If we copy the keyword first, it will make InaSAFE assumes the
+        # layer is not file based, and it will fail to retrieve the keyword
+        self.copy_keywords(layer, out_filename)
         # end TODO
 
         for (polygon_index, postprocessing_polygon) in enumerate(


### PR DESCRIPTION
We need to write the layer first before creating the layer metadata file. If we create the metadata file, InaSAFE will assume that the layer is not file based, then the metadata will be stored in the database. However, after the layer is written to the disk, InaSAFE will assume that the layer is file based, which make InaSAFE try to find .xml for the metadata. InaSAFE doesn't find the xml, and generate default metadata (with keyword version only).
Hence, it will fail when there is a verification.

please review @timlinux 