### PR TITLE
fix #2804 - make checking the analysis environment more efficient by not reading the full raster each time you pan or zoom

### DIFF
--- a/safe/storage/layer.py
+++ b/safe/storage/layer.py
@@ -47,7 +47,7 @@ class Layer(object):
         # Defaults
         self.sublayer = sublayer
         self.filename = None
-        self.data = None
+        self._data = None  # class private
 
     def __ne__(self, other):
         """Override '!=' to allow comparison with other projection objecs

--- a/safe/storage/raster.py
+++ b/safe/storage/raster.py
@@ -94,6 +94,7 @@ class Raster(Layer):
                        projection=projection,
                        keywords=keywords,
                        style_info=style_info)
+        self.band = None
 
         # Input checks
         if data is None:
@@ -122,7 +123,6 @@ class Raster(Layer):
 
             self.rows = data.shape[0]
             self.columns = data.shape[1]
-
             self.number_of_bands = 1
 
     def __str__(self):
@@ -180,10 +180,13 @@ class Raster(Layer):
         The setter does a lazy read so that the data matrix is only
         initialised if is is actually wanted.
 
-        :returns: A matrix containing the layer data.
+        :returns: A matrix containing the layer data or None if the layer
+            has no band.
         :rtype: numpy.array
         """
         if self._data is None:
+            if self.band is None:
+                return None
             # Read from raster file
             data = self.band.ReadAsArray()
 
@@ -230,9 +233,10 @@ class Raster(Layer):
             if not os.path.exists(filename):
                 msg = 'Could not find file %s' % filename
             else:
-                msg = ('File %s exists, but could not be read. '
-                       'Please check if the file can be opened with '
-                       'e.g. qgis or gdalinfo' % filename)
+                msg = (
+                    'File %s exists, but could not be read. '
+                    'Please check if the file can be opened with '
+                    'e.g. qgis or gdalinfo' % filename)
             raise ReadLayerError(msg)
 
         # Record raster metadata from file

--- a/safe/storage/test/test_io.py
+++ b/safe/storage/test/test_io.py
@@ -1748,10 +1748,9 @@ class TestIO(unittest.TestCase):
 
         assert same_API(V, R, exclude=exclude)
 
-        for filename in [os.path.join(TESTDATA,
-                                      'test_buildings.shp'),
-                         os.path.join(HAZDATA,
-                                      'Lembang_Earthquake_Scenario.asc')]:
+        for filename in [
+            os.path.join(TESTDATA, 'test_buildings.shp'),
+            os.path.join(HAZDATA, 'Lembang_Earthquake_Scenario.asc')]:
 
             L = read_layer(filename)
 


### PR DESCRIPTION
fix #2804 - make checking the analysis environment more efficient by not reading the full raster each time you pan or zoom 

Ok I have made a fix (for rasters anyway):

Before optimisation: 15s to do a simple pan

![qgis](https://cloud.githubusercontent.com/assets/178003/17331649/26a10986-58cc-11e6-91fd-cfa4a56c13f6.gif)


After optimisation: 4s to do a simple pan

![qgis](https://cloud.githubusercontent.com/assets/178003/17331523/96acdab2-58cb-11e6-88ff-a452d7b5bd42.gif)