### PR TITLE
tropical cyclone support and multi unit hazard classifications

### DIFF
--- a/resources/img/wizard/keyword-subcategory-cyclone.svg
+++ b/resources/img/wizard/keyword-subcategory-cyclone.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="256"
+   height="256"
+   id="svg5628">
+  <defs
+     id="defs5630" />
+  <metadata
+     id="metadata5633">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-796.36218)"
+     id="layer1">
+    <g
+       transform="matrix(0.60393411,0,0,-0.60393411,-26.607132,1059.6434)"
+       id="g6223">
+      <path
+         d="m 260,329 v 2 q 130,0 175,-103 13,-30 13,-47 0,3 -1.5,7.5 -1.5,4.5 -7.5,17.5 -6,13 -16,24.5 -10,11.5 -30,24 -20,12.5 -45,20.5 13,-22 13,-51 v -6 Q 361,169 345,132 329,95 308.5,77 288,59 263.5,48 239,37 227,34.5 215,32 211,32 q 3,0 7.5,1.5 4.5,1.5 18,7.5 13.5,6 25,16 11.5,10 24,30 12.5,20 19.5,45 -22,-13 -49,-13 h -6 q -49,0 -86.5,16.5 -37.5,16.5 -55,36 Q 91,191 79.5,216.5 68,242 66,252.5 64,263 64,269 q 0,-3 1,-8 1,-5 7,-18 6,-13 15.5,-24.5 9.5,-11.5 29,-24.5 19.5,-13 45.5,-21 -13,22 -13,51 v 6 q 0,129 103,173 26,11 47,13 -3,0 -8,-1 -5,-1 -18,-7.5 -13,-6.5 -24.5,-16 Q 237,382 224.5,362 212,342 205,316 q 26,15 51,15 4,0 4,-2 z"
+         id="path6225"
+         style="fill:currentColor" />
+    </g>
+  </g>
+</svg>

--- a/safe/common/exceptions.py
+++ b/safe/common/exceptions.py
@@ -26,6 +26,7 @@ __copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
 
 class InaSAFEError(RuntimeError):
     """Base class for all user defined exceptions"""
+
     suggestion = 'An unspecified error occurred.'
 
     def __init__(self, message=None):
@@ -62,106 +63,145 @@ class InaSAFEError(RuntimeError):
 
 
 class ReadLayerError(InaSAFEError):
+
     """When a layer can't be read"""
+
     suggestion = (
         'Check that the file exists and you have permissions to read it')
 
 
 class WriteLayerError(InaSAFEError):
+
     """When a layer can't be written"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class BoundingBoxError(InaSAFEError):
+
     """For errors relating to bboxes"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class VerificationError(InaSAFEError):
-    """Exception thrown by verify()
-    """
+
+    """Exception thrown by verify()"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class PolygonInputError(InaSAFEError):
+
     """For invalid inputs to numeric polygon functions"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class PointsInputError(InaSAFEError):
+
     """For invalid inputs to numeric point functions"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class BoundsError(InaSAFEError):
+
     """For points falling outside interpolation grid"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class GetDataError(InaSAFEError):
+
     """When layer data cannot be obtained"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class WindowsError(InaSAFEError):
+
     """For windows specific errors."""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class GridXmlFileNotFoundError(InaSAFEError):
+
     """An exception for when an grid.xml could not be found"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class GridXmlParseError(InaSAFEError):
+
     """An exception for when something went wrong parsing the grid.xml """
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class ContourCreationError(InaSAFEError):
+
     """An exception for when creating contours from shakemaps goes wrong"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class InvalidLayerError(InaSAFEError):
+
     """Raised when a gis layer is invalid"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class ZeroImpactException(InaSAFEError):
+
     """Raised if an impact function return zero impact"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class WrongDataTypeException(InaSAFEError):
+
     """Raised if expected and received data types are different"""
+
     suggestion = 'Please ask the developers of InaSAFE to add a suggestion.'
 
 
 class InvalidClipGeometryError(InaSAFEError):
+
     """Custom exception for when clip geometry is invalid."""
+
     pass
 
 
 class FileNotFoundError(InaSAFEError):
+
     """Custom exception for when a file could not be found."""
+
     pass
 
 
 class FunctionParametersError(InaSAFEError):
+
     """Custom exception for when function parameters are not valid."""
+
     pass
 
 
 class KeywordDbError(InaSAFEError):
+
     """Custom exception for when an error is encountered with keyword cache db.
     """
+
     pass
 
 
 class KeywordNotFoundError(InaSAFEError):
+
     """Custom exception for when a keyword's key (e.g. unit) cannot be found.
     """
+
     def __init__(self, message, **kwargs):
         # Call the base class constructor with the parameters it needs
         super(KeywordNotFoundError, self).__init__(message)
@@ -171,117 +211,160 @@ class KeywordNotFoundError(InaSAFEError):
 
 
 class HashNotFoundError(InaSAFEError):
+
     """Custom exception for when a no keyword hash can be found."""
+
     pass
 
 
 class InvalidParameterError(InaSAFEError):
+
     """Custom exception for when an invalid parameter is passed to a function.
     """
+
     pass
 
 
 class NoKeywordsFoundError(InaSAFEError):
+
     """Custom exception for when no keywords file exist for a layer.
     """
+
     pass
 
 
 class TranslationLoadError(InaSAFEError):
+
     """Custom exception handler for whe translation file fails
     to load."""
+
     pass
 
 
 class NoFeaturesInExtentError(InaSAFEError):
+
     """An exception that gets thrown when no features are within
     the extent being clipped."""
+
     pass
 
 
 class InvalidProjectionError(InaSAFEError):
+
     """An exception raised if a layer needs to be reprojected."""
+
     pass
 
 
 class InsufficientOverlapError(InaSAFEError):
+
     """An exception raised if an error occurs during extent calculation
     because the bounding boxes do not overlap."""
+
     pass
 
 
 class StyleError(InaSAFEError):
+
     """An exception relating to reading / generating GIS styles"""
+
     pass
 
 
 class MemoryLayerCreationError(InaSAFEError):
+
     """Raised if an error occurs creating the cities file"""
+
     pass
 
 
 class CallGDALError(InaSAFEError):
+
     """Raised if failed to call gdal command. Indicate by error message that is
     not empty"""
+
     pass
 
 
 class FileMissingError(InaSAFEError):
+
     """Raised if a file cannot be found."""
+
     pass
 
 
 class CanceledImportDialogError(InaSAFEError):
+
     """Raised if import process canceled"""
+
     pass
 
 
 class InvalidGeometryError(InaSAFEError):
+
     """Custom exception for when a feature geometry is invalid or none."""
+
     pass
 
 
 class UnsupportedProviderError(InaSAFEError):
+
     """For unsupported provider (e.g. openlayers plugin) encountered."""
+
     pass
 
 
 class TemplateLoadingError(InaSAFEError):
+
     """Raised when loading the template is error."""
+
     pass
 
 
 class DownloadError(InaSAFEError):
+
     """Raised when downloading file is error."""
+
     pass
 
 
 class NoValidLayerError(InaSAFEError):
+
     """Raised when there no valid layer in inasafe."""
+
     pass
 
 
 class InsufficientMemoryWarning(InaSAFEError):
+
     """Raised when there is a possible insufficient memory."""
+
     pass
 
 
 class InvalidKeywordsForProcessingAlgorithm(InaSAFEError):
+
     """Raised if the algorithm don't have proper keywords to run."""
+
     pass
 
 
 class InvalidExtentError(InaSAFEError):
+
     """Raised if an extent is not valid."""
+
     pass
 
 
 class NoAttributeInLayerError(InaSAFEError):
+
     """Raised if the attribute not exists in the vector layer"""
+
     pass
 
 
 class MetadataLayerConstraintError(InaSAFEError):
+
     """Raised if the metadata does not match with the IF base class.
 
     It means the layer constraint specified in the metadata is not supported
@@ -290,46 +373,64 @@ class MetadataLayerConstraintError(InaSAFEError):
 
 
 class MetadataReadError(InaSAFEError):
+
     """When a metadata xml is not correctly formatted can't be read"""
+
     suggestion = (
         'Check that the file is correct')
 
 
 class MetadataInvalidPathError(InaSAFEError):
+
     """When a path for a metadata xml is not correct"""
+
     suggestion = 'Check that the XML path of the property is correct'
 
 
 class MetadataCastError(InaSAFEError):
+
     """When a path for a metadata xml is not correct"""
+
     suggestion = 'Check that the XML value is of the correct type'
 
 
 class InvalidProvenanceDataError(InaSAFEError):
+
     """When a path for a metadata xml is not correct"""
+
     suggestion = 'Check that the IF produced all the required data'
 
 
 class MissingMetadata(InaSAFEError):
+
     """When old version of metadata is not properly read."""
+
     pass
 
 
 class MissingImpactReport(InaSAFEError):
+
     """When Impact Report do not have proper input.."""
+
     pass
 
 
 class ErrorDataStore(InaSAFEError):
+
     """When the datastore has an error."""
+
     pass
 
 
 class InvalidWizardStep(InaSAFEError):
+
     """When there is an invalid wizard step."""
+
     pass
 
 
 class ProcessingAlgError(InaSAFEError):
+
     """When there is an error in processing algorithm."""
+
     pass

--- a/safe/common/exceptions.py
+++ b/safe/common/exceptions.py
@@ -328,3 +328,8 @@ class ErrorDataStore(InaSAFEError):
 class InvalidWizardStep(InaSAFEError):
     """When there is an invalid wizard step."""
     pass
+
+
+class ProcessingAlgError(InaSAFEError):
+    """When there is an error in processing algorithm."""
+    pass

--- a/safe/definitionsv4/colors.py
+++ b/safe/definitionsv4/colors.py
@@ -17,6 +17,7 @@ yellow = QColor('#FFFFB2')
 orange = QColor('#FEB24C')
 red = QColor('#F03B20')
 dark_red = QColor('#BD0026')
+very_dark_red = QColor('#710017')
 
 # Default color for no hazard
 no_hazard = QColor('#000000')

--- a/safe/definitionsv4/hazard.py
+++ b/safe/definitionsv4/hazard.py
@@ -6,7 +6,7 @@ from safe.definitionsv4.hazard_classifications import (
     flood_hazard_classes,
     tsunami_hazard_classes,
     ash_hazard_classes,
-    cyclone_au_bom_hazard_classes)
+    cyclone_au_bom_hazard_classes, cyclone_sshws_hazard_classes)
 from safe.definitionsv4.caveats import (
     caveat_simulation, caveat_local_conditions, caveat_analysis_extent,)
 from safe.definitionsv4.concepts import concepts
