### PR TITLE
fix #2899 impact layer should draw over the hazard layer

### DIFF
--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -1267,7 +1267,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
 
         return impact_function
 
-    def add_above_layer(self, existing_layer, new_layer):
+    def add_above_layer(self, new_layer, *existing_layers):
         """Add a layer (e.g. impact layer) above another layer in the legend.
 
         .. versionadded:: 3.2
@@ -1278,9 +1278,9 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
 
         .. seealso:: issue #2322
 
-        :param existing_layer: The layer which the new layer
+        :param existing_layers: Layers which the new layer
             should be added above.
-        :type existing_layer: QgsMapLayer
+        :type existing_layers: QgsMapLayer
 
         :param new_layer: The new layer being added. An assumption is made
             that the newly added layer is not already loaded in the legend
@@ -1288,7 +1288,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         :type new_layer: QgsMapLayer
 
         """
-        if existing_layer is None or new_layer is None:
+        if len(existing_layers) is None or new_layer is None:
             return
 
         registry = QgsMapLayerRegistry.instance()
@@ -1300,11 +1300,13 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
 
         # False flag prevents layer being added to legend
         registry.addMapLayer(new_layer, False)
-        index = self.layer_legend_index(existing_layer)
-        # LOGGER.info('Inserting layer %s at position %s' % (
-        #     new_layer.source(), index))
+        minimum_index = len(QgsProject.instance().layerTreeRoot().children())
+        for layer in existing_layers:
+            index = self.layer_legend_index(layer)
+            if index < minimum_index:
+                minimum_index = index
         root = QgsProject.instance().layerTreeRoot()
-        root.insertLayer(index, new_layer)
+        root.insertLayer(minimum_index, new_layer)
 
     @staticmethod
     def layer_legend_index(layer):
@@ -1451,18 +1453,32 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         # Insert the aggregation output above the input aggregation layer
         if self.show_intermediate_layers:
             self.add_above_layer(
-                self.get_aggregation_layer(),
-                self.impact_function.aggregator.layer)
+                self.impact_function.aggregator.layer,
+                self.get_aggregation_layer())
 
-        # Insert the impact above the exposure
-        self.add_above_layer(
-            self.get_exposure_layer(),
-            qgis_impact_layer)
+        if self.hide_exposure_flag:
+            # Insert the impact always above the hazard
+            self.add_above_layer(qgis_impact_layer, self.get_hazard_layer())
+        else:
+            # Insert the impact above the hazard and the exposure if
+            # we don't hide the exposure. See #2899
+            self.add_above_layer(
+                qgis_impact_layer,
+                self.get_exposure_layer(),
+                self.get_hazard_layer())
 
         active_function = self.active_impact_function
         self.active_impact_function = active_function
         self.impact_function_parameters = \
             self.active_impact_function.parameters
+
+        # In QGIS 2.14.2 and GDAL 1.11.3, if the exposure is in 3857,
+        # the impact layer is in 54004, we need to change it. See issue #2790.
+        if self.get_exposure_layer().crs().authid() == 'EPSG:3857':
+            if qgis_impact_layer.crs().authid() != 'EPSG:3857':
+                epsg_3857 = QgsCoordinateReferenceSystem(3857)
+                qgis_impact_layer.setCrs(epsg_3857)
+
         # make sure it is active in the legend - needed since QGIS 2.4
         self.iface.setActiveLayer(qgis_impact_layer)
         # then zoom to it
@@ -1472,13 +1488,6 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             exposure_layer = self.get_exposure_layer()
             legend = self.iface.legendInterface()
             legend.setLayerVisible(exposure_layer, False)
-
-        # In QGIS 2.14.2 and GDAL 1.11.3, if the exposure is in 3857,
-        # the impact layer is in 54004, we need to change it. See issue #2790.
-        if self.get_exposure_layer().crs().authid() == 'EPSG:3857':
-            if qgis_impact_layer.crs().authid() != 'EPSG:3857':
-                epsg_3857 = QgsCoordinateReferenceSystem(3857)
-                qgis_impact_layer.setCrs(epsg_3857)
 
         self.restore_state()
 

--- a/safe/gui/widgets/test/test_dock.py
+++ b/safe/gui/widgets/test/test_dock.py
@@ -361,7 +361,7 @@ class TestDock(TestCase):
         layer_path = join(TESTDATA, 'polygon_0.shp')
         new_layer = QgsVectorLayer(layer_path, 'foo', 'ogr')
         exposure_layer = self.dock.get_exposure_layer()
-        self.dock.add_above_layer(exposure_layer, new_layer)
+        self.dock.add_above_layer(new_layer, exposure_layer)
         root = QgsProject.instance().layerTreeRoot()
         id_list = root.findLayerIds()
         self.assertIn(new_layer.id(), id_list)


### PR DESCRIPTION
Issue https://github.com/inasafe/inasafe/issues/2899

* If `hide the exposure layer` is checked : 
  * The impact layer will be above the hazard layer
  * The exposure layer will be unchecked

* If `hide the exposure layer` is not checked : 
 * The impact layer will be above the hazard layer and the exposure layer


 @Charlotte-Morgan Is-it the expected behaviour ?
For now in InaSAFE, we don't have any option to hide the hazard layer after the analysis, only the exposure layer, so the algorithm will always put the impact layer above the hazard.