### PR TITLE
Fix #2847 no aggregation table

### DIFF
--- a/safe/definitions.py
+++ b/safe/definitions.py
@@ -552,7 +552,8 @@ exposure_land_cover = {
         'The <b>land cover</b> exposure data describes features on '
         'the surface of the earth that might be exposed to a particular '
         ' hazard. This might include crops, forest and urban areas. '),
-    'notes': [  # these are additional generic notes for landcover - IF has more
+    'notes': [
+        # these are additional generic notes for landcover - IF has more
         tr('Areas reported for land cover have not been rounded.'),
     ],
     'actions': [  # these are additional generic actions - IF has more

--- a/safe/impact_functions/inundation/flood_polygon_roads/impact_function.py
+++ b/safe/impact_functions/inundation/flood_polygon_roads/impact_function.py
@@ -89,7 +89,6 @@ class FloodPolygonRoadsFunction(
             'road_class_field')
         exposure_value_mapping = self.exposure.keyword('value_mapping')
 
-
         hazard_provider = self.hazard.layer.dataProvider()
         affected_field_index = hazard_provider.fieldNameIndex(
             self.hazard_class_attribute)

--- a/safe/impact_statistics/postprocessor_manager.py
+++ b/safe/impact_statistics/postprocessor_manager.py
@@ -639,13 +639,28 @@ class PostprocessorManager(QtCore.QObject):
                     parameters['elderly_ratio'] = elderly_ratio
 
                 if key == 'BuildingType' or key == 'RoadType':
-                    try:
+                    if key == 'BuildingType':
                         key_attribute = self.keyword_io.read_keywords(
-                            self.aggregator.exposure_layer, 'key_attribute')
-                    except KeywordNotFoundError:
-                        # use 'type' as default
-                        key_attribute = 'type'
+                            self.aggregator.exposure_layer,
+                            'structure_class_field'
+                        )
+                    elif key == 'RoadType':
+                        key_attribute = self.keyword_io.read_keywords(
+                            self.aggregator.exposure_layer,
+                            'road_class_field'
+                        )
+                    else:
+                        try:
+                            key_attribute = self.keyword_io.read_keywords(
+                                self.aggregator.exposure_layer,
+                                'key_attribute'
+                            )
+                        except KeywordNotFoundError:
+                            # use 'type' as default
+                            key_attribute = 'type'
+
                     parameters['key_attribute'] = key_attribute
+                    LOGGER.debug('key_attribute: %s', key_attribute)
 
                     value_map = self.keyword_io.read_keywords(
                         self.aggregator.exposure_layer, 'value_mapping')

--- a/safe/postprocessors/abstract_building_road_type_postprocessor.py
+++ b/safe/postprocessors/abstract_building_road_type_postprocessor.py
@@ -98,7 +98,7 @@ class AbstractBuildingRoadTypePostprocessor(AbstractPostprocessor):
         self.type_fields = []
         try:
             for key in self.impact_attrs[0].iterkeys():
-                if key.lower() in self.valid_type_fields:
+                if key in self.valid_type_fields:
                     self.type_fields.append(key)
         except IndexError:
             pass

--- a/safe/postprocessors/test/test_building_type_postprocessor.py
+++ b/safe/postprocessors/test/test_building_type_postprocessor.py
@@ -36,10 +36,10 @@ class TestBuildingTypePostprocessor(unittest.TestCase):
             'target_field': 'safe_ag__4',
             'value_mapping': {u'government': [u'Government']},
             'impact_attrs': [
-                {'TYPE': 'Government', 'safe_ag__4': 1},
-                {'TYPE': 'Government', 'safe_ag__4': 0},
-                {'TYPE': 'Government', 'safe_ag__4': 1},
-                {'TYPE': 'Government', 'safe_ag__4': 0},
+                {'type': 'Government', 'safe_ag__4': 1},
+                {'type': 'Government', 'safe_ag__4': 0},
+                {'type': 'Government', 'safe_ag__4': 1},
+                {'type': 'Government', 'safe_ag__4': 0},
             ]}
         POSTPROCESSOR.setup(params)
         POSTPROCESSOR.process()
@@ -62,21 +62,15 @@ class TestBuildingTypePostprocessor(unittest.TestCase):
             'target_field': 'safe_ag__4',
             'value_mapping': {u'government': [u'Government']},
             'impact_attrs': [
-                {'TYPE': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'TYPE': 'Government', 'safe_ag__4': 'Not Affected'},
-                {'TYPE': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'TYPE': 'Government', 'safe_ag__4': 'Not Affected'},
+                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
+                {'type': 'Government', 'safe_ag__4': 'Not Affected'},
+                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
+                {'type': 'Government', 'safe_ag__4': 'Not Affected'},
             ]}
         POSTPROCESSOR.setup(params)
         POSTPROCESSOR.process()
         results = POSTPROCESSOR.results()
