### PR TITLE
Review the legend and refactoring the legend in the metadata

### DIFF
--- a/safe/gui/tools/test/test_save_scenario.py
+++ b/safe/gui/tools/test/test_save_scenario.py
@@ -87,7 +87,7 @@ class SaveScenarioTest(unittest.TestCase):
             self.DOCK,
             hazard='Classified Flood',
             exposure='Population',
-            function='Be affected in each hazard class',
+            function='Be affected',
             function_id='ClassifiedRasterHazardPopulationFunction')
         self.assertTrue(result, message)
         is_valid, message = self.save_scenario_dialog.validate_input()
@@ -106,7 +106,7 @@ class SaveScenarioTest(unittest.TestCase):
             self.DOCK,
             hazard='Classified Flood',
             exposure='Population',
-            function='Be affected in each hazard class',
+            function='Be affected',
             function_id='ClassifiedRasterHazardPopulationFunction')
         self.assertTrue(result, message)
 
@@ -165,7 +165,7 @@ class SaveScenarioTest(unittest.TestCase):
             self.DOCK,
             hazard='Classified Flood',
             exposure='Population',
-            function='Be affected in each hazard class',
+            function='Be affected',
             function_id='ClassifiedRasterHazardPopulationFunction')
         self.assertTrue(result, message)
         fake_dir = test_data_path()

--- a/safe/impact_functions/earthquake/earthquake_building/impact_function.py
+++ b/safe/impact_functions/earthquake/earthquake_building/impact_function.py
@@ -240,21 +240,13 @@ class EarthquakeBuildingFunction(
             style_type='categorizedSymbol'
         )
 
-        # For printing map purpose
-        map_title = tr('Building affected by earthquake')
-        legend_notes = tr(
-            'The level of the impact is according to the threshold the user '
-            'input.')
-        legend_units = tr('(mmi)')
-        legend_title = tr('Impact level')
-
         impact_data = self.generate_data()
 
         extra_keywords = {
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title'),
             'target_field': self.target_field,
         }
 
@@ -265,7 +257,7 @@ class EarthquakeBuildingFunction(
             data=attributes,
             projection=interpolate_result.get_projection(),
             geometry=geometry,
-            name=tr('Estimated buildings affected'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/earthquake/earthquake_building/metadata_definitions.py
+++ b/safe/impact_functions/earthquake/earthquake_building/metadata_definitions.py
@@ -79,6 +79,13 @@ class EarthquakeBuildingMetadata(ImpactFunctionMetadata):
             'actions': '',
             'limitations': [],
             'citations': [],
+            'map_title': tr('Building affected by earthquake'),
+            'legend_notes': tr(
+                'The level of the impact is according to the threshold the '
+                'user input.'),
+            'legend_units': tr('(mmi)'),
+            'legend_title': tr('Impact level'),
+            'layer_name': tr('Estimated buildings affected'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_continuous,

--- a/safe/impact_functions/earthquake/itb_bayesian_earthquake_fatality_model/metadata_definitions.py
+++ b/safe/impact_functions/earthquake/itb_bayesian_earthquake_fatality_model/metadata_definitions.py
@@ -80,7 +80,7 @@ class ITBBayesianFatalityMetadata(ITBFatalityMetadata):
                    'a Bayesian approach. Submitted for Journal of the '
                    'Geological Society')  # FIXME
             ],
-            'map_title': '',
+            'map_title': 'Earthquake impact to population',
             'legend_title': '',
             'legend_units': '',
             'legend_notes': '',

--- a/safe/impact_functions/earthquake/itb_bayesian_earthquake_fatality_model/metadata_definitions.py
+++ b/safe/impact_functions/earthquake/itb_bayesian_earthquake_fatality_model/metadata_definitions.py
@@ -80,6 +80,11 @@ class ITBBayesianFatalityMetadata(ITBFatalityMetadata):
                    'a Bayesian approach. Submitted for Journal of the '
                    'Geological Society')  # FIXME
             ],
+            'map_title': '',
+            'legend_title': '',
+            'legend_units': '',
+            'legend_notes': '',
+            'layer_name': '',
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_continuous,

