### PR TITLE
fix #2849 building report, fix align right/left

### DIFF
--- a/safe/impact_template/abstract_road_building_report_template.py
+++ b/safe/impact_template/abstract_road_building_report_template.py
@@ -79,10 +79,15 @@ class AbstractRoadBuildingReportTemplate(TemplateBase):
             table = m.Table(
                 style_class='table table-condensed table-striped')
             table.caption = v['caption']
+            attributes = v['attributes']
+
             header = m.Row()
-            for attribute in v['attributes']:
-                header.add(m.Cell(attribute, header=True))
-            header.add(m.Cell('Total', header=True))
+            # Bold and align left the 1st one.
+            header.add(m.Cell(attributes[0], header=True, align='left'))
+            for attribute in attributes[1:]:
+                # Bold and align right.
+                header.add(m.Cell(attribute, header=True, align='right'))
+            header.add(m.Cell('Total', header=True, align='right'))
             table.add(header)
 
             for field in v['fields']:
@@ -94,12 +99,13 @@ class AbstractRoadBuildingReportTemplate(TemplateBase):
                     try:
                         val = int(value)
                         total += val
-                        row.add(m.Cell(format_int(val)))
+                        # Align right integers.
+                        row.add(m.Cell(format_int(val), align='right'))
                     except ValueError:
-                        # Catch no data value
-                        row.add(m.Cell(value))
+                        # Catch no data value. Align left strings.
+                        row.add(m.Cell(value, align='left'))
 
-                row.add(m.Cell(format_int(int(round(total)))))
+                row.add(m.Cell(format_int(int(round(total))), align='right'))
                 table.add(row)
             message.add(table)
 

--- a/safe/impact_template/building_report_template.py
+++ b/safe/impact_template/building_report_template.py
@@ -80,23 +80,33 @@ class BuildingReportTemplate(AbstractRoadBuildingReportTemplate):
 
         # Table header
         row = m.Row()
-        for attribute in self.impact_table['attributes']:
+        attributes = self.impact_table['attributes']
+        # Bold and align left the 1st one.
+        row.add(m.Cell(attributes[0], header=True, align='left'))
+        for attribute in attributes[1:]:
+            # Bold and align right.
             row.add(m.Cell(attribute, header=True, align='right'))
         table.add(row)
 
         # Fields
         for record in self.impact_table['fields'][:-1]:
             row = m.Row()
-            # Bold the 1st one
-            row.add(m.Cell(record[0], header=True, align='right'))
+            # Bold and align left the 1st one.
+            row.add(m.Cell(record[0], header=True, align='left'))
             for content in record[1:-1]:
+                # Align right.
                 row.add(m.Cell(format_int(content), align='right'))
+            # Bold and align right the last one.
             row.add(m.Cell(format_int(record[-1]), header=True, align='right'))
             table.add(row)
 
         # Total Row
         row = m.Row()
-        for content in self.impact_table['fields'][-1]:
+        last_row = self.impact_table['fields'][-1]
+        # Bold and align left the 1st one.
+        row.add(m.Cell(last_row[0], header=True, align='left'))
+        for content in last_row[1:]:
+            # Bold and align right.
             row.add(m.Cell(content, header=True, align='right'))
         table.add(row)
 

--- a/safe/impact_template/template_base.py
+++ b/safe/impact_template/template_base.py
@@ -140,9 +140,13 @@ class TemplateBase(object):
             table = m.Table(
                 style_class='table table-condensed table-striped')
             table.caption = v['caption']
+            attributes = v['attributes']
             header = m.Row()
-            for attribute in v['attributes']:
-                header.add(attribute)
+            # Bold and align left the 1st one.
+            header.add(m.Cell(attributes[0], header=True, align='left'))
+            for attribute in attributes[1:]:
+                # Bold and align right.
+                header.add(m.Cell(attribute, header=True, align='right'))
             table.add(header)
 
             for field in v['fields']:
@@ -152,10 +156,11 @@ class TemplateBase(object):
                 for value in field[1:]:
                     try:
                         val = int(value)
-                        row.add(m.Cell(format_int(val)))
+                        # Align right integers.
+                        row.add(m.Cell(format_int(val), align='right'))
                     except ValueError:
-                        # Catch no data value
-                        row.add(m.Cell(value))
+                        # Catch no data value. Align left strings.
+                        row.add(m.Cell(value, align='left'))
 
                 table.add(row)
             message.add(table)

--- a/safe/impact_template/template_base.py
+++ b/safe/impact_template/template_base.py
@@ -140,13 +140,9 @@ class TemplateBase(object):
             table = m.Table(
                 style_class='table table-condensed table-striped')
             table.caption = v['caption']
-            attributes = v['attributes']
             header = m.Row()
-            # Bold and align left the 1st one.
-            header.add(m.Cell(attributes[0], header=True, align='left'))
-            for attribute in attributes[1:]:
-                # Bold and align right.
-                header.add(m.Cell(attribute, header=True, align='right'))
+            for attribute in v['attributes']:
+                header.add(attribute)
             table.add(header)
 
             for field in v['fields']:


### PR DESCRIPTION
@Charlotte-Morgan I fixed the text alignment for the breakdown and for the postprocessing, like `closed buildings`.

![3858](https://cloud.githubusercontent.com/assets/1609292/15539504/36b0978a-2283-11e6-8124-1d792a682e11.png)