-        message = (
-            'Expecting exactly 2 Government buildings to be affected. ',
-            'Using string values in affected fields.')
-        self.assertEqual(
-            results[u'Government']['value'],
-            '2',
-            message)
+        self.assertEqual(results[u'Government']['value'], '2')
 
     def test_total_affected_calculated_correctly(self):
         """Test to see that the totalling of buildings is done correctly."""
@@ -91,11 +85,11 @@ class TestBuildingTypePostprocessor(unittest.TestCase):
                 u'economy': [u'Economy'],
             },
             'impact_attrs': [
-                {'TYPE': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'TYPE': 'Museum', 'safe_ag__4': 'Zone 2'},
-                {'TYPE': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'TYPE': 'Government', 'safe_ag__4': 'Not Affected'},
-                {'TYPE': 'School', 'safe_ag__4': 'Zone 3'},
+                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
+                {'type': 'Museum', 'safe_ag__4': 'Zone 2'},
+                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
+                {'type': 'Government', 'safe_ag__4': 'Not Affected'},
+                {'type': 'School', 'safe_ag__4': 'Zone 3'},
             ]}
         POSTPROCESSOR.setup(params)
         POSTPROCESSOR.process()
@@ -115,11 +109,11 @@ class TestBuildingTypePostprocessor(unittest.TestCase):
                 u'economy': [u'Economy'],
             },
             'impact_attrs': [
-                {'TYPE': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'TYPE': 'Museum', 'safe_ag__4': 'Zone 2'},
-                {'TYPE': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'TYPE': 'Government', 'safe_ag__4': 'Not Affected'},
-                {'TYPE': 'School', 'safe_ag__4': 'Zone 3'},
+                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
+                {'type': 'Museum', 'safe_ag__4': 'Zone 2'},
+                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
+                {'type': 'Government', 'safe_ag__4': 'Not Affected'},
+                {'type': 'School', 'safe_ag__4': 'Zone 3'},
             ]}
         POSTPROCESSOR.setup(params)
         POSTPROCESSOR.process()

