### PR TITLE
Pass when the metadata is outdated on loading to combo box.

### DIFF
--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -95,7 +95,8 @@ from safe.common.exceptions import (
     UnsupportedProviderError,
     InvalidAggregationKeywords,
     InsufficientMemoryWarning,
-    MissingImpactReport
+    MissingImpactReport,
+    MetadataReadError
 )
 from safe.report.impact_report import ImpactReport
 from safe.gui.tools.about_dialog import AboutDialog
@@ -916,6 +917,8 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
                 continue
             except KeywordNotFoundError:
                 # There is a missing mandatory keyword, ignore it
+                continue
+            except MetadataReadError:
                 continue
             except:  # pylint: disable=W0702
                 # automatically adding file name to title in keywords


### PR DESCRIPTION
Fix for #2945 

The issue comes up because whenever there is a change in the list layer, InaSAFE tries to update the combobox in the dock for the hazard, exposure, and aggregation layer.

So, I just pass if the metadata is out of update (just like layer with no keyword).