@@ -221,7 +221,9 @@ hazard_cyclone = {
         'polygon',
         'raster'
     ],
-    'classifications': [cyclone_au_bom_hazard_classes, generic_hazard_classes],
+    'classifications': [cyclone_au_bom_hazard_classes,
+                        cyclone_sshws_hazard_classes,
+                        generic_hazard_classes],
     'compulsory_fields': [hazard_value_field],
     'fields': hazard_fields,
     'extra_fields': [],

--- a/safe/definitionsv4/hazard.py
+++ b/safe/definitionsv4/hazard.py
@@ -324,7 +324,7 @@ hazard_volcano = {
         caveat_simulation,
         caveat_local_conditions,
         caveat_analysis_extent,
-    ],''
+    ],
     'actions': [  # these are additional generic actions - IF has more
 
     ],

--- a/safe/definitionsv4/hazard.py
+++ b/safe/definitionsv4/hazard.py
@@ -215,15 +215,20 @@ hazard_cyclone = {
             'link': None
         }
     ],
-    'continuous_hazard_units': [unit_miles_per_hour, unit_kilometres_per_hour,
-                                unit_knots],
+    'continuous_hazard_units': [
+        unit_miles_per_hour,
+        unit_kilometres_per_hour,
+        unit_knots
+    ],
     'allowed_geometries': [
         'polygon',
         'raster'
     ],
-    'classifications': [cyclone_au_bom_hazard_classes,
-                        cyclone_sshws_hazard_classes,
-                        generic_hazard_classes],
+    'classifications': [
+        cyclone_au_bom_hazard_classes,
+        cyclone_sshws_hazard_classes,
+        generic_hazard_classes
+    ],
     'compulsory_fields': [hazard_value_field],
     'fields': hazard_fields,
     'extra_fields': [],

--- a/safe/definitionsv4/hazard.py
+++ b/safe/definitionsv4/hazard.py
@@ -5,8 +5,8 @@ from safe.definitionsv4.hazard_classifications import (
     volcano_hazard_classes,
     flood_hazard_classes,
     tsunami_hazard_classes,
-    ash_hazard_classes
-)
+    ash_hazard_classes,
+    cyclone_au_bom_hazard_classes)
 from safe.definitionsv4.caveats import (
     caveat_simulation, caveat_local_conditions, caveat_analysis_extent,)
 from safe.definitionsv4.concepts import concepts
@@ -18,7 +18,10 @@ from safe.definitionsv4.units import (
     unit_metres,
     unit_millimetres,
     unit_centimetres,
-    unit_mmi)
+    unit_mmi,
+    unit_miles_per_hour,
+    unit_kilometres_per_hour,
+    unit_knots)
 from safe.definitionsv4.layer_modes import (
     layer_mode_classified, layer_mode_continuous)
 from safe.definitionsv4.fields import (
@@ -50,7 +53,10 @@ continuous_hazard_unit = {
         unit_metres,
         unit_millimetres,
         unit_centimetres,
-        unit_mmi
+        unit_mmi,
+        unit_kilometres_per_hour,
+        unit_miles_per_hour,
+        unit_knots
     ]
 }
 continuous_hazard_unit_all = continuous_hazard_unit['types']
@@ -177,6 +183,51 @@ hazard_flood = {
     'extra_fields': [],
     'layer_modes': [layer_mode_classified, layer_mode_continuous]
 }
+
+hazard_cyclone = {
+    'key': 'cyclone',
+    'name': tr('Cyclone'),
+    'description': tr(
+        'A <b>Cyclone</b> is a rapidly rotating storm system '
+        'characterized by a low-pressure center, a closed low-level  '
+        'atmospheric circulation, strong winds, and a spiral arrangement of '
+        'thunderstorms that produce heavy rain. It is also referred to as '
+        '<b>hurricane</b> or <b>typhoon</b>.'),
+    'notes': [  # additional generic notes for flood - IF has more
+        caveat_simulation,
+        caveat_local_conditions,
+        caveat_analysis_extent,
+    ],
+    'continuous_notes': [  # notes specific to continuous data
+    ],
+    'classified_notes': [  # notes specific to classified data
+    ],
+    'single_event_notes': [  # notes specific to single event data
+    ],
+    'multi_event_notes': [  # notes specific to multi event data
+    ],
+    'actions': [  # these are additional generic actions - IF has more
+
+    ],
+    'citations': [
+        {
+            'text': None,
+            'link': None
+        }
+    ],
+    'continuous_hazard_units': [unit_miles_per_hour, unit_kilometres_per_hour,
+                                unit_knots],
+    'allowed_geometries': [
+        'polygon',
+        'raster'
+    ],
+    'classifications': [cyclone_au_bom_hazard_classes, generic_hazard_classes],
+    'compulsory_fields': [hazard_value_field],
+    'fields': hazard_fields,
+    'extra_fields': [],
+    'layer_modes': [layer_mode_classified, layer_mode_continuous]
+}
+
 hazard_volcanic_ash = {
     'key': 'volcanic_ash',
     'name': tr('Volcanic ash'),
@@ -271,7 +322,7 @@ hazard_volcano = {
         caveat_simulation,
         caveat_local_conditions,
         caveat_analysis_extent,
-    ],
+    ],''
     'actions': [  # these are additional generic actions - IF has more
 
     ],
