### PR TITLE
Layer visibility

### DIFF
--- a/safe/gui/tools/wizard/wizard_dialog.py
+++ b/safe/gui/tools/wizard/wizard_dialog.py
@@ -698,6 +698,10 @@ class WizardDialog(QDialog, FORM_CLASS):
                     self.layer.name()):
                 QgsMapLayerRegistry.instance().addMapLayers([self.layer])
 
+                # Make the layer visible. Might be hidden by default. See #2925
+                legend = self.iface.legendInterface()
+                legend.setLayerVisible(self.layer, True)
+
         # After the extent selection, save the extent and disconnect signals
         if current_step == self.step_fc_extent:
             self.step_fc_extent.write_extent()

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -58,6 +58,7 @@ from safe.utilities.resources import (
     resources_path,
     get_ui_class)
 from safe.utilities.qgis_utilities import (
+    add_above_layer,
     display_critical_message_bar,
     display_warning_message_bar,
     display_information_message_bar)
@@ -1270,81 +1271,6 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
 
         return impact_function
 
-    def add_above_layer(self, new_layer, *existing_layers):
-        """Add a layer (e.g. impact layer) above another layer in the legend.
-
-        .. versionadded:: 3.2
-
-        .. note:: This method works in QGIS 2.4 and better only. In
-            earlier versions it will just add the layer to the top of the
-            layer stack.
-
-        .. seealso:: issue #2322
-
-        :param existing_layers: Layers which the new layer
-            should be added above.
-        :type existing_layers: QgsMapLayer
-
-        :param new_layer: The new layer being added. An assumption is made
-            that the newly added layer is not already loaded in the legend
-            or the map registry.
-        :type new_layer: QgsMapLayer
-
-        """
-        # Some existing layers might be None, ie the aggregation layer #2948.
-        existing_layers = [l for l in existing_layers if l is not None]
-        if not len(existing_layers) or new_layer is None:
-            return
-
-        registry = QgsMapLayerRegistry.instance()
-
-        if QGis.QGIS_VERSION_INT < 20400:
-            # True flag adds layer directly to legend
-            registry.addMapLayer(existing_layer, True)
-            return
-
-        # False flag prevents layer being added to legend
-        registry.addMapLayer(new_layer, False)
-        minimum_index = len(QgsProject.instance().layerTreeRoot().children())
-        for layer in existing_layers:
-            index = self.layer_legend_index(layer)
-            if index < minimum_index:
-                minimum_index = index
-        root = QgsProject.instance().layerTreeRoot()
-        root.insertLayer(minimum_index, new_layer)
-
-    @staticmethod
-    def layer_legend_index(layer):
-        """Find out where in the legend layer stack a layer is.
-
-        .. note:: This function requires QGIS 2.4 or greater to work. In older
-            versions it will simply return 0.
-
-        .. version_added:: 3.2
-
-        :param layer: A map layer currently loaded in the legend.
-        :type layer: QgsMapLayer
-
-        :returns: An integer representing the z-order of the given layer in
-            the legend tree. If the layer cannot be found, or the QGIS version
-            is < 2.4 it will return 0.
-        :rtype: int
-        """
-        if QGis.QGIS_VERSION_INT < 20400:
-            return 0
-
-        root = QgsProject.instance().layerTreeRoot()
-        layer_id = layer.id()
-        current_index = 0
-        nodes = root.children()
-        for node in nodes:
-            # check if the node is a layer as opposed to a group
-            if isinstance(node, QgsLayerTreeLayer):
-                if layer_id == node.layerId():
-                    return current_index
-            current_index += 1
-        return current_index
-
     def completed(self):
         """Slot activated when the process is done.
         """
@@ -1356,6 +1282,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             LOGGER.debug(datetime.now())
             LOGGER.debug(self.impact_function is None)
             report = self.show_results()
+            self.restore_state()
         except Exception, e:  # pylint: disable=W0703
 
             # FIXME (Ole): This branch is not covered by the tests