--- a/safe/postprocessors/test/test_building_type_postprocessor.py
+++ b/safe/postprocessors/test/test_building_type_postprocessor.py
@@ -4,6 +4,11 @@
 Test building type postprocessor
 """
 
+import unittest
+
+from safe.postprocessors.building_type_postprocessor import (
+    BuildingTypePostprocessor)
+
 __author__ = 'Christian Christelis <christian@kartoza.com>'
 __revision__ = '$Format:%H$'
 __date__ = '21/07/2015'
@@ -12,114 +17,98 @@ __copyright__ = 'Copyright 2012, Australia Indonesia Facility for '
 __copyright__ += 'Disaster Reduction'
 
 
-import unittest
-
-from safe.postprocessors.building_type_postprocessor import (
-    BuildingTypePostprocessor)
-
-POSTPROCESSOR = BuildingTypePostprocessor()
-
-
 class TestBuildingTypePostprocessor(unittest.TestCase):
+    postprocessor = BuildingTypePostprocessor()
 
     def tearDown(self):
         """Run after each test."""
-        POSTPROCESSOR.clear()
+        self.postprocessor.clear()
 
     def test_process_integer_values(self):
-        """Test for checking if the ratio is wrong (total is more than one)."""
-        # ratios_total < 1 should pass
+        """Test for checking when the value is integer."""
         params = {
             'impact_total': 0,
             'key_attribute': 'type',
-            u'Building type': True,
-            'target_field': 'safe_ag__4',
-            'value_mapping': {u'government': [u'Government']},
+            'Building type': True,
+            'target_field': 'affected',
+            'value_mapping': {'government': ['Government']},
             'impact_attrs': [
-                {'type': 'Government', 'safe_ag__4': 1},
-                {'type': 'Government', 'safe_ag__4': 0},
-                {'type': 'Government', 'safe_ag__4': 1},
-                {'type': 'Government', 'safe_ag__4': 0},
+                {'type': 'Government', 'affected': 1},
+                {'type': 'Government', 'affected': 0},
+                {'type': 'Government', 'affected': 1},
+                {'type': 'Government', 'affected': 0},
             ]}
-        POSTPROCESSOR.setup(params)
-        POSTPROCESSOR.process()
-        results = POSTPROCESSOR.results()
-        message = (
-            'Expecting exactly 2 Government buildings to be affected. ',
-            'Using integer values in affected fields.')
-        self.assertEqual(
-            results[u'Government']['value'],
-            '2',
-            message)
+        self.postprocessor.setup(params)
+        self.postprocessor.process()
+        results = self.postprocessor.results()
+        self.assertEqual(results['Government']['value'], '2')
 
     def test_process_string_values(self):
-        """Test for checking if the ratio is wrong (total is more than one)."""
-        # ratios_total < 1 should pass
+        """Test for checking when the value is string."""
         params = {
             'impact_total': 0,
             'key_attribute': 'type',
-            u'Building type': True,
-            'target_field': 'safe_ag__4',
-            'value_mapping': {u'government': [u'Government']},
+            'Building type': True,
+            'target_field': 'affected',
+            'value_mapping': {'government': ['Government']},
             'impact_attrs': [
-                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'type': 'Government', 'safe_ag__4': 'Not Affected'},
-                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'type': 'Government', 'safe_ag__4': 'Not Affected'},
+                {'type': 'Government', 'affected': 'Zone 1'},
+                {'type': 'Government', 'affected': 'Not Affected'},
+                {'type': 'Government', 'affected': 'Zone 1'},
+                {'type': 'Government', 'affected': 'Not Affected'},
             ]}
-        POSTPROCESSOR.setup(params)
-        POSTPROCESSOR.process()
-        results = POSTPROCESSOR.results()
-        self.assertEqual(results[u'Government']['value'], '2')
+        self.postprocessor.setup(params)
+        self.postprocessor.process()
+        results = self.postprocessor.results()
+        self.assertEqual(results['Government']['value'], '2')
 
     def test_total_affected_calculated_correctly(self):
-        """Test to see that the totalling of buildings is done correctly."""
-        # ratios_total < 1 should pass
+        """Test for checking the total affected and value mapping"""
         params = {
             'impact_total': 0,
             'key_attribute': 'type',
-            u'Building type': True,
-            'target_field': 'safe_ag__4',
+            'Building type': True,
+            'target_field': 'affected',
             'value_mapping': {
-                u'government': [u'Government'],
-                u'economy': [u'Economy'],
+                'government': ['Government'],
+                'economy': ['Economy'],
             },
             'impact_attrs': [
-                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'type': 'Museum', 'safe_ag__4': 'Zone 2'},
-                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'type': 'Government', 'safe_ag__4': 'Not Affected'},
-                {'type': 'School', 'safe_ag__4': 'Zone 3'},
+                {'type': 'Government', 'affected': 'Zone 1'},
+                {'type': 'Museum', 'affected': 'Zone 2'},
+                {'type': 'Government', 'affected': 'Zone 1'},
+                {'type': 'Government', 'affected': 'Not Affected'},
+                {'type': 'School', 'affected': 'Zone 3'},
             ]}
-        POSTPROCESSOR.setup(params)
-        POSTPROCESSOR.process()
-        results = POSTPROCESSOR.results()
-        self.assertEqual(results[u'Government']['value'], '2')
-        self.assertEqual(results[u'Other']['value'], '2')
+        self.postprocessor.setup(params)
+        self.postprocessor.process()
+        results = self.postprocessor.results()
+        self.assertEqual(results['Government']['value'], '2')
+        self.assertEqual(results['Other']['value'], '2')
 
-        POSTPROCESSOR.clear()
+        self.postprocessor.clear()
         # Same as above, but we add the school in the value mapping.
         params = {
             'impact_total': 0,
             'key_attribute': 'type',
-            u'Building type': True,
-            'target_field': 'safe_ag__4',
+            'Building type': True,
+            'target_field': 'affected',
             'value_mapping': {
-                u'government': [u'Government', u'School'],
-                u'economy': [u'Economy'],
+                'government': ['Government', 'School'],
+                'economy': ['Economy'],
             },
             'impact_attrs': [
-                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'type': 'Museum', 'safe_ag__4': 'Zone 2'},
-                {'type': 'Government', 'safe_ag__4': 'Zone 1'},
-                {'type': 'Government', 'safe_ag__4': 'Not Affected'},
-                {'type': 'School', 'safe_ag__4': 'Zone 3'},
+                {'type': 'Government', 'affected': 'Zone 1'},
+                {'type': 'Museum', 'affected': 'Zone 2'},
+                {'type': 'Government', 'affected': 'Zone 1'},
+                {'type': 'Government', 'affected': 'Not Affected'},
+                {'type': 'School', 'affected': 'Zone 3'},
             ]}
-        POSTPROCESSOR.setup(params)
-        POSTPROCESSOR.process()
-        results = POSTPROCESSOR.results()
-        self.assertEqual(results[u'Government']['value'], '3')
-        self.assertEqual(results[u'Other']['value'], '1')
+        self.postprocessor.setup(params)
+        self.postprocessor.process()
+        results = self.postprocessor.results()
+        self.assertEqual(results['Government']['value'], '3')
+        self.assertEqual(results['Other']['value'], '1')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Problems:
- We use new keyword for aggregation to mark which field in exposure layer that should be aggregate. Meanwhile, post processor expects another keyword
- The checker is not really robust. Lowercasing one hand but not the other hand.

Fixes:
- Better setup for post processor keyword for building and road.
- Better checker.