### PR TITLE
Fix key error when name is not in the definitions.

### DIFF
--- a/safe/gui/tools/help/definitions_help.py
+++ b/safe/gui/tools/help/definitions_help.py
@@ -9,7 +9,10 @@ INFO_STYLE = styles.INFO_STYLE
 WARNING_STYLE = styles.WARNING_STYLE
 SMALL_ICON_STYLE = styles.SMALL_ICON_STYLE
 
-__author__ = 'timlinux'
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
 
 
 def definitions_help():
@@ -139,7 +142,7 @@ def definition_to_message(definition, heading_style=None):
     message.add(m.HorizontalRule())
     message.add(header)
     message.add(m.Paragraph(definition['description']))
-    # types containses e.g. hazard_all
+    # types contains e.g. hazard_all
     if 'types' in definition:
         for sub_definition in definition['types']:
             message.add(definition_to_message(

--- a/safe/gui/tools/help_dialog.py
+++ b/safe/gui/tools/help_dialog.py
@@ -1,22 +1,5 @@
 # coding=utf-8
-"""
-InaSAFE Disaster risk assessment tool developed by AusAid - **About Dialog.**
-
-Contact : ole.moller.nielsen@gmail.com
-
-.. note:: This program is free software; you can redistribute it and/or modify
-     it under the terms of the GNU General Public License as published by
-     the Free Software Foundation; either version 2 of the License, or
-     (at your option) any later version.
-
-.. todo:: Check raster is single band
-
-"""
-__author__ = 'ismail@kartoza.com'
-__revision__ = '$Format:%H$'
-__date__ = '28/09/2015'
-__copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
-                 'Disaster Reduction')
+"""Help Dialog."""
 
 # This import is to enable SIP API V2
 # noinspection PyUnresolvedReferences
@@ -29,6 +12,11 @@ from safe.gui.tools.help.dock_help import dock_help
 
 FORM_CLASS = get_ui_class('help_dialog_base.ui')
 
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
+
 
 class HelpDialog(QtGui.QDialog, FORM_CLASS):
     """About dialog for the InaSAFE plugin."""
@@ -37,7 +25,7 @@ class HelpDialog(QtGui.QDialog, FORM_CLASS):
         """Constructor for the dialog.
 
         :param message: An optional message object to display in the dialog.
-        :type message: Message
+        :type message: Message.Message
 
         :param parent: Parent widget of this dialog
         :type parent: QWidget

--- a/safe/plugin.py
+++ b/safe/plugin.py
@@ -1,21 +1,5 @@
 # coding=utf-8
-"""
-InaSAFE Disaster risk assessment tool by AusAid **QGIS plugin implementation.**
-
-Contact : ole.moller.nielsen@gmail.com
-
-.. note:: This program is free software; you can redistribute it and/or modify
-     it under the terms of the GNU General Public License as published by
-     the Free Software Foundation; either version 2 of the License, or
-     (at your option) any later version.
-
-"""
-
-__author__ = 'tim@kartoza.com'
-__revision__ = '$Format:%H$'
-__date__ = '10/01/2011'
-__copyright__ = 'Copyright 2012, Australia Indonesia Facility for '
-__copyright__ += 'Disaster Reduction'
+"""InaSAFE Plugin"""
 
 import sys
 import os
@@ -53,6 +37,11 @@ from safe.common.exceptions import TranslationLoadError
 from safe.utilities.resources import resources_path
 from safe.utilities.gis import is_raster_layer
 LOGGER = logging.getLogger('InaSAFE')
+
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
 
 
 class Plugin(object):
@@ -581,7 +570,8 @@ class Plugin(object):
         separator.setSeparator(True)
         self.iface.addPluginToMenu(self.tr('InaSAFE'), separator)
 
-    def clear_modules(self):
+    @staticmethod
+    def clear_modules():
         """Unload inasafe functions and try to return QGIS to before InaSAFE.
 
         .. todo:: I think this function can be removed. TS.

--- a/safe/utilities/keyword_io.py
+++ b/safe/utilities/keyword_io.py
@@ -415,7 +415,12 @@ class KeywordIO(QObject):
             keyword_definition = self.tr(keyword.capitalize().replace(
                 '_', ' '))
         else:
-            keyword_definition = keyword_definition['name']
+            try:
+                keyword_definition = keyword_definition['name']
+            except KeyError:
+                # Handling if name is not exist.
+                keyword_definition = keyword_definition['key'].capitalize()
+                keyword_definition = keyword_definition.replace('_', ' ')
 
         # We deal with some special cases first:
 


### PR DESCRIPTION
For fixing this error:

```
Problem

The following problem(s) were encountered whilst running the analysis.

KeyError
Suggestion

You can try the following to resolve the issue:

Check that you have the latest version of InaSAFE installed - you may have encountered a bug that is fixed in a subsequent release.
Check the InaSAFE documentation to see if you are trying to do something unsupported.
Report the problem using the issue tracker at https://github.com/inasafe/inasafe/issues. Reporting an issue requires that you first create a free account at http://github.com. When you report the issue, please copy and paste the complete contents of this panel into the issue to ensure the best possible chance of getting your issue resolved.
Try contacting one of the InaSAFE development team by sending an email to info@inasafe.org. Please ensure that you copy and paste the complete contents of this panel into the email.
Details

These additional details were reported when the problem occurred.

name
Diagnostics

In file "/Users/ismailsunni/.qgis2/python/plugins/inasafe/safe/gui/widgets/dock.py", line 1018, in layer_changed self.show_generic_keywords(layer)
In file "/Users/ismailsunni/.qgis2/python/plugins/inasafe/safe/gui/widgets/dock.py", line 966, in show_generic_keywords message = keywords.to_message()
In file "/Users/ismailsunni/.qgis2/python/plugins/inasafe/safe/utilities/keyword_io.py", line 346, in to_message row = self._keyword_to_row(keyword, value)
In file "/Users/ismailsunni/.qgis2/python/plugins/inasafe/safe/utilities/keyword_io.py", line 418, in _keyword_to_row keyword_definition = keyword_definition['name']
```

And code standards.