@@ -1376,12 +1303,19 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
 
         .. versionchanged:: 3.2 - removed parameters.
 
+        .. note:: If you update this function, please report your change to
+            safe.utilities.analysis_handler.show_results too.
+
         :returns: Provides a report for writing to the dock.
         :rtype: str
         """
+        qgis_exposure = self.get_exposure_layer()
+        qgis_hazard = self.get_hazard_layer()
+        qgis_aggregation = self.get_aggregation_layer()
+
         safe_impact_layer = self.impact_function.impact
         qgis_impact_layer = read_impact_layer(safe_impact_layer)
-        # self.layer_changed(qgis_impact_layer)
+
         keywords = self.keyword_io.read_keywords(qgis_impact_layer)
         json_path = os.path.splitext(qgis_impact_layer.source())[0] + '.json'
 
@@ -1459,21 +1393,21 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
 
         # Insert the aggregation output above the input aggregation layer
         if self.show_intermediate_layers:
-            self.add_above_layer(
+            add_above_layer(
                 self.impact_function.aggregator.layer,
-                self.get_aggregation_layer())
+                qgis_aggregation)
             legend.setLayerVisible(self.impact_function.aggregator.layer, True)
 
         if self.hide_exposure_flag:
             # Insert the impact always above the hazard
-            self.add_above_layer(qgis_impact_layer, self.get_hazard_layer())
+            add_above_layer(qgis_impact_layer, qgis_hazard)
         else:
             # Insert the impact above the hazard and the exposure if
             # we don't hide the exposure. See #2899
-            self.add_above_layer(
+            add_above_layer(
                 qgis_impact_layer,
-                self.get_exposure_layer(),
-                self.get_hazard_layer())
+                qgis_exposure,
+                qgis_hazard)
 
         active_function = self.active_impact_function
         self.active_impact_function = active_function
@@ -1482,7 +1416,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
 
         # In QGIS 2.14.2 and GDAL 1.11.3, if the exposure is in 3857,
         # the impact layer is in 54004, we need to change it. See issue #2790.
-        if self.get_exposure_layer().crs().authid() == 'EPSG:3857':
+        if qgis_exposure.crs().authid() == 'EPSG:3857':
             if qgis_impact_layer.crs().authid() != 'EPSG:3857':
                 epsg_3857 = QgsCoordinateReferenceSystem(3857)
                 qgis_impact_layer.setCrs(epsg_3857)
@@ -1493,13 +1427,10 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         if self.zoom_to_impact_flag:
             self.iface.zoomToActiveLayer()
         if self.hide_exposure_flag:
-            exposure_layer = self.get_exposure_layer()
-            legend.setLayerVisible(exposure_layer, False)
+            legend.setLayerVisible(qgis_exposure, False)
 
         # Make the layer visible. Might be hidden by default. See #2925
         legend.setLayerVisible(qgis_impact_layer, True)
-
-        self.restore_state()
 
         # Return text to display in report panel
         return report

--- a/safe/gui/widgets/test/test_dock.py
+++ b/safe/gui/widgets/test/test_dock.py
@@ -40,6 +40,7 @@ from safe.test.utilities import get_qgis_app, get_dock
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 from safe.impact_functions.loader import register_impact_functions
 from safe.common.utilities import format_int, unique_filename
+from safe.utilities.qgis_utilities import add_above_layer, layer_legend_index
 from safe.test.utilities import (
     standard_data_path,
     load_standard_layers,
@@ -342,7 +343,7 @@ class TestDock(TestCase):
             function='Need evacuation',
             function_id='FloodEvacuationRasterHazardFunction')
         layer = self.dock.get_exposure_layer()
-        index = self.dock.layer_legend_index(layer)
+        index = layer_legend_index(layer)
         self.assertEqual(index, 15)
 
     def test_add_above_layer(self):
@@ -360,7 +361,7 @@ class TestDock(TestCase):
         layer_path = join(TESTDATA, 'polygon_0.shp')
         new_layer = QgsVectorLayer(layer_path, 'foo', 'ogr')
         exposure_layer = self.dock.get_exposure_layer()
-        self.dock.add_above_layer(new_layer, exposure_layer)
+        add_above_layer(new_layer, exposure_layer)
         root = QgsProject.instance().layerTreeRoot()
         id_list = root.findLayerIds()
         self.assertIn(new_layer.id(), id_list)

--- a/safe/utilities/qgis_utilities.py
+++ b/safe/utilities/qgis_utilities.py
@@ -10,11 +10,87 @@ __copyright__ = 'Copyright 2012, Australia Indonesia Facility for '
 __copyright__ += 'Disaster Reduction'
 
 from qgis.gui import QgsMessageBar
-from qgis.core import QGis
+from qgis.core import QGis, QgsProject, QgsMapLayerRegistry, QgsLayerTreeLayer
 from qgis.utils import iface
 from PyQt4.QtGui import QMessageBox, QPushButton
 
 from safe.utilities.i18n import tr
+
+
+def add_above_layer(new_layer, *existing_layers):
+    """Add a layer (e.g. impact layer) above another layer in the legend.
+
+    .. versionadded:: 3.2
+
+    .. note:: This method works in QGIS 2.4 and better only. In
+        earlier versions it will just add the layer to the top of the
+        layer stack.
+
+    .. seealso:: issue #2322
+
+    :param existing_layers: Layers which the new layer
+        should be added above.
+    :type existing_layers: QgsMapLayer
+
+    :param new_layer: The new layer being added. An assumption is made
+        that the newly added layer is not already loaded in the legend
+        or the map registry.
+    :type new_layer: QgsMapLayer
+
+    """
+    # Some existing layers might be None, ie the aggregation layer #2948.
+    existing_layers = [l for l in existing_layers if l is not None]
+    if not len(existing_layers) or new_layer is None:
+        return
+
+    registry = QgsMapLayerRegistry.instance()
+
+    if QGis.QGIS_VERSION_INT < 20400:
+        # True flag adds layer directly to legend
+        registry.addMapLayer(existing_layers, True)
+        return
+
+    # False flag prevents layer being added to legend
+    registry.addMapLayer(new_layer, False)
+    minimum_index = len(QgsProject.instance().layerTreeRoot().children())
+    for layer in existing_layers:
+        index = layer_legend_index(layer)
+        if index < minimum_index:
+            minimum_index = index
+    root = QgsProject.instance().layerTreeRoot()
+    root.insertLayer(minimum_index, new_layer)
+
+
+def layer_legend_index(layer):
+    """Find out where in the legend layer stack a layer is.
+
+    .. note:: This function requires QGIS 2.4 or greater to work. In older
+        versions it will simply return 0.
+
+    .. version_added:: 3.2
+
+    :param layer: A map layer currently loaded in the legend.
+    :type layer: QgsMapLayer
+
+    :returns: An integer representing the z-order of the given layer in
+        the legend tree. If the layer cannot be found, or the QGIS version
+        is < 2.4 it will return 0.
+    :rtype: int
+    """
+    if QGis.QGIS_VERSION_INT < 20400:
+        return 0
+
+    root = QgsProject.instance().layerTreeRoot()
+    layer_id = layer.id()
+    current_index = 0
+    nodes = root.children()
+    for node in nodes:
+        # check if the node is a layer as opposed to a group
+        if isinstance(node, QgsLayerTreeLayer):
+            if layer_id == node.layerId():
+                return current_index
+        current_index += 1
+    return current_index
 
 
 def display_information_message_box(


### PR DESCRIPTION
* Make the layer added by the IFCW visible by default when we add a new hazard/exposure layer.
* When the analysis is finished, the dock is checking where to put the impact layer (above the hazard/exposure), enable the impact layer by default ,.... but these statements were not executed by the wizard. For now, I tried quickly to refactor common functions and I copy/paste some statements from the dock which were missing. I'm going to write a ticket to fix that later.

@NyakudyaA Can you try this PR ? Thanks to notice that the wizard does not have the same behaviour.
It's related to #2925 