--- a/safe/impact_functions/earthquake/itb_earthquake_fatality_model/impact_function.py
+++ b/safe/impact_functions/earthquake/itb_earthquake_fatality_model/impact_function.py
@@ -25,8 +25,7 @@ from safe.common.utilities import (
     humanize_class,
     format_int,
     create_classes,
-    create_label,
-    get_thousand_separator)
+    create_label)
 from safe.utilities.i18n import tr
 from safe.gui.tools.minimum_needs.needs_profile import (
     add_needs_parameters,
@@ -354,14 +353,6 @@ class ITBFatalityFunction(
                           style_classes=style_classes,
                           style_type='rasterStyle')
 
-        # For printing map purpose
-        map_title = tr('Earthquake impact to population')
-        legend_title = tr('Population Count')
-        legend_units = tr('(people per cell)')
-        legend_notes = tr(
-            'Thousand separator is represented by %s' %
-            get_thousand_separator())
-
         impact_data = self.generate_data()
 
         extra_keywords = {
@@ -372,10 +363,10 @@ class ITBFatalityFunction(
             'fatalities_per_mmi': number_of_fatalities,
             'total_displaced': population_rounding(total_displaced),
             'displaced_per_mmi': number_of_displaced,
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title'),
             'total_needs': total_needs,
             'prob_fatality_mag': prob_fatality_mag,
         }
@@ -388,7 +379,7 @@ class ITBFatalityFunction(
             projection=self.exposure.layer.get_projection(),
             geotransform=self.exposure.layer.get_geotransform(),
             keywords=impact_layer_keywords,
-            name=tr('Estimated displaced population per cell'),
+            name=self.metadata().key('layer_name'),
             style_info=style_info)
 
         impact_layer.impact_data = impact_data

--- a/safe/impact_functions/earthquake/itb_earthquake_fatality_model/metadata_definitions.py
+++ b/safe/impact_functions/earthquake/itb_earthquake_fatality_model/metadata_definitions.py
@@ -10,7 +10,7 @@ Contact : ole.moller.nielsen@gmail.com
      (at your option) any later version.
 
 """
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 from safe.defaults import default_minimum_needs
 from safe.defaults import (
     default_gender_postprocessor,
@@ -117,6 +117,13 @@ class ITBFatalityMetadata(ImpactFunctionMetadata):
                    'for global earthquake fatality estimation, Earthq. '
                    'Spectra 26, 1017-1037.')
             ],
+            'map_title': tr('Earthquake impact to population'),
+            'legend_title': tr('Population Count'),
+            'legend_units': tr('(people per cell)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by %s' %
+                get_thousand_separator()),
+            'layer_name': tr('Estimated displaced population per cell'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_continuous,

--- a/safe/impact_functions/earthquake/pager_earthquake_fatality_model/metadata_definitions.py
+++ b/safe/impact_functions/earthquake/pager_earthquake_fatality_model/metadata_definitions.py
@@ -72,6 +72,11 @@ class PAGFatalityMetadata(ITBFatalityMetadata):
             'output': '',
             'actions': '',
             'limitations': [],
+            'map_title': '',
+            'legend_title': '',
+            'legend_units': '',
+            'legend_notes': '',
+            'layer_name': '',
             'citations': [
                 tr('Jaiswal, K. S., Wald, D. J., and Hearne, M. (2009a). '
                    'Estimating casualties for large worldwide earthquakes '

--- a/safe/impact_functions/earthquake/pager_earthquake_fatality_model/metadata_definitions.py
+++ b/safe/impact_functions/earthquake/pager_earthquake_fatality_model/metadata_definitions.py
@@ -72,7 +72,7 @@ class PAGFatalityMetadata(ITBFatalityMetadata):
             'output': '',
             'actions': '',
             'limitations': [],
-            'map_title': '',
+            'map_title': 'Earthquake impact to population',
             'legend_title': '',
             'legend_units': '',
             'legend_notes': '',

--- a/safe/impact_functions/generic/classified_polygon_building/impact_function.py
+++ b/safe/impact_functions/generic/classified_polygon_building/impact_function.py
@@ -23,9 +23,7 @@ from safe.impact_functions.generic.classified_polygon_building \
     import ClassifiedPolygonHazardBuildingFunctionMetadata
 from safe.common.exceptions import (
     InaSAFEError, ZeroImpactException, KeywordNotFoundError)
-from safe.common.utilities import (
-    get_thousand_separator,
-    color_ramp)
+from safe.common.utilities import color_ramp
 from safe.impact_reports.building_exposure_report_mixin import (
     BuildingExposureReportMixin)
 from safe.engine.interpolation_qgis import interpolate_polygon_polygon
@@ -186,8 +184,7 @@ class ClassifiedPolygonHazardBuildingFunction(
         colours = color_ramp(len(categories))
         style_classes = []
 
-        i = 0
-        for hazard_zone in self.affected_buildings.keys():
+        for i, hazard_zone in enumerate(self.affected_buildings.keys()):
             style_class = dict()
             style_class['label'] = tr(hazard_zone)
             style_class['transparency'] = 0
@@ -195,7 +192,6 @@ class ClassifiedPolygonHazardBuildingFunction(
             style_class['size'] = 1
             style_class['colour'] = colours[i]
             style_classes.append(style_class)
-            i += 1
 
         # Override style info with new classes and name
         style_info = dict(
@@ -204,22 +200,14 @@ class ClassifiedPolygonHazardBuildingFunction(
             style_type='categorizedSymbol'
         )
 
-        # For printing map purpose
-        map_title = tr('Buildings affected')
-        legend_title = tr('Building count')
-        legend_units = tr('(building)')
-        legend_notes = tr(
-            'Thousand separator is represented by %s' %
-            get_thousand_separator())
-
         impact_data = self.generate_data()
 
         extra_keywords = {
             'target_field': self.target_field,
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title')
         }
 
         impact_layer_keywords = self.generate_impact_keywords(extra_keywords)
@@ -227,7 +215,7 @@ class ClassifiedPolygonHazardBuildingFunction(
         # Create vector layer and return
         impact_layer = Vector(
             data=interpolated_layer,
-            name=tr('Buildings affected'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/generic/classified_polygon_building/impact_function.py
+++ b/safe/impact_functions/generic/classified_polygon_building/impact_function.py
@@ -205,7 +205,7 @@ class ClassifiedPolygonHazardBuildingFunction(
         )
 
         # For printing map purpose
-        map_title = tr('Buildings affected by each hazard zone')
+        map_title = tr('Buildings affected')
         legend_title = tr('Building count')
         legend_units = tr('(building)')
         legend_notes = tr(
@@ -227,7 +227,7 @@ class ClassifiedPolygonHazardBuildingFunction(
         # Create vector layer and return
         impact_layer = Vector(
             data=interpolated_layer,
-            name=tr('Buildings affected by each hazard zone'),
+            name=tr('Buildings affected'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/generic/classified_polygon_building/metadata_definitions.py
+++ b/safe/impact_functions/generic/classified_polygon_building/metadata_definitions.py
@@ -10,7 +10,7 @@ Contact : ole.moller.nielsen@gmail.com
      (at your option) any later version.
 
 """
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 from safe.defaults import building_type_postprocessor
 from safe.definitions import (
     layer_mode_classified,
@@ -74,6 +74,13 @@ class ClassifiedPolygonHazardBuildingFunctionMetadata(ImpactFunctionMetadata):
                 'each hazard zone.'),
             'limitations': [],
             'citations': [],
+            'map_title': tr('Buildings affected'),
+            'legend_title': tr('Building count'),
+            'legend_units': tr('(building)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by %s' %
+                get_thousand_separator()),
+            'layer_name': tr('Buildings affected'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_classified,

--- a/safe/impact_functions/generic/classified_polygon_landcover/impact_function.py
+++ b/safe/impact_functions/generic/classified_polygon_landcover/impact_function.py
@@ -279,7 +279,7 @@ class ClassifiedPolygonHazardLandCoverFunction(ClassifiedVHClassifiedVE):
         # Create vector layer and return
         impact_layer = Vector(
             data=impact_layer,
-            name=tr('Land cover affected by each hazard zone'),
+            name=tr('Land cover affected'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/generic/classified_polygon_landcover/impact_function.py
+++ b/safe/impact_functions/generic/classified_polygon_landcover/impact_function.py
@@ -270,7 +270,7 @@ class ClassifiedPolygonHazardLandCoverFunction(ClassifiedVHClassifiedVE):
             style_type='categorizedSymbol')
 
         extra_keywords = {
-            'map_title': tr('Affected Land Cover'),
+            'map_title': self.metadata().key('map_title'),
             'target_field': self.target_field
         }
 
@@ -279,7 +279,7 @@ class ClassifiedPolygonHazardLandCoverFunction(ClassifiedVHClassifiedVE):
         # Create vector layer and return
         impact_layer = Vector(
             data=impact_layer,
-            name=tr('Land cover affected'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/generic/classified_polygon_landcover/metadata_definitions.py
+++ b/safe/impact_functions/generic/classified_polygon_landcover/metadata_definitions.py
@@ -65,6 +65,8 @@ class ClassifiedPolygonHazardLandCoverFunctionMetadata(ImpactFunctionMetadata):
                 'each hazard zone.'),
             'limitations': [],
             'citations': [],
+            'map_title': tr('Affected Land Cover'),
+            'layer_name': tr('Land cover affected'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_classified,

--- a/safe/impact_functions/generic/classified_polygon_landcover/metadata_definitions.py
+++ b/safe/impact_functions/generic/classified_polygon_landcover/metadata_definitions.py
@@ -65,6 +65,9 @@ class ClassifiedPolygonHazardLandCoverFunctionMetadata(ImpactFunctionMetadata):
                 'each hazard zone.'),
             'limitations': [],
             'citations': [],
+            'legend_title': '',
+            'legend_units': '',
+            'legend_notes': '',
             'map_title': tr('Affected Land Cover'),
             'layer_name': tr('Land cover affected'),
             'layer_requirements': {

--- a/safe/impact_functions/generic/classified_polygon_people/impact_function.py
+++ b/safe/impact_functions/generic/classified_polygon_people/impact_function.py
@@ -253,7 +253,7 @@ class ClassifiedPolygonHazardPolygonPeopleFunction(
         # Create vector layer and return
         impact_layer = Vector(
             data=impact_layer,
-            name=tr('People affected by each hazard zone'),
+            name=tr('People affected'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/generic/classified_polygon_people/impact_function.py
+++ b/safe/impact_functions/generic/classified_polygon_people/impact_function.py
@@ -245,7 +245,7 @@ class ClassifiedPolygonHazardPolygonPeopleFunction(
 
         extra_keywords = {
             'target_field': self.target_field,
-            'map_title': tr('Affected People'),
+            'map_title': self.metadata().key('map_title'),
         }
 
         impact_layer_keywords = self.generate_impact_keywords(extra_keywords)
@@ -253,7 +253,7 @@ class ClassifiedPolygonHazardPolygonPeopleFunction(
         # Create vector layer and return
         impact_layer = Vector(
             data=impact_layer,
-            name=tr('People affected'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/generic/classified_polygon_people/metadata_definitions.py
+++ b/safe/impact_functions/generic/classified_polygon_people/metadata_definitions.py
@@ -79,6 +79,9 @@ class ClassifiedPolygonHazardPolygonPeopleFunctionMetadata(
                 'each hazard zone.'),
             'limitations': [],
             'citations': [],
+            'legend_title': '',
+            'legend_units': '',
+            'legend_notes': '',
             'map_title': tr('Affected People'),
             'layer_name': tr('People affected'),
             'layer_requirements': {

--- a/safe/impact_functions/generic/classified_polygon_people/metadata_definitions.py
+++ b/safe/impact_functions/generic/classified_polygon_people/metadata_definitions.py
@@ -79,6 +79,8 @@ class ClassifiedPolygonHazardPolygonPeopleFunctionMetadata(
                 'each hazard zone.'),
             'limitations': [],
             'citations': [],
+            'map_title': tr('Affected People'),
+            'layer_name': tr('People affected'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_classified,

--- a/safe/impact_functions/generic/classified_polygon_population/impact_function.py
+++ b/safe/impact_functions/generic/classified_polygon_population/impact_function.py
@@ -26,8 +26,7 @@ from safe.common.utilities import (
     format_int,
     humanize_class,
     create_classes,
-    create_label,
-    get_thousand_separator)
+    create_label)
 from safe.impact_functions.core import (
     no_population_impact_message,
     get_key_for_value)
@@ -216,22 +215,14 @@ class ClassifiedPolygonHazardPopulationFunction(
             style_classes=style_classes,
             style_type='rasterStyle')
 
-        # For printing map purpose
-        map_title = tr('People impacted')
-        legend_title = tr('Population')
-        legend_units = tr('(people per cell)')
-        legend_notes = tr(
-            'Thousand separator is represented by  %s' %
-            get_thousand_separator())
-
         impact_data = self.generate_data()
 
         extra_keywords = {
             'target_field': self.target_field,
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title')
         }
 
         impact_layer_keywords = self.generate_impact_keywords(extra_keywords)
@@ -241,7 +232,7 @@ class ClassifiedPolygonHazardPopulationFunction(
             data=covered_exposure_layer.get_data(),
             projection=covered_exposure_layer.get_projection(),
             geotransform=covered_exposure_layer.get_geotransform(),
-            name=tr('People impacted'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/generic/classified_polygon_population/impact_function.py
+++ b/safe/impact_functions/generic/classified_polygon_population/impact_function.py
@@ -217,7 +217,7 @@ class ClassifiedPolygonHazardPopulationFunction(
             style_type='rasterStyle')
 
         # For printing map purpose
-        map_title = tr('People impacted by each hazard zone')
+        map_title = tr('People impacted')
         legend_title = tr('Population')
         legend_units = tr('(people per cell)')
         legend_notes = tr(
@@ -241,7 +241,7 @@ class ClassifiedPolygonHazardPopulationFunction(
             data=covered_exposure_layer.get_data(),
             projection=covered_exposure_layer.get_projection(),
             geotransform=covered_exposure_layer.get_geotransform(),
-            name=tr('People impacted by each hazard zone'),
+            name=tr('People impacted'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/generic/classified_polygon_population/metadata_definitions.py
+++ b/safe/impact_functions/generic/classified_polygon_population/metadata_definitions.py
@@ -10,7 +10,7 @@ Contact : ole.moller.nielsen@gmail.com
      (at your option) any later version.
 
 """
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 from safe.definitions import (
     layer_mode_classified,
     layer_mode_continuous,
@@ -77,6 +77,13 @@ class ClassifiedPolygonHazardPopulationFunctionMetadata(
                 'within each hazard zone.'),
             'limitations': [],
             'citations': [],
+            'map_title': tr('People impacted'),
+            'legend_title': tr('Population'),
+            'legend_units': tr('(people per cell)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by  %s' %
+                get_thousand_separator()),
+            'layer_name': tr('People impacted'),
             'overview': tr(
                 'To assess the number of people that may be impacted by '
                 'each hazard zone.'),

--- a/safe/impact_functions/generic/classified_raster_building/impact_function.py
+++ b/safe/impact_functions/generic/classified_raster_building/impact_function.py
@@ -182,18 +182,13 @@ class ClassifiedRasterHazardBuildingFunction(
             style_classes=style_classes,
             style_type='categorizedSymbol')
 
-        # For printing map purpose
-        map_title = tr('Buildings affected')
-        legend_title = tr('Structure inundated status')
-        legend_units = tr('(Low, Medium, High)')
-
         impact_data = self.generate_data()
 
         extra_keywords = {
             'target_field': self.affected_field,
-            'map_title': map_title,
-            'legend_units': legend_units,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title'),
             'buildings_total': buildings_total,
             'buildings_affected': self.total_affected_buildings
         }
@@ -205,7 +200,7 @@ class ClassifiedRasterHazardBuildingFunction(
             data=attributes,
             projection=self.exposure.layer.get_projection(),
             geometry=self.exposure.layer.get_geometry(),
-            name=tr('Estimated buildings affected'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/generic/classified_raster_building/metadata_definitions.py
+++ b/safe/impact_functions/generic/classified_raster_building/metadata_definitions.py
@@ -95,6 +95,10 @@ class ClassifiedRasterHazardBuildingMetadata(ImpactFunctionMetadata):
                 'within each hazard class.'),
             'limitations': [tr('The number of classes is three.')],
             'citations': [],
+            'map_title': tr('Buildings affected'),
+            'legend_units': tr('(Low, Medium, High)'),
+            'legend_title': tr('Structure inundated status'),
+            'layer_name': tr('Estimated buildings affected'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_classified,

--- a/safe/impact_functions/generic/classified_raster_building/metadata_definitions.py
+++ b/safe/impact_functions/generic/classified_raster_building/metadata_definitions.py
@@ -95,6 +95,7 @@ class ClassifiedRasterHazardBuildingMetadata(ImpactFunctionMetadata):
                 'within each hazard class.'),
             'limitations': [tr('The number of classes is three.')],
             'citations': [],
+            'legend_notes': '',
             'map_title': tr('Buildings affected'),
             'legend_units': tr('(Low, Medium, High)'),
             'legend_title': tr('Structure inundated status'),

--- a/safe/impact_functions/generic/classified_raster_population/impact_function.py
+++ b/safe/impact_functions/generic/classified_raster_population/impact_function.py
@@ -31,8 +31,7 @@ from safe.storage.raster import Raster
 from safe.common.utilities import (
     humanize_class,
     create_classes,
-    create_label,
-    get_thousand_separator)
+    create_label)
 from safe.utilities.i18n import tr
 from safe.impact_functions.generic.\
     classified_raster_population.metadata_definitions import \
@@ -213,21 +212,13 @@ class ClassifiedRasterHazardPopulationFunction(
             style_classes=style_classes,
             style_type='rasterStyle')
 
-        # For printing map purpose
-        map_title = tr('Number of people affected in each class')
-        legend_title = tr('Number of People')
-        legend_units = tr('(people per cell)')
-        legend_notes = tr(
-            'Thousand separator is represented by %s' %
-            get_thousand_separator())
-
         impact_data = self.generate_data()
 
         extra_keywords = {
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title'),
             'total_needs': total_needs
         }
 
@@ -238,9 +229,7 @@ class ClassifiedRasterHazardPopulationFunction(
             data=affected_population,
             projection=self.exposure.layer.get_projection(),
             geotransform=self.exposure.layer.get_geotransform(),
-            name=tr('People that might %s') % (
-                self.impact_function_manager
-                .get_function_title(self).lower()),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/generic/classified_raster_population/metadata_definitions.py
+++ b/safe/impact_functions/generic/classified_raster_population/metadata_definitions.py
@@ -17,7 +17,7 @@ __filename__ = 'metadata_definitions'
 __date__ = '24/03/15'
 __copyright__ = 'lana.pcfre@gmail.com'
 
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 from safe.defaults import default_minimum_needs
 from safe.defaults import (
     default_gender_postprocessor,
@@ -65,8 +65,8 @@ class ClassifiedRasterHazardPopulationMetadata(ImpactFunctionMetadata):
         dict_meta = {
             'id': 'ClassifiedRasterHazardPopulationFunction',
             'name': tr('Classified raster hazard on population'),
-            'impact': tr('Be affected in each class'),
-            'title': tr('Be affected in each hazard class'),
+            'impact': tr('Be affected'),
+            'title': tr('Be affected'),
             'function_type': 'old-style',
             'author': 'Dianne Bencito',
             'date_implemented': 'N/A',
@@ -97,6 +97,13 @@ class ClassifiedRasterHazardPopulationMetadata(ImpactFunctionMetadata):
                 'affected for each hazard class.'),
             'limitations': [tr('The number of classes is three.')],
             'citations': [],
+            'map_title': tr('Number of people affected in each class'),
+            'legend_title': tr('Number of People'),
+            'legend_units': tr('(people per cell)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by %s' %
+                get_thousand_separator()),
+            'layer_name': tr('People that might be affected'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_classified,

--- a/safe/impact_functions/generic/continuous_hazard_population/impact_function.py
+++ b/safe/impact_functions/generic/continuous_hazard_population/impact_function.py
@@ -38,8 +38,7 @@ from safe.utilities.i18n import tr
 from safe.common.utilities import (
     create_classes,
     create_label,
-    humanize_class,
-    get_thousand_separator)
+    humanize_class)
 from safe.common.exceptions import (
     FunctionParametersError, ZeroImpactException)
 from safe.gui.tools.minimum_needs.needs_profile import (
@@ -214,21 +213,13 @@ class ContinuousHazardPopulationFunction(
             style_classes=style_classes,
             style_type='rasterStyle')
 
-        # For printing map purpose
-        map_title = tr('People in each hazard areas (low, medium, high)')
-        legend_title = tr('Number of People')
-        legend_units = tr('(people per cell)')
-        legend_notes = tr(
-            'Thousand separator is represented by %s' %
-            get_thousand_separator())
-
         impact_data = self.generate_data()
 
         extra_keywords = {
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title'),
             'total_needs': total_needs
         }
 
@@ -239,9 +230,7 @@ class ContinuousHazardPopulationFunction(
             data=impacted_exposure,
             projection=self.hazard.layer.get_projection(),
             geotransform=self.hazard.layer.get_geotransform(),
-            name=tr('Population might %s') % (
-                self.impact_function_manager.
-                get_function_title(self).lower()),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/generic/continuous_hazard_population/metadata_definitions.py
+++ b/safe/impact_functions/generic/continuous_hazard_population/metadata_definitions.py
@@ -14,7 +14,7 @@ Contact : ole.moller.nielsen@gmail.com
 __author__ = 'lucernae'
 __date__ = '24/03/15'
 
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 from safe.defaults import default_minimum_needs
 from safe.defaults import (
     default_gender_postprocessor,
@@ -90,6 +90,13 @@ class ContinuousHazardPopulationMetadata(ImpactFunctionMetadata):
                 'be impacted in each category.'),
             'limitations': [tr('Only three categories can be used.')],
             'citations': [],
+            'map_title': tr('People in each hazard areas (low, medium, high)'),
+            'legend_title': tr('Number of People'),
+            'legend_units': tr('(people per cell)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by %s' %
+                get_thousand_separator()),
+            'layer_name': tr('Population might be impacted'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_continuous,

--- a/safe/impact_functions/impact_function_metadata.py
+++ b/safe/impact_functions/impact_function_metadata.py
@@ -248,6 +248,11 @@ class ImpactFunctionMetadata(object):
             'actions': basestring,
             'limitations': list,  # list of string
             'citations': list,  # list of string
+            'map_title': basestring,
+            'legend_title': basestring,
+            'legend_units': basestring,
+            'legend_notes': basestring,
+            'layer_name': basestring,
             'layer_requirements': dict
         }
 

--- a/safe/impact_functions/impact_function_metadata.py
+++ b/safe/impact_functions/impact_function_metadata.py
@@ -342,6 +342,18 @@ class ImpactFunctionMetadata(object):
         return cls.as_dict().get('name', '')
 
     @classmethod
+    def key(cls, key):
+        """Return the IF metadata value according to the key specified.
+
+        :param key: The metadata key to retrieve.
+        :type key: str
+
+        :return: The metadata value or None.
+        :rtype: str, list, dict
+        """
+        return cls.as_dict().get(key, None)
+
+    @classmethod
     def get_hazard_requirements(cls):
         """Get hazard layer requirements."""
         return cls.get_layer_requirements()['hazard']

--- a/safe/impact_functions/inundation/flood_polygon_population/impact_function.py
+++ b/safe/impact_functions/inundation/flood_polygon_population/impact_function.py
@@ -31,8 +31,7 @@ from safe.common.utilities import (
     format_int,
     create_classes,
     humanize_class,
-    create_label,
-    get_thousand_separator)
+    create_label)
 from safe.gui.tools.minimum_needs.needs_profile import add_needs_parameters, \
     get_needs_provenance_value, filter_needs_parameters
 from safe.common.exceptions import ZeroImpactException
@@ -255,22 +254,14 @@ class FloodEvacuationVectorHazardFunction(
             style_classes=style_classes,
             style_type='rasterStyle')
 
-        # For printing map purpose
-        map_title = tr('People affected by flood prone areas')
-        legend_title = tr('Population Count')
-        legend_units = tr('(people per polygon)')
-        legend_notes = tr(
-            'Thousand separator is represented by %s' %
-            get_thousand_separator())
-
         impact_data = self.generate_data()
 
         extra_keywords = {
             'target_field': self.target_field,
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title'),
             'affected_population': total_affected_population,
             'total_population': self.total_population,
             'total_needs': self.total_needs
@@ -283,7 +274,7 @@ class FloodEvacuationVectorHazardFunction(
             data=new_covered_exposure_data,
             projection=covered_exposure.get_projection(),
             geotransform=covered_exposure.get_geotransform(),
-            name=tr('People affected by flood prone areas'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/inundation/flood_polygon_population/metadata_definitions.py
+++ b/safe/impact_functions/inundation/flood_polygon_population/metadata_definitions.py
@@ -13,7 +13,7 @@ Contact : ole.moller.nielsen@gmail.com
 
 __author__ = 'Rizky Maulana Nugraha'
 
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 from safe.defaults import (
     default_minimum_needs,
     default_gender_postprocessor,
@@ -93,6 +93,13 @@ class FloodEvacuationVectorHazardMetadata(ImpactFunctionMetadata):
                 'resources would be required to support them.'),
             'limitations': [],
             'citations': [],
+            'map_title': tr('People affected by flood prone areas'),
+            'legend_title': tr('Population Count'),
+            'legend_units': tr('(people per polygon)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by %s' %
+                get_thousand_separator()),
+            'layer_name': tr('People affected by flood prone areas'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_classified,

--- a/safe/impact_functions/inundation/flood_polygon_roads/impact_function.py
+++ b/safe/impact_functions/inundation/flood_polygon_roads/impact_function.py
@@ -205,10 +205,6 @@ class FloodPolygonRoadsFunction(
 
         self.reorder_dictionaries()
 
-        # For printing map purpose
-        map_title = tr('Roads inundated')
-        legend_title = tr('Road inundated status')
-
         style_classes = [dict(label=tr('Not Inundated'), value=0,
                               colour='#1EFC7C', transparency=0, size=0.5),
                          dict(label=tr('Inundated'), value=1,
@@ -227,8 +223,8 @@ class FloodPolygonRoadsFunction(
         impact_data = self.generate_data()
 
         extra_keywords = {
-            'map_title': map_title,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_title': self.metadata().key('legend_title'),
             'target_field': self.target_field
         }
 
@@ -236,7 +232,7 @@ class FloodPolygonRoadsFunction(
 
         impact_layer = Vector(
             data=line_layer,
-            name=tr('Flooded roads'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info
         )

--- a/safe/impact_functions/inundation/flood_polygon_roads/metadata_definitions.py
+++ b/safe/impact_functions/inundation/flood_polygon_roads/metadata_definitions.py
@@ -64,6 +64,9 @@ class FloodPolygonRoadsMetadata(ImpactFunctionMetadata):
             'actions': tr(''),
             'limitations': [],
             'citations': [],
+            'map_title': tr('Roads inundated'),
+            'legend_title': tr('Road inundated status'),
+            'layer_name': tr('Flooded roads'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_classified,

--- a/safe/impact_functions/inundation/flood_polygon_roads/metadata_definitions.py
+++ b/safe/impact_functions/inundation/flood_polygon_roads/metadata_definitions.py
@@ -64,6 +64,8 @@ class FloodPolygonRoadsMetadata(ImpactFunctionMetadata):
             'actions': tr(''),
             'limitations': [],
             'citations': [],
+            'legend_units': '',
+            'legend_notes': '',
             'map_title': tr('Roads inundated'),
             'legend_title': tr('Road inundated status'),
             'layer_name': tr('Flooded roads'),

--- a/safe/impact_functions/inundation/flood_raster_osm_building_impact/impact_function.py
+++ b/safe/impact_functions/inundation/flood_raster_osm_building_impact/impact_function.py
@@ -133,11 +133,6 @@ class FloodRasterBuildingFunction(
         self.building_report_threshold = building_postprocessors.value[0].value
         self._consolidate_to_other()
 
-        # For printing map purpose
-        map_title = tr('Flooded buildings')
-        legend_title = tr('Flooded structure status')
-        legend_units = tr('(flooded, wet, or dry)')
-
         style_classes = [
             dict(
                 label=tr('Dry (<= 0 m)'),
@@ -170,9 +165,9 @@ class FloodRasterBuildingFunction(
 
         extra_keywords = {
             'target_field': self.target_field,
-            'map_title': map_title,
-            'legend_title': legend_title,
-            'legend_units': legend_units,
+            'map_title': self.metadata().key('map_title'),
+            'legend_title': self.metadata().key('legend_title'),
+            'legend_units': self.metadata().key('legend_units'),
             'buildings_total': total_features,
             'buildings_affected': self.total_affected_buildings
         }
@@ -183,7 +178,7 @@ class FloodRasterBuildingFunction(
             data=features,
             projection=interpolated_layer.get_projection(),
             geometry=interpolated_layer.get_geometry(),
-            name=tr('Estimated buildings affected'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/inundation/flood_raster_osm_building_impact/metadata_definitions.py
+++ b/safe/impact_functions/inundation/flood_raster_osm_building_impact/metadata_definitions.py
@@ -92,6 +92,10 @@ class FloodRasterBuildingMetadata(ImpactFunctionMetadata):
                    'either based on a fixed threshold')
             ],
             'citations': [],
+            'map_title': tr('Flooded buildings'),
+            'legend_title': tr('Flooded structure status'),
+            'legend_units': tr('(flooded, wet, or dry)'),
+            'layer_name': tr('Estimated buildings affected'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_continuous,

--- a/safe/impact_functions/inundation/flood_raster_osm_building_impact/metadata_definitions.py
+++ b/safe/impact_functions/inundation/flood_raster_osm_building_impact/metadata_definitions.py
@@ -92,6 +92,7 @@ class FloodRasterBuildingMetadata(ImpactFunctionMetadata):
                    'either based on a fixed threshold')
             ],
             'citations': [],
+            'legend_notes': '',
             'map_title': tr('Flooded buildings'),
             'legend_title': tr('Flooded structure status'),
             'legend_units': tr('(flooded, wet, or dry)'),

--- a/safe/impact_functions/inundation/flood_raster_population/impact_function.py
+++ b/safe/impact_functions/inundation/flood_raster_population/impact_function.py
@@ -33,8 +33,7 @@ from safe.common.utilities import (
     create_classes,
     humanize_class,
     create_label,
-    verify,
-    get_thousand_separator)
+    verify)
 from safe.gui.tools.minimum_needs.needs_profile import add_needs_parameters, \
     get_needs_provenance_value
 from safe.impact_reports.population_exposure_report_mixin import \
@@ -230,21 +229,13 @@ class FloodEvacuationRasterHazardFunction(
             style_classes=style_classes,
             style_type='rasterStyle')
 
-        # For printing map purpose
-        map_title = tr('People in need of evacuation')
-        legend_title = tr('Population Count')
-        legend_units = tr('(people per cell)')
-        legend_notes = tr(
-            'Thousand separator is represented by %s' %
-            get_thousand_separator())
-
         impact_data = self.generate_data()
 
         extra_keywords = {
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title'),
             'evacuated': evacuated,
             'total_needs': total_needs
         }
@@ -256,9 +247,7 @@ class FloodEvacuationRasterHazardFunction(
             impact,
             projection=self.hazard.layer.get_projection(),
             geotransform=self.hazard.layer.get_geotransform(),
-            name=tr('Population which %s') % (
-                self.impact_function_manager
-                .get_function_title(self).lower()),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/inundation/flood_raster_population/metadata_definitions.py
+++ b/safe/impact_functions/inundation/flood_raster_population/metadata_definitions.py
@@ -13,7 +13,7 @@ Contact : ole.moller.nielsen@gmail.com
 
 __author__ = 'Rizky Maulana Nugraha'
 
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 
 from safe.defaults import (
     default_minimum_needs,
@@ -103,6 +103,13 @@ class FloodEvacuationRasterHazardMetadata(ImpactFunctionMetadata):
                    'on consensus, not hard evidence.')
             ],
             'citations': [],
+            'map_title': tr('People in need of evacuation'),
+            'legend_title': tr('Population Count'),
+            'legend_units': tr('(people per cell)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by %s' %
+                get_thousand_separator()),
+            'layer_name': tr('Population which need evacuation'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_continuous,

--- a/safe/impact_functions/inundation/flood_raster_road/impact_function.py
+++ b/safe/impact_functions/inundation/flood_raster_road/impact_function.py
@@ -366,10 +366,6 @@ class FloodRasterRoadsFunction(
 
         self.reorder_dictionaries()
 
-        # For printing map purpose
-        map_title = tr('Roads inundated')
-        legend_title = tr('Road inundated status')
-
         style_classes = [
             dict(
                 label=tr('Not Inundated'), value=0,
@@ -385,8 +381,8 @@ class FloodRasterRoadsFunction(
         impact_data = self.generate_data()
 
         extra_keywords = {
-            'map_title': map_title,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_title': self.metadata().key('legend_title'),
             'target_field': target_field
         }
 
@@ -395,7 +391,7 @@ class FloodRasterRoadsFunction(
         # Convert QgsVectorLayer to inasafe layer and return it
         impact_layer = Vector(
             data=line_layer,
-            name=tr('Flooded roads'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/inundation/flood_raster_road/metadata_definitions.py
+++ b/safe/impact_functions/inundation/flood_raster_road/metadata_definitions.py
@@ -74,6 +74,9 @@ class FloodRasterRoadsMetadata(ImpactFunctionMetadata):
             'actions': '',
             'limitations': [],
             'citations': [],
+            'map_title': tr('Roads inundated'),
+            'legend_title': tr('Road inundated status'),
+            'layer_name': tr('Flooded roads'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_continuous,

--- a/safe/impact_functions/inundation/flood_raster_road/metadata_definitions.py
+++ b/safe/impact_functions/inundation/flood_raster_road/metadata_definitions.py
@@ -74,6 +74,8 @@ class FloodRasterRoadsMetadata(ImpactFunctionMetadata):
             'actions': '',
             'limitations': [],
             'citations': [],
+            'legend_units': '',
+            'legend_notes': '',
             'map_title': tr('Roads inundated'),
             'legend_title': tr('Road inundated status'),
             'layer_name': tr('Flooded roads'),

--- a/safe/impact_functions/inundation/flood_vector_building_impact/impact_function.py
+++ b/safe/impact_functions/inundation/flood_vector_building_impact/impact_function.py
@@ -246,10 +246,6 @@ class FloodPolygonBuildingFunction(
         self.building_report_threshold = building_postprocessors.value[0].value
         self._consolidate_to_other()
 
-        # For printing map purpose
-        map_title = tr('Buildings inundated')
-        legend_title = tr('Structure inundated status')
-
         style_classes = [
             dict(label=tr('Not Inundated'), value=0, colour='#1EFC7C',
                  transparency=0, size=0.5),
@@ -268,8 +264,8 @@ class FloodPolygonBuildingFunction(
         impact_data = self.generate_data()
 
         extra_keywords = {
-            'map_title': map_title,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_title': self.metadata().key('legend_title'),
             'target_field': self.target_field,
             'buildings_total': self.total_buildings,
             'buildings_affected': self.total_affected_buildings
@@ -279,7 +275,7 @@ class FloodPolygonBuildingFunction(
 
         impact_layer = Vector(
             data=building_layer,
-            name=tr('Flooded buildings'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/inundation/flood_vector_building_impact/metadata_definitions.py
+++ b/safe/impact_functions/inundation/flood_vector_building_impact/metadata_definitions.py
@@ -80,6 +80,8 @@ class FloodPolygonBuildingFunctionMetadata(ImpactFunctionMetadata):
             'actions': '',
             'limitations': [],
             'citations': [],
+            'legend_units': '',
+            'legend_notes': '',
             'map_title': tr('Buildings inundated'),
             'legend_title': tr('Structure inundated status'),
             'layer_name': tr('Flooded buildings'),

--- a/safe/impact_functions/inundation/flood_vector_building_impact/metadata_definitions.py
+++ b/safe/impact_functions/inundation/flood_vector_building_impact/metadata_definitions.py
@@ -80,6 +80,9 @@ class FloodPolygonBuildingFunctionMetadata(ImpactFunctionMetadata):
             'actions': '',
             'limitations': [],
             'citations': [],
+            'map_title': tr('Buildings inundated'),
+            'legend_title': tr('Structure inundated status'),
+            'layer_name': tr('Flooded buildings'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_classified,

--- a/safe/impact_functions/inundation/tsunami_population_evacuation_raster/impact_function.py
+++ b/safe/impact_functions/inundation/tsunami_population_evacuation_raster/impact_function.py
@@ -28,8 +28,7 @@ from safe.common.utilities import (
     verify,
     humanize_class,
     create_classes,
-    create_label,
-    get_thousand_separator)
+    create_label)
 
 from safe.common.exceptions import ZeroImpactException
 from safe.gui.tools.minimum_needs.needs_profile import add_needs_parameters, \
@@ -202,21 +201,13 @@ class TsunamiEvacuationFunction(
             style_classes=style_classes,
             style_type='rasterStyle')
 
-        # For printing map purpose
-        map_title = tr('People in need of evacuation')
-        legend_title = tr('Population')
-        legend_units = tr('(people per cell)')
-        legend_notes = tr(
-            'Thousand separator is represented by %s' %
-            get_thousand_separator())
-
         impact_data = self.generate_data()
 
         extra_keywords = {
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title'),
             'evacuated': self.total_evacuated,
             'total_needs': self.total_needs
         }
@@ -228,8 +219,7 @@ class TsunamiEvacuationFunction(
             impact,
             projection=self.hazard.layer.get_projection(),
             geotransform=self.hazard.layer.get_geotransform(),
-            name=tr('Population which %s') % (
-                self.impact_function_manager.get_function_title(self).lower()),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/inundation/tsunami_population_evacuation_raster/metadata_definitions.py
+++ b/safe/impact_functions/inundation/tsunami_population_evacuation_raster/metadata_definitions.py
@@ -28,7 +28,7 @@ from safe.impact_functions.impact_function_metadata import \
 from safe.impact_functions.inundation.tsunami_population_evacuation_raster\
     .parameter_definitions import threshold
 from safe.utilities.i18n import tr
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 from safe.definitions import (
     layer_mode_continuous,
     layer_geometry_raster,
@@ -113,6 +113,13 @@ class TsunamiEvacuationMetadata(ImpactFunctionMetadata):
                    'than a flood threshold because in a tsunami, the water is '
                    'moving with force.'),
             ],
+            'map_title': tr('People in need of evacuation'),
+            'legend_title': tr('Population'),
+            'legend_units': tr('(people per cell)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by %s' %
+                get_thousand_separator()),
+            'layer_name': tr('Population which need evacuation'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_continuous,

--- a/safe/impact_functions/inundation/tsunami_raster_building/impact_function.py
+++ b/safe/impact_functions/inundation/tsunami_raster_building/impact_function.py
@@ -168,11 +168,6 @@ class TsunamiRasterBuildingFunction(
         self.building_report_threshold = building_postprocessors.value[0].value
         self._consolidate_to_other()
 
-        # For printing map purpose
-        map_title = tr('Inundated buildings')
-        legend_title = tr('Inundated structure status')
-        legend_units = tr('(low, medium, high, and very high)')
-
         style_classes = [
             dict(
                 label=self.hazard_classes[0] + ': 0 m',
@@ -223,9 +218,9 @@ class TsunamiRasterBuildingFunction(
 
         extra_keywords = {
             'target_field': self.target_field,
-            'map_title': map_title,
-            'legend_title': legend_title,
-            'legend_units': legend_units,
+            'map_title': self.metadata().key('map_title'),
+            'legend_title': self.metadata().key('legend_title'),
+            'legend_units': self.metadata().key('legend_units'),
             'buildings_total': total_features,
             'buildings_affected': self.total_affected_buildings
         }
@@ -236,7 +231,7 @@ class TsunamiRasterBuildingFunction(
             data=features,
             projection=interpolated_layer.get_projection(),
             geometry=interpolated_layer.get_geometry(),
-            name=tr('Estimated buildings affected'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/inundation/tsunami_raster_building/metadata_definitions.py
+++ b/safe/impact_functions/inundation/tsunami_raster_building/metadata_definitions.py
@@ -101,6 +101,10 @@ class TsunamiRasterBuildingMetadata(ImpactFunctionMetadata):
                    '"A proposal for a new tsunami intensity scale." '
                    'ITS 2001 proceedings, no. 5-1, pp. 569-577. 2001.')
             ],
+            'map_title': tr('Inundated buildings'),
+            'legend_title': tr('Inundated structure status'),
+            'legend_units': tr('(low, medium, high, and very high)'),
+            'layer_name': tr('Estimated buildings affected'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_continuous,

--- a/safe/impact_functions/inundation/tsunami_raster_building/metadata_definitions.py
+++ b/safe/impact_functions/inundation/tsunami_raster_building/metadata_definitions.py
@@ -101,6 +101,7 @@ class TsunamiRasterBuildingMetadata(ImpactFunctionMetadata):
                    '"A proposal for a new tsunami intensity scale." '
                    'ITS 2001 proceedings, no. 5-1, pp. 569-577. 2001.')
             ],
+            'legend_notes': '',
             'map_title': tr('Inundated buildings'),
             'legend_title': tr('Inundated structure status'),
             'legend_units': tr('(low, medium, high, and very high)'),

--- a/safe/impact_functions/inundation/tsunami_raster_landcover/impact_function.py
+++ b/safe/impact_functions/inundation/tsunami_raster_landcover/impact_function.py
@@ -253,7 +253,7 @@ class TsunamiRasterLandcoverFunction(ContinuousRHClassifiedVE):
             style_type='categorizedSymbol')
 
         extra_keywords = {
-            'map_title': tr('Affected Land Cover'),
+            'map_title': self.metadata().key('map_title'),
             'target_field': self.target_field
         }
 
@@ -262,7 +262,7 @@ class TsunamiRasterLandcoverFunction(ContinuousRHClassifiedVE):
         # Create vector layer and return
         impact_layer = Vector(
             data=impact_layer,
-            name=tr('Land cover affected'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/inundation/tsunami_raster_landcover/impact_function.py
+++ b/safe/impact_functions/inundation/tsunami_raster_landcover/impact_function.py
@@ -262,7 +262,7 @@ class TsunamiRasterLandcoverFunction(ContinuousRHClassifiedVE):
         # Create vector layer and return
         impact_layer = Vector(
             data=impact_layer,
-            name=tr('Land cover affected by each hazard zone'),
+            name=tr('Land cover affected'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/inundation/tsunami_raster_landcover/metadata_definitions.py
+++ b/safe/impact_functions/inundation/tsunami_raster_landcover/metadata_definitions.py
@@ -80,6 +80,8 @@ class TsunamiRasterHazardLandCoverFunctionMetadata(ImpactFunctionMetadata):
                 tr('Papadopoulos, Gerassimos A., and Fumihiko Imamura. '
                    '"A proposal for a new tsunami intensity scale." '
                    'ITS 2001 proceedings, no. 5-1, pp. 569-577. 2001.')],
+            'map_title': tr('Affected Land Cover'),
+            'layer_name': tr('Land cover affected'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_continuous,

--- a/safe/impact_functions/inundation/tsunami_raster_landcover/metadata_definitions.py
+++ b/safe/impact_functions/inundation/tsunami_raster_landcover/metadata_definitions.py
@@ -80,6 +80,9 @@ class TsunamiRasterHazardLandCoverFunctionMetadata(ImpactFunctionMetadata):
                 tr('Papadopoulos, Gerassimos A., and Fumihiko Imamura. '
                    '"A proposal for a new tsunami intensity scale." '
                    'ITS 2001 proceedings, no. 5-1, pp. 569-577. 2001.')],
+            'legend_title': '',
+            'legend_units': '',
+            'legend_notes': '',
             'map_title': tr('Affected Land Cover'),
             'layer_name': tr('Land cover affected'),
             'layer_requirements': {

--- a/safe/impact_functions/inundation/tsunami_raster_road/impact_function.py
+++ b/safe/impact_functions/inundation/tsunami_raster_road/impact_function.py
@@ -431,10 +431,6 @@ class TsunamiRasterRoadsFunction(
 
         self.reorder_dictionaries()
 
-        # For printing map purpose
-        map_title = tr('Roads inundated')
-        legend_title = tr('Road inundated status')
-
         style_classes = [
             # FIXME 0 - 0.1
             dict(
@@ -484,8 +480,8 @@ class TsunamiRasterRoadsFunction(
         impact_data = self.generate_data()
 
         extra_keywords = {
-            'map_title': map_title,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_title': self.metadata().key('legend_title'),
             'target_field': target_field
         }
 
@@ -494,7 +490,7 @@ class TsunamiRasterRoadsFunction(
         # Convert QgsVectorLayer to inasafe layer and return it
         impact_layer = Vector(
             data=line_layer,
-            name=tr('Flooded roads'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/inundation/tsunami_raster_road/metadata_definitions.py
+++ b/safe/impact_functions/inundation/tsunami_raster_road/metadata_definitions.py
@@ -91,6 +91,9 @@ class TsunamiRasterRoadMetadata(ImpactFunctionMetadata):
                 'might be inundated.'),
             'limitations': [],
             'citations': [],
+            'map_title': tr('Roads inundated'),
+            'legend_title': tr('Road inundated status'),
+            'layer_name': tr('Flooded roads'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_continuous,

--- a/safe/impact_functions/inundation/tsunami_raster_road/metadata_definitions.py
+++ b/safe/impact_functions/inundation/tsunami_raster_road/metadata_definitions.py
@@ -91,6 +91,8 @@ class TsunamiRasterRoadMetadata(ImpactFunctionMetadata):
                 'might be inundated.'),
             'limitations': [],
             'citations': [],
+            'legend_units': '',
+            'legend_notes': '',
             'map_title': tr('Roads inundated'),
             'legend_title': tr('Road inundated status'),
             'layer_name': tr('Flooded roads'),

--- a/safe/impact_functions/test/test_impact_function_metadata.py
+++ b/safe/impact_functions/test/test_impact_function_metadata.py
@@ -21,6 +21,7 @@ import unittest
 from safe.test.utilities import get_qgis_app
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 
+from safe.impact_functions.test.test_registry import EXPECTED_IF
 from safe.impact_functions.impact_function_metadata import (
     ImpactFunctionMetadata)
 
@@ -32,12 +33,18 @@ from safe.impact_functions.earthquake.itb_earthquake_fatality_model. \
     impact_function import ITBFatalityFunction
 from safe.impact_functions.earthquake.pager_earthquake_fatality_model. \
     impact_function import PAGFatalityFunction
+from safe.impact_functions.earthquake.itb_bayesian_earthquake_fatality_model.\
+    impact_function import ITBBayesianFatalityFunction
 
 # Generic IFs
 from safe.impact_functions.generic.classified_polygon_building\
     .impact_function import ClassifiedPolygonHazardBuildingFunction
 from safe.impact_functions.generic.classified_polygon_population \
     .impact_function import ClassifiedPolygonHazardPopulationFunction
+from safe.impact_functions.generic.classified_polygon_people\
+    .impact_function import ClassifiedPolygonHazardPolygonPeopleFunction
+from safe.impact_functions.generic.classified_polygon_landcover\
+    .impact_function import ClassifiedPolygonHazardLandCoverFunction
 from safe.impact_functions.generic.classified_raster_building \
     .impact_function import ClassifiedRasterHazardBuildingFunction
 from safe.impact_functions.generic.classified_raster_population \
@@ -58,10 +65,16 @@ from safe.impact_functions.inundation.flood_raster_road\
     .impact_function import FloodRasterRoadsFunction
 from safe.impact_functions.inundation.flood_vector_building_impact\
     .impact_function import FloodPolygonBuildingFunction
+
+# Tsunami
 from safe.impact_functions.inundation.tsunami_population_evacuation_raster\
     .impact_function import TsunamiEvacuationFunction
 from safe.impact_functions.inundation.tsunami_raster_road\
     .impact_function import TsunamiRasterRoadsFunction
+from safe.impact_functions.inundation.tsunami_raster_landcover\
+    .impact_function import TsunamiRasterLandcoverFunction
+from safe.impact_functions.inundation.tsunami_raster_building\
+    .impact_function import TsunamiRasterBuildingFunction
 
 # Volcanic IFs
 from safe.impact_functions.volcanic.volcano_point_building.impact_function\
@@ -109,12 +122,17 @@ class TestImpactFunctionMetadata(unittest.TestCase):
             EarthquakeBuildingFunction(),
             ITBFatalityFunction(),
             PAGFatalityFunction(),
+            ITBBayesianFatalityFunction(),
+
             # Generic
             ClassifiedPolygonHazardBuildingFunction(),
+            ClassifiedPolygonHazardLandCoverFunction(),
             ClassifiedPolygonHazardPopulationFunction(),
+            ClassifiedPolygonHazardPolygonPeopleFunction(),
             ClassifiedRasterHazardBuildingFunction(),
             ClassifiedRasterHazardPopulationFunction(),
             ContinuousHazardPopulationFunction(),
+
             # Inundation
             FloodEvacuationVectorHazardFunction(),
             FloodPolygonRoadsFunction(),
@@ -122,14 +140,21 @@ class TestImpactFunctionMetadata(unittest.TestCase):
             FloodEvacuationRasterHazardFunction(),
             FloodRasterRoadsFunction(),
             FloodPolygonBuildingFunction(),
+
+            # Tsunami
             TsunamiEvacuationFunction(),
             TsunamiRasterRoadsFunction(),
+            TsunamiRasterLandcoverFunction(),
+            TsunamiRasterBuildingFunction(),
+
             # Volcanic
             VolcanoPointBuildingFunction(),
             VolcanoPointPopulationFunction(),
             VolcanoPolygonBuildingFunction(),
             VolcanoPolygonPopulationFunction()
         ]
+        self.assertEqual(len(impact_functions), len(EXPECTED_IF))
+
         for impact_function in impact_functions:
             valid = impact_function.metadata().is_valid()
             impact_function_name = impact_function.__class__.__name__

--- a/safe/impact_functions/test/test_registry.py
+++ b/safe/impact_functions/test/test_registry.py
@@ -48,6 +48,35 @@ from safe.definitions import (
     layer_mode_classified
 )
 
+# This list is used in another test file.
+EXPECTED_IF = [
+    'Polygon flood on buildings',
+    'Polygon flood on roads',
+    'Polygon flood on people',
+    'Raster flood on population',
+    'Raster flood on buildings',
+    'Raster flood on roads',
+    'Tsunami evacuation',
+    'Raster tsunami on buildings',
+    'Raster tsunami on roads',
+    'Raster tsunami on land cover',
+    'Classified raster hazard on buildings',
+    'Classified raster hazard on population',
+    'Continuous raster hazard on population',
+    'Classified polygon hazard on population',
+    'Classified polygon hazard on buildings',
+    'Classified polygon hazard on polygon people',
+    'Classified polygon hazard on land cover',
+    'Earthquake on buildings',
+    'Earthquake ITB fatality function',
+    'Earthquake PAGER fatality function',
+    'Earthquake ITB fatality function based on a Bayesian approach',
+    'Point volcano on buildings',
+    'Polygon volcano on buildings',
+    'Point volcano on population',
+    'Polygon volcano on population'
+]
+
 
 class TestRegistry(unittest.TestCase):
 
@@ -78,33 +107,7 @@ class TestRegistry(unittest.TestCase):
         """TestRegistry: Test list all register IFs."""
         registry = Registry()
         impact_functions = registry.list()
-        expected = [
-            'Polygon flood on buildings',
-            'Polygon flood on roads',
-            'Polygon flood on people',
-            'Raster flood on population',
-            'Raster flood on buildings',
-            'Raster flood on roads',
-            'Tsunami evacuation',
-            'Raster tsunami on buildings',
-            'Raster tsunami on roads',
-            'Raster tsunami on land cover',
-            'Classified raster hazard on buildings',
-            'Classified raster hazard on population',
-            'Continuous raster hazard on population',
-            'Classified polygon hazard on population',
-            'Classified polygon hazard on buildings',
-            'Classified polygon hazard on polygon people',
-            'Classified polygon hazard on land cover',
-            'Earthquake on buildings',
-            'Earthquake ITB fatality function',
-            'Earthquake PAGER fatality function',
-            'Earthquake ITB fatality function based on a Bayesian approach',
-            'Point volcano on buildings',
-            'Polygon volcano on buildings',
-            'Point volcano on population',
-            'Polygon volcano on population']
-        self.assertItemsEqual(expected, impact_functions)
+        self.assertItemsEqual(EXPECTED_IF, impact_functions)
 
     def test_get_impact_function_instance(self):
         """TestRegistry: Test we can get an impact function instance."""

--- a/safe/impact_functions/volcanic/volcano_point_building/impact_function.py
+++ b/safe/impact_functions/volcanic/volcano_point_building/impact_function.py
@@ -18,9 +18,7 @@ from safe.impact_functions.volcanic.volcano_point_building\
 from safe.storage.vector import Vector
 from safe.utilities.i18n import tr
 from safe.utilities.utilities import main_type
-from safe.common.utilities import (
-    get_thousand_separator,
-    get_non_conflicting_attribute_name)
+from safe.common.utilities import get_non_conflicting_attribute_name
 from safe.engine.interpolation import (
     assign_hazard_values_to_exposure_data)
 from safe.impact_reports.building_exposure_report_mixin import (
@@ -152,8 +150,7 @@ class VolcanoPointBuildingFunction(
         colours = colours[:len(category_names)]
         style_classes = []
 
-        i = 0
-        for category_name in category_names:
+        for i, category_name in enumerate(category_names):
             style_class = dict()
             style_class['label'] = tr('Radius %s km') % tr(category_name)
             style_class['transparency'] = 0
@@ -163,7 +160,6 @@ class VolcanoPointBuildingFunction(
             if i >= len(category_names):
                 i = len(category_names) - 1
             style_class['colour'] = colours[i]
-            i += 1
 
             style_classes.append(style_class)
 
@@ -173,22 +169,14 @@ class VolcanoPointBuildingFunction(
             style_classes=style_classes,
             style_type='categorizedSymbol')
 
-        # For printing map purpose
-        map_title = tr('Buildings affected by volcanic buffered point')
-        legend_title = tr('Building count')
-        legend_units = tr('(building)')
-        legend_notes = tr(
-            'Thousand separator is represented by %s' %
-            get_thousand_separator())
-
         impact_data = self.generate_data()
 
         extra_keywords = {
             'target_field': target_field,
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title')
         }
 
         impact_layer_keywords = self.generate_impact_keywords(extra_keywords)
@@ -198,7 +186,7 @@ class VolcanoPointBuildingFunction(
             data=features,
             projection=interpolated_layer.get_projection(),
             geometry=interpolated_layer.get_geometry(),
-            name=tr('Buildings affected by volcanic buffered point'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/volcanic/volcano_point_building/metadata_definitions.py
+++ b/safe/impact_functions/volcanic/volcano_point_building/metadata_definitions.py
@@ -10,7 +10,7 @@ Contact : ole.moller.nielsen@gmail.com
      (at your option) any later version.
 
 """
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 from safe.defaults import building_type_postprocessor
 from safe.impact_functions.impact_function_metadata import \
     ImpactFunctionMetadata
@@ -78,6 +78,13 @@ class VolcanoPointBuildingFunctionMetadata(ImpactFunctionMetadata):
                 'affected by each hazard zones.'),
             'limitations': [],
             'citations': [],
+            'map_title': tr('Buildings affected by volcanic buffered point'),
+            'legend_title': tr('Building count'),
+            'legend_units': tr('(building)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by %s' %
+                get_thousand_separator()),
+            'layer_name': tr('Buildings affected by volcanic buffered point'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_classified,

--- a/safe/impact_functions/volcanic/volcano_point_population/impact_function.py
+++ b/safe/impact_functions/volcanic/volcano_point_population/impact_function.py
@@ -26,8 +26,7 @@ from safe.common.utilities import (
     format_int,
     humanize_class,
     create_classes,
-    create_label,
-    get_thousand_separator)
+    create_label)
 from safe.gui.tools.minimum_needs.needs_profile import add_needs_parameters, \
     filter_needs_parameters, get_needs_provenance_value
 from safe.impact_reports.population_exposure_report_mixin import \
@@ -206,23 +205,15 @@ class VolcanoPointPopulationFunction(
             style_classes=style_classes,
             style_type='rasterStyle')
 
-        # For printing map purpose
-        map_title = tr('People affected by the buffered point volcano')
-        legend_title = tr('Population')
-        legend_units = tr('(people per cell)')
-        legend_notes = tr(
-            'Thousand separator is represented by  %s' %
-            get_thousand_separator())
-
         impact_data = self.generate_data()
 
         # Create vector layer and return
         extra_keywords = {
             'target_field': self.target_field,
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title'),
             'total_needs': self.total_needs
         }
 
@@ -232,7 +223,7 @@ class VolcanoPointPopulationFunction(
             data=covered_exposure_layer.get_data(),
             projection=covered_exposure_layer.get_projection(),
             geotransform=covered_exposure_layer.get_geotransform(),
-            name=tr('People affected by the buffered point volcano'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info)
 

--- a/safe/impact_functions/volcanic/volcano_point_population/metadata_definitions.py
+++ b/safe/impact_functions/volcanic/volcano_point_population/metadata_definitions.py
@@ -10,7 +10,7 @@ Contact : ole.moller.nielsen@gmail.com
      (at your option) any later version.
 
 """
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 from safe.defaults import (
     default_minimum_needs,
     default_gender_postprocessor,
@@ -76,6 +76,13 @@ class VolcanoPointPopulationFunctionMetadata(ImpactFunctionMetadata):
                 'be affected by each hazard zone.'),
             'limitations': [],
             'citations': [],
+            'map_title': tr('People affected by the buffered point volcano'),
+            'legend_title': tr('Population'),
+            'legend_units': tr('(people per cell)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by  %s' %
+                get_thousand_separator()),
+            'layer_name': tr('People affected by the buffered point volcano'),
             'overview': tr(
                 'To assess the impacts of volcano eruption on '
                 'population.'),

--- a/safe/impact_functions/volcanic/volcano_polygon_building/impact_function.py
+++ b/safe/impact_functions/volcanic/volcano_polygon_building/impact_function.py
@@ -18,7 +18,6 @@ from safe.utilities.i18n import tr
 from safe.impact_functions.volcanic.volcano_polygon_building\
     .metadata_definitions import VolcanoPolygonBuildingFunctionMetadata
 from safe.common.exceptions import InaSAFEError
-from safe.common.utilities import get_thousand_separator
 from safe.engine.interpolation import (
     assign_hazard_values_to_exposure_data)
 from safe.impact_reports.building_exposure_report_mixin import (
@@ -171,8 +170,7 @@ class VolcanoPolygonBuildingFunction(
 
         style_classes = []
 
-        i = 0
-        for category_name in self.affected_buildings.keys():
+        for i, category_name in enumerate(self.affected_buildings.keys()):
             style_class = dict()
             style_class['label'] = tr(category_name)
             style_class['transparency'] = 0
@@ -182,7 +180,6 @@ class VolcanoPolygonBuildingFunction(
             if i >= len(self.affected_buildings.keys()):
                 i = len(self.affected_buildings.keys()) - 1
             style_class['colour'] = colours[i]
-            i += 1
 
             style_classes.append(style_class)
 
@@ -191,21 +188,14 @@ class VolcanoPolygonBuildingFunction(
                           style_classes=style_classes,
                           style_type='categorizedSymbol')
 
-        # For printing map purpose
-        map_title = tr('Buildings affected by volcanic hazard zone')
-        legend_title = tr('Building count')
-        legend_units = tr('(building)')
-        legend_notes = tr('Thousand separator is represented by %s' %
-                          get_thousand_separator())
-
         impact_data = self.generate_data()
 
         extra_keywords = {
             'target_field': self.target_field,
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title')
         }
 
         impact_layer_keywords = self.generate_impact_keywords(extra_keywords)
@@ -215,7 +205,7 @@ class VolcanoPolygonBuildingFunction(
             data=features,
             projection=interpolated_layer.get_projection(),
             geometry=interpolated_layer.get_geometry(),
-            name=tr('Buildings affected by volcanic hazard zone'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info
         )

--- a/safe/impact_functions/volcanic/volcano_polygon_building/metadata_definitions.py
+++ b/safe/impact_functions/volcanic/volcano_polygon_building/metadata_definitions.py
@@ -10,7 +10,7 @@ Contact : ole.moller.nielsen@gmail.com
      (at your option) any later version.
 
 """
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 from safe.defaults import building_type_postprocessor
 from safe.impact_functions.impact_function_metadata import \
     ImpactFunctionMetadata
@@ -81,6 +81,13 @@ class VolcanoPolygonBuildingFunctionMetadata(ImpactFunctionMetadata):
                 'within each hazard zone.'),
             'limitations': [],
             'citations': [],
+            'map_title': tr('Buildings affected by volcanic hazard zone'),
+            'legend_title': tr('Building count'),
+            'legend_units': tr('(building)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by %s' %
+                get_thousand_separator()),
+            'layer_name': tr('Buildings affected by volcanic hazard zone'),
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_classified,

--- a/safe/impact_functions/volcanic/volcano_polygon_population/impact_function.py
+++ b/safe/impact_functions/volcanic/volcano_polygon_population/impact_function.py
@@ -243,22 +243,14 @@ class VolcanoPolygonPopulationFunction(
             style_classes=style_classes,
             style_type='rasterStyle')
 
-        # For printing map purpose
-        map_title = tr('People affected by Volcano Hazard Zones')
-        legend_title = tr('Population')
-        legend_units = tr('(people per cell)')
-        legend_notes = tr(
-            'Thousand separator is represented by  %s' %
-            get_thousand_separator())
-
         impact_data = self.generate_data()
 
         extra_keywords = {
             'target_field': self.target_field,
-            'map_title': map_title,
-            'legend_notes': legend_notes,
-            'legend_units': legend_units,
-            'legend_title': legend_title,
+            'map_title': self.metadata().key('map_title'),
+            'legend_notes': self.metadata().key('legend_notes'),
+            'legend_units': self.metadata().key('legend_units'),
+            'legend_title': self.metadata().key('legend_title'),
             'total_needs': self.total_needs
         }
 
@@ -269,7 +261,7 @@ class VolcanoPolygonPopulationFunction(
             data=covered_exposure_layer.get_data(),
             projection=covered_exposure_layer.get_projection(),
             geotransform=covered_exposure_layer.get_geotransform(),
-            name=tr('People affected by volcano hazard zones'),
+            name=self.metadata().key('layer_name'),
             keywords=impact_layer_keywords,
             style_info=style_info
         )

--- a/safe/impact_functions/volcanic/volcano_polygon_population/metadata_definitions.py
+++ b/safe/impact_functions/volcanic/volcano_polygon_population/metadata_definitions.py
@@ -10,7 +10,7 @@ Contact : ole.moller.nielsen@gmail.com
      (at your option) any later version.
 
 """
-from safe.common.utilities import OrderedDict
+from safe.common.utilities import OrderedDict, get_thousand_separator
 from safe.defaults import (
     default_minimum_needs,
     default_gender_postprocessor,
@@ -84,6 +84,13 @@ class VolcanoPolygonPopulationFunctionMetadata(ImpactFunctionMetadata):
                 'each hazard zone.'),
             'limitations': [],
             'citations': [],
+            'map_title': tr('People affected by Volcano Hazard Zones'),
+            'legend_title': tr('Population'),
+            'legend_units': tr('(people per cell)'),
+            'legend_notes': tr(
+                'Thousand separator is represented by  %s' %
+                get_thousand_separator()),
+            'layer_name': tr('People affected by volcano hazard zones'),
             'overview': tr(
                 'To assess the impact of a volcano eruption on people.'),
             'detailed_description': '',


### PR DESCRIPTION
This PR removes 'by each hazard zone' in the legend. See #https://github.com/inasafe/inasafe/issues/2765
And I made a refactoring to put these parameters in the metadata file instead of the IF itself.

Soon, we will be able to remove the Vector layer from the return statement.

Can you review it @ismailsunni or @lucernae ? Thanks