@@ -306,6 +357,7 @@ hazard_all = [
     hazard_earthquake,
     hazard_volcano,
     hazard_volcanic_ash,
+    hazard_cyclone,
     hazard_generic
 ]
 hazards = {

--- a/safe/definitionsv4/hazard_classifications.py
+++ b/safe/definitionsv4/hazard_classifications.py
@@ -476,13 +476,12 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 5 (severe tropical cyclone)'),
             'affected': True,
             'description': tr(
-                    'Extremely dangerous with widespread destruction. A '
-                    'Category '
-                    '5 cyclone\'s strongest winds are VERY DESTRUCTIVE winds '
-                    'with '
-                    'typical gusts over open flat land of more than 151 kn. '
-                    'These winds correspond to the highest category on the '
-                    'Beaufort scale, Beaufort 12 (Hurricane).'
+                    'Extremely dangerous with widespread destruction. A  '
+                    'Category 5 cyclone\'s strongest winds are VERY '
+                    'DESTRUCTIVE winds with typical gusts over open flat land '
+                    'of more than 151 kn These winds correspond to the '
+                    'highest category on the Beaufort scale, Beaufort 12 ('
+                    'Hurricane).'
             ),
             'numeric_default_min': {
                 unit_knots['key']: 107,

--- a/safe/definitionsv4/hazard_classifications.py
+++ b/safe/definitionsv4/hazard_classifications.py
@@ -7,7 +7,8 @@ to have a table showing you classes of each kind of hazard.
 """
 from safe.definitionsv4 import concepts, small_number
 from safe.utilities.i18n import tr
-from safe.definitionsv4.units import unit_centimetres
+from safe.definitionsv4.units import unit_centimetres, unit_miles_per_hour, \
+    unit_kilometres_per_hour, unit_knots
 from safe.definitionsv4.colors import (
     green,
     light_green,
@@ -452,6 +453,8 @@ cyclone_au_bom_hazard_classes = {
             'link': 'https://en.wikipedia.org/wiki/Tropical_cyclone_scales#Australia_and_Fiji'
         }
     ],
+    'multiple_units': [unit_miles_per_hour, unit_kilometres_per_hour,
+                       unit_knots],
     'classes': [
         {
             'key': 'category_5',
@@ -460,13 +463,19 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 5 (severe tropical cyclone)'),
             'affected': True,
             'description': tr(
-                'Extremely dangerous with widespread destruction. A Category '
-                '5 cyclone\'s strongest winds are VERY DESTRUCTIVE winds with '
-                'typical gusts over open flat land of more than 151 kn. '
-                'These winds correspond to the highest category on the '
-                'Beaufort scale, Beaufort 12 (Hurricane).'
+                    'Extremely dangerous with widespread destruction. A '
+                    'Category '
+                    '5 cyclone\'s strongest winds are VERY DESTRUCTIVE winds '
+                    'with '
+                    'typical gusts over open flat land of more than 151 kn. '
+                    'These winds correspond to the highest category on the '
+                    'Beaufort scale, Beaufort 12 (Hurricane).'
             ),
-            'numeric_default_min': 107,
+            'numeric_default_min': {
+                unit_knots['key']: 107,
+                unit_miles_per_hour['key']: 123,
+                unit_kilometres_per_hour['key']: 198
+                },
             'numeric_default_max': 9999999999,
             'citations': [
                 {
@@ -482,16 +491,24 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 4 (severe tropical cyclone)'),
             'affected': True,
             'description': tr(
-                'Significant roofing loss and structural damage. Many '
-                'caravans destroyed and blown away. Dangerous airborne '
-                'debris. Widespread power failures. A Category 4 cyclone\'s'
-                'strongest winds are VERY DESTRUCTIVE winds with typical '
-                'gusts over open flat land of 122 - 151 kn. These winds '
-                'correspond to the highest category on the Beaufort scale, '
-                'Beaufort 12 (Hurricane).'
+                    'Significant roofing loss and structural damage. Many '
+                    'caravans destroyed and blown away. Dangerous airborne '
+                    'debris. Widespread power failures. A Category 4 cyclone\'s'
+                    'strongest winds are VERY DESTRUCTIVE winds with typical '
+                    'gusts over open flat land of 122 - 151 kn. These winds '
+                    'correspond to the highest category on the Beaufort scale, '
+                    'Beaufort 12 (Hurricane).'
             ),
-            'numeric_default_min': 85,
-            'numeric_default_max': 107,
+            'numeric_default_min': {
+                unit_knots['key']: 85,
+                unit_miles_per_hour['key']: 98,
+                unit_kilometres_per_hour['key']: 157
+                },
+            'numeric_default_max': {
+                unit_knots['key']: 107,
+                unit_miles_per_hour['key']: 123,
+                unit_kilometres_per_hour['key']: 198
+                },
             'citations': [
                 {
                     'text': None,
@@ -506,14 +523,22 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 3 (severe tropical cyclone)'),
             'affected': True,
             'description': tr(
-                'Some roof and structural damage. Some caravans destroyed. '
-                'Power failures likely. A Category 3 cyclone\'s strongest '
-                'winds are VERY DESTRUCTIVE winds with typical gusts over '
-                'open flat land of 90 - 121 kn. These winds correspond to '
-                'the highest category on the Beaufort scale, Beaufort 12 ('
-                'Hurricane).'),
-            'numeric_default_min': 63,
-            'numeric_default_max': 85,
+                    'Some roof and structural damage. Some caravans destroyed. '
+                    'Power failures likely. A Category 3 cyclone\'s strongest '
+                    'winds are VERY DESTRUCTIVE winds with typical gusts over '
+                    'open flat land of 90 - 121 kn. These winds correspond to '
+                    'the highest category on the Beaufort scale, Beaufort 12 ('
+                    'Hurricane).'),
+            'numeric_default_min': {
+                unit_knots['key']: 63,
+                unit_miles_per_hour['key']: 72,
+                unit_kilometres_per_hour['key']: 117
+                },
+            'numeric_default_max': {
+                unit_knots['key']: 85,
+                unit_miles_per_hour['key']: 98,
+                unit_kilometres_per_hour['key']: 157
+                },
             'citations': [
                 {
                     'text': None,
@@ -528,14 +553,25 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 2 (tropical cyclone)'),
             'affected': True,
             'description': tr(
-                'Minor house damage. Significant damage to signs, trees and '
-                'caravans. Heavy damage to some crops. Risk of power failure. '
-                'Small craft may break moorings. A Category 2 cyclone\'s '
-                'strongest winds are DESTRUCTIVE winds with typical gusts '
-                'over open flat land of 68 - 89 kn. These winds '
-                'correspond to Beaufort 10 and 11 (Storm and violent storm).'),
-            'numeric_default_min': 47,
-            'numeric_default_max': 63,
+                    'Minor house damage. Significant damage to signs, '
+                    'trees and '
+                    'caravans. Heavy damage to some crops. Risk of power '
+                    'failure. '
+                    'Small craft may break moorings. A Category 2 cyclone\'s '
+                    'strongest winds are DESTRUCTIVE winds with typical gusts '
+                    'over open flat land of 68 - 89 kn. These winds '
+                    'correspond to Beaufort 10 and 11 (Storm and violent '
+                    'storm).'),
+            'numeric_default_min': {
+                unit_knots['key']: 47,
+                unit_miles_per_hour['key']: 54,
+                unit_kilometres_per_hour['key']: 88
+                },
+            'numeric_default_max': {
+                unit_knots['key']: 63,
+                unit_miles_per_hour['key']: 72,
+                unit_kilometres_per_hour['key']: 117
+                },
             'citations': [
                 {
                     'text': None,
@@ -550,13 +586,23 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 1 (tropical cyclone)'),
             'affected': False,
             'description': tr(
-                'Negligible house damage. Damage to some crops, trees and '
-                'caravans. Craft may drag moorings. A Category 1 cyclone\'s '
-                'strongest winds are GALES with typical gusts over open flat '
-                'land of 49 - 67 kn. These winds correspond to Beaufort 8 '
-                'and 9 (Gales and strong gales).'),
-            'numeric_default_min': 34,
-            'numeric_default_max': 47,
+                    'Negligible house damage. Damage to some crops, trees and '
+                    'caravans. Craft may drag moorings. A Category 1 '
+                    'cyclone\'s '
+                    'strongest winds are GALES with typical gusts over open '
+                    'flat '
+                    'land of 49 - 67 kn. These winds correspond to Beaufort 8 '
+                    'and 9 (Gales and strong gales).'),
+            'numeric_default_min': {
+                unit_knots['key']: 34,
+                unit_miles_per_hour['key']: 39,
+                unit_kilometres_per_hour['key']: 63
+                },
+            'numeric_default_max': {
+                unit_knots['key']: 47,
+                unit_miles_per_hour['key']: 54,
+                unit_kilometres_per_hour['key']: 88
+                },
             'citations': [
                 {
                     'text': None,
@@ -575,7 +621,11 @@ cyclone_au_bom_hazard_classes = {
                               'surface circulation, which has maximum '
                               'sustained winds of less than 34 kn.'),
             'numeric_default_min': 0,
-            'numeric_default_max': 34,
+            'numeric_default_max': {
+                unit_knots['key']: 34,
+                unit_miles_per_hour['key']: 39,
+                unit_kilometres_per_hour['key']: 63
+                },
             'citations': [
                 {
                     'text': None,
@@ -585,6 +635,8 @@ cyclone_au_bom_hazard_classes = {
         },
     ]
 }
+
+cyclone_hazard_classes = [cyclone_au_bom_hazard_classes]
 
 hazard_classification = {
     'key': 'hazard_classification',
@@ -602,9 +654,9 @@ hazard_classification = {
         flood_hazard_classes,
         tsunami_hazard_classes,
         volcano_hazard_classes,
-        ash_hazard_classes,
-        cyclone_au_bom_hazard_classes
+        ash_hazard_classes
     ]
 }
+hazard_classification['types'].extend(cyclone_hazard_classes)
 
 all_hazard_classes = hazard_classification['types']

--- a/safe/definitionsv4/hazard_classifications.py
+++ b/safe/definitionsv4/hazard_classifications.py
@@ -400,8 +400,8 @@ tsunami_hazard_classes = {
             'name': tr('Low hazard zone'),
             'affected': False,
             'description': tr(
-                    'Water above ground height and less than 1.0m. The area is '
-                    'potentially hit by a tsunami wave with an inundation '
+                    'Water above ground height and less than 1.0m. The area '
+                    'is potentially hit by a tsunami wave with an inundation '
                     'depth '
                     'less than 1 m or similar to tsunami intensity scale of V '
                     'or '
@@ -413,8 +413,8 @@ tsunami_hazard_classes = {
                     'from '
                     'shore. Small vessels drift and collide and some turn '
                     'over. '
-                    'Sand is deposited and there is flooding of areas close to '
-                    'the shore.'),
+                    'Sand is deposited and there is flooding of areas close '
+                    'to the shore.'),
             'numeric_default_min': 0.1,
             'numeric_default_max': 1,
             'citations': [
@@ -506,11 +506,11 @@ cyclone_au_bom_hazard_classes = {
             'description': tr(
                     'Significant roofing loss and structural damage. Many '
                     'caravans destroyed and blown away. Dangerous airborne '
-                    'debris. Widespread power failures. A Category 4 cyclone\'s'
-                    'strongest winds are VERY DESTRUCTIVE winds with typical '
-                    'gusts over open flat land of 122 - 151 kn. These winds '
-                    'correspond to the highest category on the Beaufort scale, '
-                    'Beaufort 12 (Hurricane).'
+                    'debris. Widespread power failures. A Category 4 '
+                    'cyclone\'s strongest winds are VERY DESTRUCTIVE winds '
+                    'with typical gusts over open flat land of 122 - 151 kn. '
+                    'These winds correspond to the highest category on the '
+                    'Beaufort scale, Beaufort 12 (Hurricane).'
             ),
             'numeric_default_min': {
                 unit_knots['key']: 85,
@@ -536,7 +536,7 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 3 (severe tropical cyclone)'),
             'affected': True,
             'description': tr(
-                    'Some roof and structural damage. Some caravans destroyed. '
+                    'Some roof and structural damage. Some caravans destroyed.'
                     'Power failures likely. A Category 3 cyclone\'s strongest '
                     'winds are VERY DESTRUCTIVE winds with typical gusts over '
                     'open flat land of 90 - 121 kn. These winds correspond to '
@@ -653,8 +653,8 @@ cyclone_sshws_hazard_classes = {
     'key': 'cyclone_sshws_hazard_classes',
     'name': tr('Hurricane classes (SSHWS)'),
     'description': tr(
-            'The <b>Saffir-Simpson Hurricane Wind Scale</b> is a 1 to 5 rating '
-            'based on a hurricane\'s sustained wind speed. This scale '
+            'The <b>Saffir-Simpson Hurricane Wind Scale</b> is a 1 to 5 rating'
+            ' based on a hurricane\'s sustained wind speed. This scale '
             'estimates '
             'potential property damage. Hurricanes reaching Category 3 and '
             'higher are considered major hurricanes because of their '
@@ -672,7 +672,8 @@ cyclone_sshws_hazard_classes = {
         },
         {
             'text': 'Saffir–Simpson scale - wikpedia',
-            'link': 'https://en.wikipedia.org/wiki/Saffir%E2%80%93Simpson_scale'
+            'link':
+                'https://en.wikipedia.org/wiki/Saffir%E2%80%93Simpson_scale'
         }
     ],
     'multiple_units': [unit_miles_per_hour, unit_kilometres_per_hour,

--- a/safe/definitionsv4/hazard_classifications.py
+++ b/safe/definitionsv4/hazard_classifications.py
@@ -93,8 +93,8 @@ volcano_hazard_classes = {
     'key': 'volcano_hazard_classes',
     'name': tr('Volcano classes'),
     'description': tr(
-            'Three classes are supported for volcano vector hazard data: '
-            '<b>low</b>, <b>medium</b>, or <b>high</b>.'),
+        'Three classes are supported for volcano vector hazard data: '
+        '<b>low</b>, <b>medium</b>, or <b>high</b>.'),
     'citations': [
         {
             'text': None,
@@ -160,10 +160,10 @@ flood_hazard_classes = {
     'key': 'flood_hazard_classes',
     'name': tr('Flood classes'),
     'description': tr(
-            'This is a binary description for an area. The area is either '
-            '<b>wet</b> (affected by flood water) or <b>dry</b> (not affected '
-            'by flood water). This unit does not describe how <b>wet</b> or '
-            '<b>dry</b> an area is.'),
+        'This is a binary description for an area. The area is either '
+        '<b>wet</b> (affected by flood water) or <b>dry</b> (not affected '
+        'by flood water). This unit does not describe how <b>wet</b> or '
+        '<b>dry</b> an area is.'),
     'citations': [
         {
             'text': None,
@@ -212,9 +212,9 @@ ash_hazard_classes = {
     'key': 'ash_hazard_classes',
     'name': tr('Ash classes'),
     'description': tr(
-            'Three four are supported for ash vector hazard data: '
-            '<b>very low</b>, <b>low</b>, <b>medium</b>, <b>high</b> or '
-            '<b>very high</b>.'),
+        'Three four are supported for ash vector hazard data: '
+        '<b>very low</b>, <b>low</b>, <b>medium</b>, <b>high</b> or '
+        '<b>very high</b>.'),
     'unit': unit_centimetres,
     'citations': [
         {
@@ -310,11 +310,11 @@ tsunami_hazard_classes = {
     'key': 'tsunami_hazard_classes',
     'name': tr('Tsunami classes'),
     'description': tr(
-            'This is a quinary description for an area. The area is either '
-            '<b>dry</b>, <b>low</b>, <b>medium</b>, <b>high</b>, or '
-            '<b>very high</b> for tsunami hazard classification. '
-            'The following description for these classes is provided by Badan '
-            'Geologi based on BNPB Perka 2/2012'),
+        'This is a quinary description for an area. The area is either '
+        '<b>dry</b>, <b>low</b>, <b>medium</b>, <b>high</b>, or '
+        '<b>very high</b> for tsunami hazard classification. '
+        'The following description for these classes is provided by Badan '
+        'Geologi based on BNPB Perka 2/2012'),
     'citations': [
         {
             'text': None,
@@ -345,19 +345,19 @@ tsunami_hazard_classes = {
             'name': tr('High hazard zone'),
             'affected': True,
             'description': tr(
-                    'Water above 3.1m and less than 8.0m. The area is '
-                    'potentially '
-                    'hit by a tsunami wave with an inundation depth > 3 m or '
-                    'reach a tsunami intensity scale of VII or even more '
-                    '(Papadoupulos and Imamura, 2001). Tsunami wave with 4 m '
-                    'inundation depth cause damage to small vessel, '
-                    'a few ships '
-                    'are drifted inland, severe damage on most wooden houses. '
-                    'Boulders are deposited on shore. If tsunami height '
-                    'reaches '
-                    '8 m, it will cause severe damage. Dykes, wave breaker, '
-                    'tsunami protection walls and green belts will be washed '
-                    'away.'),
+                'Water above 3.1m and less than 8.0m. The area is '
+                'potentially '
+                'hit by a tsunami wave with an inundation depth > 3 m or '
+                'reach a tsunami intensity scale of VII or even more '
+                '(Papadoupulos and Imamura, 2001). Tsunami wave with 4 m '
+                'inundation depth cause damage to small vessel, '
+                'a few ships '
+                'are drifted inland, severe damage on most wooden houses. '
+                'Boulders are deposited on shore. If tsunami height '
+                'reaches '
+                '8 m, it will cause severe damage. Dykes, wave breaker, '
+                'tsunami protection walls and green belts will be washed '
+                'away.'),
             'numeric_default_min': 3,
             'numeric_default_max': 8,
             'citations': [
@@ -374,16 +374,16 @@ tsunami_hazard_classes = {
             'name': tr('Medium hazard zone'),
             'affected': True,
             'description': tr(
-                    'Water above 1.1m and less than 3.0m. The area is '
-                    'potentially '
-                    'hit by a tsunami wave with an inundation depth of 1 - 3 '
-                    'm or '
-                    'equal to V-VI tsunami intensity scale (Papadoupulos and '
-                    'Imamura, 2001). Tsunami wave with a 3m inundation depth '
-                    'causes most people frightened and to flee to higher '
-                    'ground. '
-                    'Small vessels drift and collide. Damage occurs to some '
-                    'wooden houses, while most of them are safe.'),
+                'Water above 1.1m and less than 3.0m. The area is '
+                'potentially '
+                'hit by a tsunami wave with an inundation depth of 1 - 3 '
+                'm or '
+                'equal to V-VI tsunami intensity scale (Papadoupulos and '
+                'Imamura, 2001). Tsunami wave with a 3m inundation depth '
+                'causes most people frightened and to flee to higher '
+                'ground. '
+                'Small vessels drift and collide. Damage occurs to some '
+                'wooden houses, while most of them are safe.'),
             'numeric_default_min': 1,
             'numeric_default_max': 3,
             'citations': [
@@ -400,21 +400,21 @@ tsunami_hazard_classes = {
             'name': tr('Low hazard zone'),
             'affected': False,
             'description': tr(
-                    'Water above ground height and less than 1.0m. The area '
-                    'is potentially hit by a tsunami wave with an inundation '
-                    'depth '
-                    'less than 1 m or similar to tsunami intensity scale of V '
-                    'or '
-                    'less in (Papadoupulos and Imamura, 2001). Tsunami wave '
-                    'of 1m '
-                    'height causes few people to be frightened and flee to '
-                    'higher '
-                    'elevation. Felt by most people on large ship, observed '
-                    'from '
-                    'shore. Small vessels drift and collide and some turn '
-                    'over. '
-                    'Sand is deposited and there is flooding of areas close '
-                    'to the shore.'),
+                'Water above ground height and less than 1.0m. The area '
+                'is potentially hit by a tsunami wave with an inundation '
+                'depth '
+                'less than 1 m or similar to tsunami intensity scale of V '
+                'or '
+                'less in (Papadoupulos and Imamura, 2001). Tsunami wave '
+                'of 1m '
+                'height causes few people to be frightened and flee to '
+                'higher '
+                'elevation. Felt by most people on large ship, observed '
+                'from '
+                'shore. Small vessels drift and collide and some turn '
+                'over. '
+                'Sand is deposited and there is flooding of areas close '
+                'to the shore.'),
             'numeric_default_min': 0.1,
             'numeric_default_max': 1,
             'citations': [
@@ -447,13 +447,13 @@ cyclone_au_bom_hazard_classes = {
     'key': 'cyclone_au_bom_hazard_classes',
     'name': tr('Cyclone classes (AU - BOM)'),
     'description': tr(
-            'The quinary <b>tropical cyclone</b> intensity classification '
-            'according to the Australian Bureau of Metereology is defined by '
-            'the '
-            'maximum mean wind speed over open flat land or water. '
-            'This is sometimes referred to as the maximum sustained wind and '
-            'will'
-            'be experienced around the eye-wall of the cyclone.'),
+        'The quinary <b>tropical cyclone</b> intensity classification '
+        'according to the Australian Bureau of Metereology is defined by '
+        'the '
+        'maximum mean wind speed over open flat land or water. '
+        'This is sometimes referred to as the maximum sustained wind and '
+        'will'
+        'be experienced around the eye-wall of the cyclone.'),
     'citations': [
         {
             'text': 'Australian Bureau of Metereology - Tropical Cyclone '
@@ -476,12 +476,12 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 5 (severe tropical cyclone)'),
             'affected': True,
             'description': tr(
-                    'Extremely dangerous with widespread destruction. A  '
-                    'Category 5 cyclone\'s strongest winds are VERY '
-                    'DESTRUCTIVE winds with typical gusts over open flat land '
-                    'of more than 151 kn These winds correspond to the '
-                    'highest category on the Beaufort scale, Beaufort 12 ('
-                    'Hurricane).'
+                'Extremely dangerous with widespread destruction. A  '
+                'Category 5 cyclone\'s strongest winds are VERY '
+                'DESTRUCTIVE winds with typical gusts over open flat land '
+                'of more than 151 kn These winds correspond to the '
+                'highest category on the Beaufort scale, Beaufort 12 ('
+                'Hurricane).'
             ),
             'numeric_default_min': {
                 unit_knots['key']: 107,
@@ -503,13 +503,13 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 4 (severe tropical cyclone)'),
             'affected': True,
             'description': tr(
-                    'Significant roofing loss and structural damage. Many '
-                    'caravans destroyed and blown away. Dangerous airborne '
-                    'debris. Widespread power failures. A Category 4 '
-                    'cyclone\'s strongest winds are VERY DESTRUCTIVE winds '
-                    'with typical gusts over open flat land of 122 - 151 kn. '
-                    'These winds correspond to the highest category on the '
-                    'Beaufort scale, Beaufort 12 (Hurricane).'
+                'Significant roofing loss and structural damage. Many '
+                'caravans destroyed and blown away. Dangerous airborne '
+                'debris. Widespread power failures. A Category 4 '
+                'cyclone\'s strongest winds are VERY DESTRUCTIVE winds '
+                'with typical gusts over open flat land of 122 - 151 kn. '
+                'These winds correspond to the highest category on the '
+                'Beaufort scale, Beaufort 12 (Hurricane).'
             ),
             'numeric_default_min': {
                 unit_knots['key']: 85,
@@ -535,12 +535,12 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 3 (severe tropical cyclone)'),
             'affected': True,
             'description': tr(
-                    'Some roof and structural damage. Some caravans destroyed.'
-                    'Power failures likely. A Category 3 cyclone\'s strongest '
-                    'winds are VERY DESTRUCTIVE winds with typical gusts over '
-                    'open flat land of 90 - 121 kn. These winds correspond to '
-                    'the highest category on the Beaufort scale, Beaufort 12 ('
-                    'Hurricane).'),
+                'Some roof and structural damage. Some caravans destroyed.'
+                'Power failures likely. A Category 3 cyclone\'s strongest '
+                'winds are VERY DESTRUCTIVE winds with typical gusts over '
+                'open flat land of 90 - 121 kn. These winds correspond to '
+                'the highest category on the Beaufort scale, Beaufort 12 ('
+                'Hurricane).'),
             'numeric_default_min': {
                 unit_knots['key']: 63,
                 unit_miles_per_hour['key']: 72,
@@ -565,15 +565,15 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 2 (tropical cyclone)'),
             'affected': True,
             'description': tr(
-                    'Minor house damage. Significant damage to signs, '
-                    'trees and '
-                    'caravans. Heavy damage to some crops. Risk of power '
-                    'failure. '
-                    'Small craft may break moorings. A Category 2 cyclone\'s '
-                    'strongest winds are DESTRUCTIVE winds with typical gusts '
-                    'over open flat land of 68 - 89 kn. These winds '
-                    'correspond to Beaufort 10 and 11 (Storm and violent '
-                    'storm).'),
+                'Minor house damage. Significant damage to signs, '
+                'trees and '
+                'caravans. Heavy damage to some crops. Risk of power '
+                'failure. '
+                'Small craft may break moorings. A Category 2 cyclone\'s '
+                'strongest winds are DESTRUCTIVE winds with typical gusts '
+                'over open flat land of 68 - 89 kn. These winds '
+                'correspond to Beaufort 10 and 11 (Storm and violent '
+                'storm).'),
             'numeric_default_min': {
                 unit_knots['key']: 47,
                 unit_miles_per_hour['key']: 54,
@@ -598,13 +598,13 @@ cyclone_au_bom_hazard_classes = {
             'name': tr('Category 1 (tropical cyclone)'),
             'affected': False,
             'description': tr(
-                    'Negligible house damage. Damage to some crops, trees and '
-                    'caravans. Craft may drag moorings. A Category 1 '
-                    'cyclone\'s '
-                    'strongest winds are GALES with typical gusts over open '
-                    'flat '
-                    'land of 49 - 67 kn. These winds correspond to Beaufort 8 '
-                    'and 9 (Gales and strong gales).'),
+                'Negligible house damage. Damage to some crops, trees and '
+                'caravans. Craft may drag moorings. A Category 1 '
+                'cyclone\'s '
+                'strongest winds are GALES with typical gusts over open '
+                'flat '
+                'land of 49 - 67 kn. These winds correspond to Beaufort 8 '
+                'and 9 (Gales and strong gales).'),
             'numeric_default_min': {
                 unit_knots['key']: 34,
                 unit_miles_per_hour['key']: 39,
@@ -652,18 +652,18 @@ cyclone_sshws_hazard_classes = {
     'key': 'cyclone_sshws_hazard_classes',
     'name': tr('Hurricane classes (SSHWS)'),
     'description': tr(
-            'The <b>Saffir-Simpson Hurricane Wind Scale</b> is a 1 to 5 rating'
-            ' based on a hurricane\'s sustained wind speed. This scale '
-            'estimates '
-            'potential property damage. Hurricanes reaching Category 3 and '
-            'higher are considered major hurricanes because of their '
-            'potential for '
-            'significant loss of life and damage. Category 1 and 2 storms are '
-            'still dangerous, however, and require preventative measures. In '
-            'the '
-            'western North Pacific, the term "super typhoon" is used for '
-            'tropical '
-            'cyclones with sustained winds exceeding 150 mph.'),
+        'The <b>Saffir-Simpson Hurricane Wind Scale</b> is a 1 to 5 rating'
+        ' based on a hurricane\'s sustained wind speed. This scale '
+        'estimates '
+        'potential property damage. Hurricanes reaching Category 3 and '
+        'higher are considered major hurricanes because of their '
+        'potential for '
+        'significant loss of life and damage. Category 1 and 2 storms are '
+        'still dangerous, however, and require preventative measures. In '
+        'the '
+        'western North Pacific, the term "super typhoon" is used for '
+        'tropical '
+        'cyclones with sustained winds exceeding 150 mph.'),
     'citations': [
         {
             'text': 'NOAA - NHC',
@@ -685,12 +685,12 @@ cyclone_sshws_hazard_classes = {
             'name': tr('Category 5 (severe tropical cyclone)'),
             'affected': True,
             'description': tr(
-                    'Catastrophic damage will occur: A high percentage of '
-                    'framed homes will be destroyed, with total roof failure '
-                    'and wall collapse. Fallen trees and power poles will '
-                    'isolate residential areas. Power outages will last for '
-                    'weeks to possibly months. Most of the area will be '
-                    'uninhabitable for weeks or months.'
+                'Catastrophic damage will occur: A high percentage of '
+                'framed homes will be destroyed, with total roof failure '
+                'and wall collapse. Fallen trees and power poles will '
+                'isolate residential areas. Power outages will last for '
+                'weeks to possibly months. Most of the area will be '
+                'uninhabitable for weeks or months.'
             ),
             'numeric_default_min': {
                 unit_knots['key']: 136,
@@ -712,13 +712,13 @@ cyclone_sshws_hazard_classes = {
             'name': tr('Category 4 (severe tropical cyclone)'),
             'affected': True,
             'description': tr(
-                    'Catastrophic damage will occur: Well-built framed homes '
-                    'can sustain severe damage with loss of most of the roof '
-                    'structure and/or some exterior walls. Most trees will be '
-                    'snapped or uprooted and power poles downed. Fallen trees '
-                    'and power poles will isolate residential areas. Power '
-                    'outages will last weeks to possibly months. Most of the '
-                    'area will be uninhabitable for weeks or months.'
+                'Catastrophic damage will occur: Well-built framed homes '
+                'can sustain severe damage with loss of most of the roof '
+                'structure and/or some exterior walls. Most trees will be '
+                'snapped or uprooted and power poles downed. Fallen trees '
+                'and power poles will isolate residential areas. Power '
+                'outages will last weeks to possibly months. Most of the '
+                'area will be uninhabitable for weeks or months.'
             ),
             'numeric_default_min': {
                 unit_knots['key']: 112,
@@ -744,12 +744,12 @@ cyclone_sshws_hazard_classes = {
             'name': tr('Category 3 (severe tropical cyclone)'),
             'affected': True,
             'description': tr(
-                    'Devastating damage will occur: Well-built framed homes '
-                    'may incur major damage or removal of roof decking and '
-                    'gable ends. Many trees will be snapped or uprooted, '
-                    'blocking numerous roads. Electricity and water will be '
-                    'unavailable for several days to weeks after the storm '
-                    'passes.'),
+                'Devastating damage will occur: Well-built framed homes '
+                'may incur major damage or removal of roof decking and '
+                'gable ends. Many trees will be snapped or uprooted, '
+                'blocking numerous roads. Electricity and water will be '
+                'unavailable for several days to weeks after the storm '
+                'passes.'),
             'numeric_default_min': {
                 unit_knots['key']: 95,
                 unit_miles_per_hour['key']: 110,
@@ -774,12 +774,12 @@ cyclone_sshws_hazard_classes = {
             'name': tr('Category 2 (tropical cyclone)'),
             'affected': True,
             'description': tr(
-                    'Extremely dangerous winds will cause extensive damage: '
-                    'Well-constructed frame homes could sustain major roof '
-                    'and siding damage. Many shallowly rooted trees will be '
-                    'snapped or uprooted and block numerous roads. Near-total '
-                    'power loss is expected with outages that could last from '
-                    'several days to weeks.'),
+                'Extremely dangerous winds will cause extensive damage: '
+                'Well-constructed frame homes could sustain major roof '
+                'and siding damage. Many shallowly rooted trees will be '
+                'snapped or uprooted and block numerous roads. Near-total '
+                'power loss is expected with outages that could last from '
+                'several days to weeks.'),
             'numeric_default_min': {
                 unit_knots['key']: 82,
                 unit_miles_per_hour['key']: 95,
@@ -804,13 +804,13 @@ cyclone_sshws_hazard_classes = {
             'name': tr('Category 1 (tropical cyclone)'),
             'affected': False,
             'description': tr(
-                    'Very dangerous winds will produce some damage: '
-                    'Well-constructed frame homes could have damage to roof, '
-                    'shingles, vinyl siding and gutters. Large branches of '
-                    'trees will snap and shallowly rooted trees may be '
-                    'toppled. Extensive damage to power lines and poles '
-                    'likely will result in power outages that could last a '
-                    'few to several days.'),
+                'Very dangerous winds will produce some damage: '
+                'Well-constructed frame homes could have damage to roof, '
+                'shingles, vinyl siding and gutters. Large branches of '
+                'trees will snap and shallowly rooted trees may be '
+                'toppled. Extensive damage to power lines and poles '
+                'likely will result in power outages that could last a '
+                'few to several days.'),
             'numeric_default_min': {
                 unit_knots['key']: 64,
                 unit_miles_per_hour['key']: 74,
@@ -855,7 +855,7 @@ hazard_classification = {
     'key': 'hazard_classification',
     'name': tr('Classes'),
     'description': tr(
-            'Hazard classes are a way to group values.'),
+        'Hazard classes are a way to group values.'),
     'citations': [
         {
             'text': None,

--- a/safe/definitionsv4/hazard_classifications.py
+++ b/safe/definitionsv4/hazard_classifications.py
@@ -93,8 +93,8 @@ volcano_hazard_classes = {
     'key': 'volcano_hazard_classes',
     'name': tr('Volcano classes'),
     'description': tr(
-        'Three classes are supported for volcano vector hazard data: '
-        '<b>low</b>, <b>medium</b>, or <b>high</b>.'),
+            'Three classes are supported for volcano vector hazard data: '
+            '<b>low</b>, <b>medium</b>, or <b>high</b>.'),
     'citations': [
         {
             'text': None,
@@ -160,10 +160,10 @@ flood_hazard_classes = {
     'key': 'flood_hazard_classes',
     'name': tr('Flood classes'),
     'description': tr(
-        'This is a binary description for an area. The area is either '
-        '<b>wet</b> (affected by flood water) or <b>dry</b> (not affected '
-        'by flood water). This unit does not describe how <b>wet</b> or '
-        '<b>dry</b> an area is.'),
+            'This is a binary description for an area. The area is either '
+            '<b>wet</b> (affected by flood water) or <b>dry</b> (not affected '
+            'by flood water). This unit does not describe how <b>wet</b> or '
+            '<b>dry</b> an area is.'),
     'citations': [
         {
             'text': None,
@@ -212,9 +212,9 @@ ash_hazard_classes = {
     'key': 'ash_hazard_classes',
     'name': tr('Ash classes'),
     'description': tr(
-        'Three four are supported for ash vector hazard data: '
-        '<b>very low</b>, <b>low</b>, <b>medium</b>, <b>high</b> or '
-        '<b>very high</b>.'),
+            'Three four are supported for ash vector hazard data: '
+            '<b>very low</b>, <b>low</b>, <b>medium</b>, <b>high</b> or '
+            '<b>very high</b>.'),
     'unit': unit_centimetres,
     'citations': [
         {
@@ -306,16 +306,15 @@ ash_hazard_classes = {
     ]
 }
 
-
 tsunami_hazard_classes = {
     'key': 'tsunami_hazard_classes',
     'name': tr('Tsunami classes'),
     'description': tr(
-        'This is a quinary description for an area. The area is either '
-        '<b>dry</b>, <b>low</b>, <b>medium</b>, <b>high</b>, or '
-        '<b>very high</b> for tsunami hazard classification. '
-        'The following description for these classes is provided by Badan '
-        'Geologi based on BNPB Perka 2/2012'),
+            'This is a quinary description for an area. The area is either '
+            '<b>dry</b>, <b>low</b>, <b>medium</b>, <b>high</b>, or '
+            '<b>very high</b> for tsunami hazard classification. '
+            'The following description for these classes is provided by Badan '
+            'Geologi based on BNPB Perka 2/2012'),
     'citations': [
         {
             'text': None,
@@ -346,16 +345,19 @@ tsunami_hazard_classes = {
             'name': tr('High hazard zone'),
             'affected': True,
             'description': tr(
-                'Water above 3.1m and less than 8.0m. The area is potentially '
-                'hit by a tsunami wave with an inundation depth > 3 m or '
-                'reach a tsunami intensity scale of VII or even more '
-                '(Papadoupulos and Imamura, 2001). Tsunami wave with 4 m '
-                'inundation depth cause damage to small vessel, a few ships '
-                'are drifted inland, severe damage on most wooden houses. '
-                'Boulders are deposited on shore. If tsunami height reaches '
-                '8 m, it will cause severe damage. Dykes, wave breaker, '
-                'tsunami protection walls and green belts will be washed '
-                'away.'),
+                    'Water above 3.1m and less than 8.0m. The area is '
+                    'potentially '
+                    'hit by a tsunami wave with an inundation depth > 3 m or '
+                    'reach a tsunami intensity scale of VII or even more '
+                    '(Papadoupulos and Imamura, 2001). Tsunami wave with 4 m '
+                    'inundation depth cause damage to small vessel, '
+                    'a few ships '
+                    'are drifted inland, severe damage on most wooden houses. '
+                    'Boulders are deposited on shore. If tsunami height '
+                    'reaches '
+                    '8 m, it will cause severe damage. Dykes, wave breaker, '
+                    'tsunami protection walls and green belts will be washed '
+                    'away.'),
             'numeric_default_min': 3,
             'numeric_default_max': 8,
             'citations': [
@@ -372,13 +374,16 @@ tsunami_hazard_classes = {
             'name': tr('Medium hazard zone'),
             'affected': True,
             'description': tr(
-                'Water above 1.1m and less than 3.0m. The area is potentially '
-                'hit by a tsunami wave with an inundation depth of 1 - 3 m or '
-                'equal to V-VI tsunami intensity scale (Papadoupulos and '
-                'Imamura, 2001). Tsunami wave with a 3m inundation depth '
-                'causes most people frightened and to flee to higher ground. '
-                'Small vessels drift and collide. Damage occurs to some '
-                'wooden houses, while most of them are safe.'),
+                    'Water above 1.1m and less than 3.0m. The area is '
+                    'potentially '
+                    'hit by a tsunami wave with an inundation depth of 1 - 3 '
+                    'm or '
+                    'equal to V-VI tsunami intensity scale (Papadoupulos and '
+                    'Imamura, 2001). Tsunami wave with a 3m inundation depth '
+                    'causes most people frightened and to flee to higher '
+                    'ground. '
+                    'Small vessels drift and collide. Damage occurs to some '
+                    'wooden houses, while most of them are safe.'),
             'numeric_default_min': 1,
             'numeric_default_max': 3,
             'citations': [
@@ -395,15 +400,21 @@ tsunami_hazard_classes = {
             'name': tr('Low hazard zone'),
             'affected': False,
             'description': tr(
-                'Water above ground height and less than 1.0m. The area is '
-                'potentially hit by a tsunami wave with an inundation depth '
-                'less than 1 m or similar to tsunami intensity scale of V or '
-                'less in (Papadoupulos and Imamura, 2001). Tsunami wave of 1m '
-                'height causes few people to be frightened and flee to higher '
-                'elevation. Felt by most people on large ship, observed from '
-                'shore. Small vessels drift and collide and some turn over. '
-                'Sand is deposited and there is flooding of areas close to '
-                'the shore.'),
+                    'Water above ground height and less than 1.0m. The area is '
+                    'potentially hit by a tsunami wave with an inundation '
+                    'depth '
+                    'less than 1 m or similar to tsunami intensity scale of V '
+                    'or '
+                    'less in (Papadoupulos and Imamura, 2001). Tsunami wave '
+                    'of 1m '
+                    'height causes few people to be frightened and flee to '
+                    'higher '
+                    'elevation. Felt by most people on large ship, observed '
+                    'from '
+                    'shore. Small vessels drift and collide and some turn '
+                    'over. '
+                    'Sand is deposited and there is flooding of areas close to '
+                    'the shore.'),
             'numeric_default_min': 0.1,
             'numeric_default_max': 1,
             'citations': [
@@ -432,16 +443,17 @@ tsunami_hazard_classes = {
     ]
 }
 
-
 cyclone_au_bom_hazard_classes = {
     'key': 'cyclone_au_bom_hazard_classes',
     'name': tr('Cyclone classes (AU - BOM)'),
     'description': tr(
-        'The quinary <b>tropical cyclone</b> intensity classification '
-        'according to the Australian Bureau of Metereology is defined by the '
-        'maximum mean wind speed over open flat land or water. '
-        'This is sometimes referred to as the maximum sustained wind and will'
-        'be experienced around the eye-wall of the cyclone.'),
+            'The quinary <b>tropical cyclone</b> intensity classification '
+            'according to the Australian Bureau of Metereology is defined by '
+            'the '
+            'maximum mean wind speed over open flat land or water. '
+            'This is sometimes referred to as the maximum sustained wind and '
+            'will'
+            'be experienced around the eye-wall of the cyclone.'),
     'citations': [
         {
             'text': 'Australian Bureau of Metereology - Tropical Cyclone '
@@ -450,7 +462,8 @@ cyclone_au_bom_hazard_classes = {
         },
         {
             'text': 'Tropical cyclone scales - wikpedia',
-            'link': 'https://en.wikipedia.org/wiki/Tropical_cyclone_scales#Australia_and_Fiji'
+            'link': 'https://en.wikipedia.org/wiki/Tropical_cyclone_scales'
+                    '#Australia_and_Fiji'
         }
     ],
     'multiple_units': [unit_miles_per_hour, unit_kilometres_per_hour,
@@ -475,7 +488,7 @@ cyclone_au_bom_hazard_classes = {
                 unit_knots['key']: 107,
                 unit_miles_per_hour['key']: 123,
                 unit_kilometres_per_hour['key']: 198
-                },
+            },
             'numeric_default_max': 9999999999,
             'citations': [
                 {
@@ -503,12 +516,12 @@ cyclone_au_bom_hazard_classes = {
                 unit_knots['key']: 85,
                 unit_miles_per_hour['key']: 98,
                 unit_kilometres_per_hour['key']: 157
-                },
+            },
             'numeric_default_max': {
                 unit_knots['key']: 107,
                 unit_miles_per_hour['key']: 123,
                 unit_kilometres_per_hour['key']: 198
-                },
+            },
             'citations': [
                 {
                     'text': None,
@@ -533,12 +546,12 @@ cyclone_au_bom_hazard_classes = {
                 unit_knots['key']: 63,
                 unit_miles_per_hour['key']: 72,
                 unit_kilometres_per_hour['key']: 117
-                },
+            },
             'numeric_default_max': {
                 unit_knots['key']: 85,
                 unit_miles_per_hour['key']: 98,
                 unit_kilometres_per_hour['key']: 157
-                },
+            },
             'citations': [
                 {
                     'text': None,
@@ -566,12 +579,12 @@ cyclone_au_bom_hazard_classes = {
                 unit_knots['key']: 47,
                 unit_miles_per_hour['key']: 54,
                 unit_kilometres_per_hour['key']: 88
-                },
+            },
             'numeric_default_max': {
                 unit_knots['key']: 63,
                 unit_miles_per_hour['key']: 72,
                 unit_kilometres_per_hour['key']: 117
-                },
+            },
             'citations': [
                 {
                     'text': None,
@@ -597,12 +610,12 @@ cyclone_au_bom_hazard_classes = {
                 unit_knots['key']: 34,
                 unit_miles_per_hour['key']: 39,
                 unit_kilometres_per_hour['key']: 63
-                },
+            },
             'numeric_default_max': {
                 unit_knots['key']: 47,
                 unit_miles_per_hour['key']: 54,
                 unit_kilometres_per_hour['key']: 88
-                },
+            },
             'citations': [
                 {
                     'text': None,
@@ -625,7 +638,7 @@ cyclone_au_bom_hazard_classes = {
                 unit_knots['key']: 34,
                 unit_miles_per_hour['key']: 39,
                 unit_kilometres_per_hour['key']: 63
-                },
+            },
             'citations': [
                 {
                     'text': None,
@@ -636,13 +649,213 @@ cyclone_au_bom_hazard_classes = {
     ]
 }
 
-cyclone_hazard_classes = [cyclone_au_bom_hazard_classes]
+cyclone_sshws_hazard_classes = {
+    'key': 'cyclone_sshws_hazard_classes',
+    'name': tr('Hurricane classes (SSHWS)'),
+    'description': tr(
+            'The <b>Saffir-Simpson Hurricane Wind Scale</b> is a 1 to 5 rating '
+            'based on a hurricane\'s sustained wind speed. This scale '
+            'estimates '
+            'potential property damage. Hurricanes reaching Category 3 and '
+            'higher are considered major hurricanes because of their '
+            'potential for '
+            'significant loss of life and damage. Category 1 and 2 storms are '
+            'still dangerous, however, and require preventative measures. In '
+            'the '
+            'western North Pacific, the term "super typhoon" is used for '
+            'tropical '
+            'cyclones with sustained winds exceeding 150 mph.'),
+    'citations': [
+        {
+            'text': 'NOAA - NHC',
+            'link': 'http://www.nhc.noaa.gov/aboutsshws.php'
+        },
+        {
+            'text': 'Saffir–Simpson scale - wikpedia',
+            'link': 'https://en.wikipedia.org/wiki/Saffir%E2%80%93Simpson_scale'
+        }
+    ],
+    'multiple_units': [unit_miles_per_hour, unit_kilometres_per_hour,
+                       unit_knots],
+    'classes': [
+        {
+            'key': 'category_5',
+            'value': 5,
+            'color': very_dark_red,
+            'name': tr('Category 5 (severe tropical cyclone)'),
+            'affected': True,
+            'description': tr(
+                    'Catastrophic damage will occur: A high percentage of '
+                    'framed homes will be destroyed, with total roof failure '
+                    'and wall collapse. Fallen trees and power poles will '
+                    'isolate residential areas. Power outages will last for '
+                    'weeks to possibly months. Most of the area will be '
+                    'uninhabitable for weeks or months.'
+            ),
+            'numeric_default_min': {
+                unit_knots['key']: 136,
+                unit_miles_per_hour['key']: 156,
+                unit_kilometres_per_hour['key']: 251
+            },
+            'numeric_default_max': 9999999999,
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+        {
+            'key': 'category_4',
+            'value': 4,
+            'color': dark_red,
+            'name': tr('Category 4 (severe tropical cyclone)'),
+            'affected': True,
+            'description': tr(
+                    'Catastrophic damage will occur: Well-built framed homes '
+                    'can sustain severe damage with loss of most of the roof '
+                    'structure and/or some exterior walls. Most trees will be '
+                    'snapped or uprooted and power poles downed. Fallen trees '
+                    'and power poles will isolate residential areas. Power '
+                    'outages will last weeks to possibly months. Most of the '
+                    'area will be uninhabitable for weeks or months.'
+            ),
+            'numeric_default_min': {
+                unit_knots['key']: 112,
+                unit_miles_per_hour['key']: 129,
+                unit_kilometres_per_hour['key']: 208
+            },
+            'numeric_default_max': {
+                unit_knots['key']: 136,
+                unit_miles_per_hour['key']: 156,
+                unit_kilometres_per_hour['key']: 251
+            },
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+        {
+            'key': 'category_3',
+            'value': 3,
+            'color': red,
+            'name': tr('Category 3 (severe tropical cyclone)'),
+            'affected': True,
+            'description': tr(
+                    'Devastating damage will occur: Well-built framed homes '
+                    'may incur major damage or removal of roof decking and '
+                    'gable ends. Many trees will be snapped or uprooted, '
+                    'blocking numerous roads. Electricity and water will be '
+                    'unavailable for several days to weeks after the storm '
+                    'passes.'),
+            'numeric_default_min': {
+                unit_knots['key']: 95,
+                unit_miles_per_hour['key']: 110,
+                unit_kilometres_per_hour['key']: 177
+            },
+            'numeric_default_max': {
+                unit_knots['key']: 112,
+                unit_miles_per_hour['key']: 129,
+                unit_kilometres_per_hour['key']: 208
+            },
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+        {
+            'key': 'category_2',
+            'value': 2,
+            'color': orange,
+            'name': tr('Category 2 (tropical cyclone)'),
+            'affected': True,
+            'description': tr(
+                    'Extremely dangerous winds will cause extensive damage: '
+                    'Well-constructed frame homes could sustain major roof '
+                    'and siding damage. Many shallowly rooted trees will be '
+                    'snapped or uprooted and block numerous roads. Near-total '
+                    'power loss is expected with outages that could last from '
+                    'several days to weeks.'),
+            'numeric_default_min': {
+                unit_knots['key']: 82,
+                unit_miles_per_hour['key']: 95,
+                unit_kilometres_per_hour['key']: 153
+            },
+            'numeric_default_max': {
+                unit_knots['key']: 95,
+                unit_miles_per_hour['key']: 110,
+                unit_kilometres_per_hour['key']: 177
+            },
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+        {
+            'key': 'category_1',
+            'value': 1,
+            'color': yellow,
+            'name': tr('Category 1 (tropical cyclone)'),
+            'affected': False,
+            'description': tr(
+                    'Very dangerous winds will produce some damage: '
+                    'Well-constructed frame homes could have damage to roof, '
+                    'shingles, vinyl siding and gutters. Large branches of '
+                    'trees will snap and shallowly rooted trees may be '
+                    'toppled. Extensive damage to power lines and poles '
+                    'likely will result in power outages that could last a '
+                    'few to several days.'),
+            'numeric_default_min': {
+                unit_knots['key']: 64,
+                unit_miles_per_hour['key']: 74,
+                unit_kilometres_per_hour['key']: 119
+            },
+            'numeric_default_max': {
+                unit_knots['key']: 82,
+                unit_miles_per_hour['key']: 95,
+                unit_kilometres_per_hour['key']: 153
+            },
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+        {
+            'key': 'no_hurricane',
+            'value': 0,
+            'color': green,
+            'name': tr('No hurricane'),
+            'affected': False,
+            'description': tr('Winds less than Category 1 Hurricane'),
+            'numeric_default_min': 0,
+            'numeric_default_max': {
+                unit_knots['key']: 64,
+                unit_miles_per_hour['key']: 74,
+                unit_kilometres_per_hour['key']: 119
+            },
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+    ]
+}
 
 hazard_classification = {
     'key': 'hazard_classification',
     'name': tr('Classes'),
     'description': tr(
-        'Hazard classes are a way to group values.'),
+            'Hazard classes are a way to group values.'),
     'citations': [
         {
             'text': None,
@@ -654,9 +867,10 @@ hazard_classification = {
         flood_hazard_classes,
         tsunami_hazard_classes,
         volcano_hazard_classes,
-        ash_hazard_classes
+        ash_hazard_classes,
+        cyclone_au_bom_hazard_classes,
+        cyclone_sshws_hazard_classes,
     ]
 }
-hazard_classification['types'].extend(cyclone_hazard_classes)
 
 all_hazard_classes = hazard_classification['types']

--- a/safe/definitionsv4/hazard_classifications.py
+++ b/safe/definitionsv4/hazard_classifications.py
@@ -15,7 +15,7 @@ from safe.definitionsv4.colors import (
     orange,
     red,
     dark_red,
-)
+    very_dark_red)
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -421,6 +421,161 @@ tsunami_hazard_classes = {
             'description': tr('No water above ground height.'),
             'numeric_default_min': 0,
             'numeric_default_max': 0.1,
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+    ]
+}
+
+
+cyclone_au_bom_hazard_classes = {
+    'key': 'cyclone_au_bom_hazard_classes',
+    'name': tr('Cyclone classes (AU - BOM)'),
+    'description': tr(
+        'The quinary <b>tropical cyclone</b> intensity classification '
+        'according to the Australian Bureau of Metereology is defined by the '
+        'maximum mean wind speed over open flat land or water. '
+        'This is sometimes referred to as the maximum sustained wind and will'
+        'be experienced around the eye-wall of the cyclone.'),
+    'citations': [
+        {
+            'text': 'Australian Bureau of Metereology - Tropical Cyclone '
+                    'Intensity and Impacts',
+            'link': 'http://www.bom.gov.au/cyclone/about/intensity.shtml#WindC'
+        },
+        {
+            'text': 'Tropical cyclone scales - wikpedia',
+            'link': 'https://en.wikipedia.org/wiki/Tropical_cyclone_scales#Australia_and_Fiji'
+        }
+    ],
+    'classes': [
+        {
+            'key': 'category_5',
+            'value': 5,
+            'color': very_dark_red,
+            'name': tr('Category 5 (severe tropical cyclone)'),
+            'affected': True,
+            'description': tr(
+                'Extremely dangerous with widespread destruction. A Category '
+                '5 cyclone\'s strongest winds are VERY DESTRUCTIVE winds with '
+                'typical gusts over open flat land of more than 151 kn. '
+                'These winds correspond to the highest category on the '
+                'Beaufort scale, Beaufort 12 (Hurricane).'
+            ),
+            'numeric_default_min': 107,
+            'numeric_default_max': 9999999999,
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+        {
+            'key': 'category_4',
+            'value': 4,
+            'color': dark_red,
+            'name': tr('Category 4 (severe tropical cyclone)'),
+            'affected': True,
+            'description': tr(
+                'Significant roofing loss and structural damage. Many '
+                'caravans destroyed and blown away. Dangerous airborne '
+                'debris. Widespread power failures. A Category 4 cyclone\'s'
+                'strongest winds are VERY DESTRUCTIVE winds with typical '
+                'gusts over open flat land of 122 - 151 kn. These winds '
+                'correspond to the highest category on the Beaufort scale, '
+                'Beaufort 12 (Hurricane).'
+            ),
+            'numeric_default_min': 85,
+            'numeric_default_max': 107,
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+        {
+            'key': 'category_3',
+            'value': 3,
+            'color': red,
+            'name': tr('Category 3 (severe tropical cyclone)'),
+            'affected': True,
+            'description': tr(
+                'Some roof and structural damage. Some caravans destroyed. '
+                'Power failures likely. A Category 3 cyclone\'s strongest '
+                'winds are VERY DESTRUCTIVE winds with typical gusts over '
+                'open flat land of 90 - 121 kn. These winds correspond to '
+                'the highest category on the Beaufort scale, Beaufort 12 ('
+                'Hurricane).'),
+            'numeric_default_min': 63,
+            'numeric_default_max': 85,
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+        {
+            'key': 'category_2',
+            'value': 2,
+            'color': orange,
+            'name': tr('Category 2 (tropical cyclone)'),
+            'affected': True,
+            'description': tr(
+                'Minor house damage. Significant damage to signs, trees and '
+                'caravans. Heavy damage to some crops. Risk of power failure. '
+                'Small craft may break moorings. A Category 2 cyclone\'s '
+                'strongest winds are DESTRUCTIVE winds with typical gusts '
+                'over open flat land of 68 - 89 kn. These winds '
+                'correspond to Beaufort 10 and 11 (Storm and violent storm).'),
+            'numeric_default_min': 47,
+            'numeric_default_max': 63,
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+        {
+            'key': 'category_1',
+            'value': 1,
+            'color': yellow,
+            'name': tr('Category 1 (tropical cyclone)'),
+            'affected': False,
+            'description': tr(
+                'Negligible house damage. Damage to some crops, trees and '
+                'caravans. Craft may drag moorings. A Category 1 cyclone\'s '
+                'strongest winds are GALES with typical gusts over open flat '
+                'land of 49 - 67 kn. These winds correspond to Beaufort 8 '
+                'and 9 (Gales and strong gales).'),
+            'numeric_default_min': 34,
+            'numeric_default_max': 47,
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
+        },
+        {
+            'key': 'tropical_depression',
+            'value': 0,
+            'color': green,
+            'name': tr('Tropical Depression'),
+            'affected': False,
+            'description': tr('A tropical depression is a tropical '
+                              'disturbance, that has a clearly defined '
+                              'surface circulation, which has maximum '
+                              'sustained winds of less than 34 kn.'),
+            'numeric_default_min': 0,
+            'numeric_default_max': 34,
             'citations': [
                 {
                     'text': None,

--- a/safe/definitionsv4/hazard_classifications.py
+++ b/safe/definitionsv4/hazard_classifications.py
@@ -603,6 +603,7 @@ hazard_classification = {
         tsunami_hazard_classes,
         volcano_hazard_classes,
         ash_hazard_classes,
+        cyclone_au_bom_hazard_classes
     ]
 }
 

--- a/safe/definitionsv4/test/scripts.py
+++ b/safe/definitionsv4/test/scripts.py
@@ -9,7 +9,8 @@ def generate_field_table():
         print '| --- | ---- | ---------- | ----------- |'
         for i in fields:
             print('| %s | %s | %s | %s |' %
-                   (i['key'], i['name'], i['field_name'], i['description']))
+                  (i['key'], i['name'], i['field_name'], i['description']))
+
 
 if __name__ == '__main__':
     generate_field_table()

--- a/safe/definitionsv4/test/scripts.py
+++ b/safe/definitionsv4/test/scripts.py
@@ -8,7 +8,7 @@ def generate_field_table():
         print '| Key | Name | Field Name | Description |'
         print '| --- | ---- | ---------- | ----------- |'
         for i in fields:
-            print ('| %s | %s | %s | %s |' %
+            print('| %s | %s | %s | %s |' %
                    (i['key'], i['name'], i['field_name'], i['description']))
 
 if __name__ == '__main__':

--- a/safe/definitionsv4/test/test_utilities.py
+++ b/safe/definitionsv4/test/test_utilities.py
@@ -206,8 +206,8 @@ class TestDefinitionsUtilities(unittest.TestCase):
             layer_geometry_polygon,
             layer_geometry_raster
         ]
-        print [x['key'] for x in expected]
-        print [x['key'] for x in allowed_geometries]
+        print[x['key'] for x in expected]
+        print[x['key'] for x in allowed_geometries]
         self.assertEqual(allowed_geometries, expected)
 
     def test_all_default_fields(self):

--- a/safe/definitionsv4/test/test_utilities.py
+++ b/safe/definitionsv4/test/test_utilities.py
@@ -31,6 +31,7 @@ from safe.definitionsv4 import (
     layer_geometry_point,
     layer_geometry_polygon
 )
+from safe.definitionsv4.hazard import hazard_cyclone
 
 from safe.definitionsv4.utilities import (
     definition,
@@ -79,6 +80,7 @@ class TestDefinitionsUtilities(unittest.TestCase):
 
     def test_hazards_for_layer(self):
         """Test for hazards_for_layer"""
+        self.maxDiff = None
         hazards = hazards_for_layer(
             'polygon', 'single_event')
         expected = [
@@ -87,6 +89,7 @@ class TestDefinitionsUtilities(unittest.TestCase):
             hazard_earthquake,
             hazard_volcano,
             hazard_volcanic_ash,
+            hazard_cyclone,
             hazard_generic
         ]
         self.assertItemsEqual(hazards, expected)
@@ -98,6 +101,7 @@ class TestDefinitionsUtilities(unittest.TestCase):
             hazard_earthquake,
             hazard_volcano,
             hazard_volcanic_ash,
+            hazard_cyclone,
             hazard_generic
         ]
         self.assertItemsEqual(hazards, expected)
@@ -110,6 +114,7 @@ class TestDefinitionsUtilities(unittest.TestCase):
             hazard_earthquake,
             hazard_volcanic_ash,
             hazard_volcano,
+            hazard_cyclone,
             hazard_generic
         ]
         self.assertItemsEqual(hazards, expected)

--- a/safe/definitionsv4/units.py
+++ b/safe/definitionsv4/units.py
@@ -55,6 +55,51 @@ unit_kilogram_per_meter_square = {
         }
     ]
 }
+unit_kilometres_per_hour = {
+    'key': 'kilometres_per_hour',
+    'name': tr('km/h'),
+    'plural_name': tr('km/h'),
+    'abbreviation': tr('km/h'),
+    'description': tr(
+        '<b>The kilometre per hour</b> is a unit of speed, expressing the '
+        'number of kilometres covered in one hour.'),
+    'citations': [
+        {
+            'text': None,
+            'link': None
+        }
+    ]
+}
+unit_miles_per_hour = {
+    'key': 'miles_per_hour',
+    'name': tr('mph'),
+    'plural_name': tr('mph'),
+    'abbreviation': tr('mph'),
+    'description': tr(
+        '<b>The mile per hour</b> is a unit of speed, expressing the '
+        'number of statute miles covered in one hour.'),
+    'citations': [
+        {
+            'text': None,
+            'link': None
+        }
+    ]
+}
+unit_knots = {
+    'key': 'knots',
+    'name': tr('kn'),
+    'plural_name': tr('kn'),
+    'abbreviation': tr('kn'),
+    'description': tr(
+        '<b>The knot</b> is a unit of speed, expressing the '
+        'number of nautical miles covered in one hour.'),
+    'citations': [
+        {
+            'text': None,
+            'link': None
+        }
+    ]
+}
 unit_kilometres = {
     'key': 'kilometres',
     'name': tr('Kilometres'),

--- a/safe/gisv4/raster/clip_bounding_box.py
+++ b/safe/gisv4/raster/clip_bounding_box.py
@@ -7,6 +7,7 @@ import processing
 
 from qgis.core import QgsRasterLayer
 
+from safe.common.exceptions import ProcessingAlgError
 from safe.common.utilities import unique_filename, temp_dir
 from safe.definitionsv4.processing_steps import quick_clip_steps
 from safe.utilities.profiling import profile
@@ -75,6 +76,10 @@ def clip_by_extent(layer, extent, callback=None):
         False,
         "",
         output_raster)
+
+    if result is None:
+        raise ProcessingAlgError('It seems like QGIS processing plugin is not '
+                                 'installed')
 
     clipped = QgsRasterLayer(result['OUTPUT'], output_layer_name)
 

--- a/safe/gui/tools/wizard/step_kw25_classification.py
+++ b/safe/gui/tools/wizard/step_kw25_classification.py
@@ -80,9 +80,17 @@ class StepKwClassification(WizardStep, FORM_CLASS):
         subcategory_key = self.parent.step_kw_subcategory.\
             selected_subcategory()['key']
         layer_purpose = self.parent.step_kw_purpose.selected_purpose()
-        if layer_purpose in [
-            layer_purpose_hazard, layer_purpose_exposure]:
-            return get_classifications(subcategory_key)
+        if layer_purpose in [layer_purpose_hazard, layer_purpose_exposure]:
+            classifications = []
+            selected_unit = self.parent.step_kw_unit.selected_unit()
+            for classification in get_classifications(subcategory_key):
+                if 'multiple_units' in classification:
+                    if selected_unit in classification['multiple_units']:
+                        classifications.append(classification)
+                else:
+                    classifications.append(classification)
+
+            return classifications
         else:
             # There are no classifications for non exposure and hazard
             # defined yet

--- a/safe/gui/tools/wizard/step_kw25_classification.py
+++ b/safe/gui/tools/wizard/step_kw25_classification.py
@@ -84,10 +84,9 @@ class StepKwClassification(WizardStep, FORM_CLASS):
             classifications = []
             selected_unit = self.parent.step_kw_unit.selected_unit()
             for classification in get_classifications(subcategory_key):
-                if 'multiple_units' in classification:
-                    if selected_unit in classification['multiple_units']:
-                        classifications.append(classification)
-                else:
+                if 'multiple_units' not in classification:
+                    classifications.append(classification)
+                elif selected_unit in classification['multiple_units']:
                     classifications.append(classification)
 
             return classifications

--- a/safe/gui/tools/wizard/step_kw43_threshold.py
+++ b/safe/gui/tools/wizard/step_kw43_threshold.py
@@ -142,6 +142,7 @@ class StepKwThreshold(WizardStep, FORM_CLASS):
         self.lblThreshold.setText(text)
 
         thresholds = self.parent.get_existing_keyword('thresholds')
+        selected_unit = self.parent.step_kw_unit.selected_unit()['key']
 
         self.classes = OrderedDict()
         classes = classification.get('classes')
@@ -162,7 +163,10 @@ class StepKwThreshold(WizardStep, FORM_CLASS):
             if thresholds.get(the_class['key']):
                 min_value_input.setValue(thresholds[the_class['key']][0])
             else:
-                min_value_input.setValue(the_class['numeric_default_min'])
+                default_min = the_class['numeric_default_min']
+                if isinstance(default_min, dict):
+                    default_min = the_class['numeric_default_min'][selected_unit]
+                min_value_input.setValue(default_min)
             min_value_input.setSingleStep(0.1)
             min_value_input.setMinimum(min_value_layer)
             min_value_input.setMaximum(max_value_layer)
@@ -175,7 +179,10 @@ class StepKwThreshold(WizardStep, FORM_CLASS):
             if thresholds.get(the_class['key']):
                 max_value_input.setValue(thresholds[the_class['key']][1])
             else:
-                max_value_input.setValue(the_class['numeric_default_max'])
+                default_max = the_class['numeric_default_max']
+                if isinstance(default_max, dict):
+                    default_max = the_class['numeric_default_max'][selected_unit]
+                max_value_input.setValue(default_max)
             max_value_input.setSingleStep(0.1)
             max_value_input.setMinimum(min_value_layer)
             max_value_input.setMaximum(max_value_layer)

--- a/safe/gui/tools/wizard/step_kw43_threshold.py
+++ b/safe/gui/tools/wizard/step_kw43_threshold.py
@@ -165,7 +165,8 @@ class StepKwThreshold(WizardStep, FORM_CLASS):
             else:
                 default_min = the_class['numeric_default_min']
                 if isinstance(default_min, dict):
-                    default_min = the_class['numeric_default_min'][selected_unit]
+                    default_min = the_class[
+                        'numeric_default_min'][selected_unit]
                 min_value_input.setValue(default_min)
             min_value_input.setSingleStep(0.1)
             min_value_input.setMinimum(min_value_layer)
@@ -181,7 +182,8 @@ class StepKwThreshold(WizardStep, FORM_CLASS):
             else:
                 default_max = the_class['numeric_default_max']
                 if isinstance(default_max, dict):
-                    default_max = the_class['numeric_default_max'][selected_unit]
+                    default_max = the_class[
+                        'numeric_default_max'][selected_unit]
                 max_value_input.setValue(default_max)
             max_value_input.setSingleStep(0.1)
             max_value_input.setMinimum(min_value_layer)

--- a/safe/gui/tools/wizard/wizard_strings.py
+++ b/safe/gui/tools/wizard/wizard_strings.py
@@ -101,6 +101,12 @@ tephra_kgm2_question = tr(
     'tephra intensity in kg/m<sup>2</sup>')
 volcano_volcano_categorical_question = tr(
     'volcano hazard categorical level')
+cyclone_kilometres_per_hour_question = tr(
+    'wind speed in km/h')
+cyclone_miles_per_hour_question = tr(
+    'wind speed in mph')
+cyclone_knots_question = tr(
+    'wind speed in kn')
 population_count_question = tr(
     'the number of people')
 population_density_question = tr(

--- a/scripts/create_api_docs.py
+++ b/scripts/create_api_docs.py
@@ -133,7 +133,7 @@ def write_rst_file(file_directory, file_name, content):
         fl.close()
 
     except Exception, e:
-        print ('Creating %s failed' % os.path.join(
+        print('Creating %s failed' % os.path.join(
             file_directory, file_name + '.rst'), e)
 
 


### PR DESCRIPTION
This PR adds tropical cyclone support and multi unit hazard classifications. 

Tropical Cyclone is a metadata based impact calculation that classifies impacted building.
Classification can be done using the  Saffir–Simpson hurricane wind scale, the Australian Bureau of Metereology Tropical Cyclone or a generic high-medium-low scale 

Each classification can have default values in different units. to do this, add `'multiple_units': [unit_miles_per_hour, unit_kilometres_per_hour, unit_knots],` to the classification and 
```
'numeric_default_min': {
               unit_knots['key']: 107,
               unit_miles_per_hour['key']: 123,
               unit_kilometres_per_hour['key']: 198
           },
'numeric_default_max': 9999999999,
           'citations': [
               {
                   'text': None,
                   'link': None
               }
```
if a value is common to all units (for example 0 or 99999999), you can simply put it once.

This PR also adds three new units (Knots, kmh and mph) and a new color (very_dark_red)