### PR TITLE
Skip inasafe-field step when there is no field found #3555

### DIFF
--- a/safe/gui/tools/wizard/step_kw40_classify.py
+++ b/safe/gui/tools/wizard/step_kw40_classify.py
@@ -23,7 +23,8 @@ from osgeo.gdalconst import GA_ReadOnly
 
 from safe.definitionsv4.layer_purposes import layer_purpose_aggregation
 from safe.definitionsv4.layer_geometry import layer_geometry_raster
-from safe.definitionsv4.utilities import get_fields
+from safe.definitionsv4.utilities import get_fields, get_compulsory_fields
+from safe.definitionsv4.constants import no_field
 from safe.gui.tools.wizard.wizard_step import WizardStep
 from safe.gui.tools.wizard.wizard_step import get_wizard_step_ui_class
 from safe.gui.tools.wizard.wizard_strings import (
@@ -77,20 +78,30 @@ class StepKwClassify(WizardStep, FORM_CLASS):
         else:
             subcategory = {'key': None}
 
-        # Check if it can go to inasafe field step
+        # Get all fields with replace_null = False
         inasafe_fields = get_fields(
             layer_purpose['key'], subcategory['key'], replace_null=False)
-        if inasafe_fields:
+        # remove compulsory field since it has been set in previous step
+        try:
+            inasafe_fields.remove(get_compulsory_fields(
+                layer_purpose['key'], subcategory['key']))
+        except ValueError:
+            pass
+
+        # Check if possible to skip inasafe field step
+        if self.skip_inasafe_field(inasafe_fields):
+            default_inasafe_fields = get_fields(
+                layer_purpose['key'], subcategory['key'], replace_null=True)
+            # Check if it can go to inasafe default step
+            if default_inasafe_fields:
+                return self.parent.step_kw_default_inasafe_fields
+            # Else, go to source step
+            else:
+                return self.parent.step_kw_source
+
+        # If not possible to skip inasafe field step, then go there
+        else:
             return self.parent.step_kw_inasafe_fields
-
-        # Check if it can go to inasafe default field step
-        default_inasafe_fields = get_fields(
-            layer_purpose['key'], subcategory['key'], replace_null=True)
-        if default_inasafe_fields:
-            return self.parent.step_kw_default_inasafe_fields
-
-        # Any other case
-        return self.parent.step_kw_source
 
     # noinspection PyMethodMayBeStatic
     def update_dragged_item_flags(self, item, column):
@@ -302,3 +313,23 @@ class StepKwClassify(WizardStep, FORM_CLASS):
                     QtCore.Qt.ItemIsDragEnabled)
                 tree_leaf.setData(0, QtCore.Qt.UserRole, value)
                 tree_leaf.setText(0, string_value)
+
+    def skip_inasafe_field(self, inasafe_fields):
+        """Check if it possible to skip inasafe field step.
+
+        The function will check if the layer has a specified field type.
+
+        :return: boolean. True if there are no specified field type.
+        """
+        layer_data_provider = self.parent.layer.dataProvider()
+        # Iterate through all inasafe fields
+        for inasafe_field in inasafe_fields:
+            for field in layer_data_provider.fields():
+                # Check the field type
+                if isinstance(inasafe_field['type'], list):
+                    if field.type() in inasafe_field['type']:
+                        return False
+                else:
+                    if field.type() == inasafe_field['type']:
+                        return False
+        return True

--- a/safe/gui/tools/wizard/test/test_keyword_wizard.py
+++ b/safe/gui/tools/wizard/test/test_keyword_wizard.py
@@ -18,7 +18,8 @@ from safe.definitionsv4.layer_modes import (
     layer_mode_continuous, layer_mode_classified)
 from safe.definitionsv4.layer_purposes import (
     layer_purpose_hazard, layer_purpose_exposure, layer_purpose_aggregation)
-from safe.definitionsv4.hazard import hazard_volcano, hazard_flood
+from safe.definitionsv4.hazard import (
+    hazard_volcano, hazard_flood, hazard_earthquake)
 from safe.definitionsv4.exposure import exposure_structure, exposure_population
 from safe.definitionsv4.hazard_category import hazard_category_multiple_event
 from safe.definitionsv4.hazard_classifications import (
@@ -289,7 +290,7 @@ class TestKeywordWizard(unittest.TestCase):
         # Click next to finish title step and go to kw summary step
         dialog.pbnNext.click()
 
-        # Check if in title step
+        # Check if in summary step
         self.check_current_step(dialog.step_kw_summary)
 
         # Click finish
@@ -312,6 +313,153 @@ class TestKeywordWizard(unittest.TestCase):
             'value_map': assigned_values,
             'date': source_date,
             'classification': volcano_hazard_classes['key'],
+            'layer_geometry': layer_geometry_polygon['key'],
+            'layer_purpose': layer_purpose_hazard['key'],
+            'layer_mode': layer_mode_classified['key']
+        }
+
+        real_keywords = dialog.get_keywords()
+        self.assertDictEqual(real_keywords, expected_keyword)
+
+    def test_layer_without_inasafe_fields(self):
+        """Test keyword wizard for layer without inasafe fields."""
+        # cloning layer that has no inasafe fields
+        layer = load_test_vector_layer(
+            'hazard', 'classified_generic_polygon.shp', clone=True)
+
+        # noinspection PyTypeChecker
+        dialog = WizardDialog()
+        dialog.set_keywords_creation_mode(layer)
+
+        # check if in select purpose step
+        self.check_current_step(dialog.step_kw_purpose)
+
+        # Select hazard
+        self.select_from_list_widget(
+            layer_purpose_hazard['name'], dialog.step_kw_purpose.lstCategories)
+
+        # Click next to select hazard
+        dialog.pbnNext.click()
+
+        # Check if in select hazard step
+        self.check_current_step(dialog.step_kw_subcategory)
+
+        # select earthquake
+        self.select_from_list_widget(
+            hazard_earthquake['name'],
+            dialog.step_kw_subcategory.lstSubcategories)
+
+        # Click next to select earthquake
+        dialog.pbnNext.click()
+
+        # Check if in select hazard category step
+        self.check_current_step(dialog.step_kw_hazard_category)
+
+        # select multiple event
+        self.select_from_list_widget(
+            hazard_category_multiple_event['name'],
+            dialog.step_kw_hazard_category.lstHazardCategories)
+
+        # Click next to select multiple event
+        dialog.pbnNext.click()
+
+        # Check if in select layer mode step
+        self.check_current_step(dialog.step_kw_layermode)
+
+        # select classified mode
+        self.select_from_list_widget(
+            layer_mode_classified['name'],
+            dialog.step_kw_layermode.lstLayerModes)
+
+        # Click next to select classified
+        dialog.pbnNext.click()
+
+        # Check if in select classification step
+        self.check_current_step(dialog.step_kw_classification)
+
+        # select generic hazard classification
+        self.select_from_list_widget(
+            generic_hazard_classes['name'],
+            dialog.step_kw_classification.lstClassifications)
+
+        # Click next to select generic hazard classification
+        dialog.pbnNext.click()
+
+        # Check if in select field step
+        self.check_current_step(dialog.step_kw_field)
+
+        # select h_zone field
+        self.select_from_list_widget(
+            'h_zone',
+            dialog.step_kw_field.lstFields)
+
+        # Click next to select h_zone
+        dialog.pbnNext.click()
+
+        # Check if in classify step
+        self.check_current_step(dialog.step_kw_classify)
+
+        # select value map
+        classification = dialog.step_kw_classification.\
+            selected_classification()
+        default_classes = classification['classes']
+        unassigned_values = []  # no need to check actually, not save in file
+        assigned_values = {
+            'low' : ['Low Hazard Zone'],
+            'medium' : ['Medium Hazard Zone'],
+            'high' : ['High hazard Zone']
+        }
+        dialog.step_kw_classify.populate_classified_values(
+            unassigned_values, assigned_values, default_classes)
+
+        # Click next to finish value mapping
+        dialog.pbnNext.click()
+
+        # Check if in source step
+        self.check_current_step(dialog.step_kw_source)
+
+        # Fill source form
+        dialog.step_kw_source.leSource.setText(source)
+        dialog.step_kw_source.leSource_scale.setText(source_scale)
+        dialog.step_kw_source.leSource_url.setText(source_url)
+        dialog.step_kw_source.ckbSource_date.setChecked(True)
+        dialog.step_kw_source.dtSource_date.setDateTime(source_date)
+        dialog.step_kw_source.leSource_license.setText(source_license)
+
+        # Click next to finish source step and go to title step
+        dialog.pbnNext.click()
+
+        # Check if in title step
+        self.check_current_step(dialog.step_kw_title)
+
+        # Fill title form
+        dialog.step_kw_title.leTitle.setText(layer_title)
+
+        # Click next to finish title step and go to summary step
+        dialog.pbnNext.click()
+
+        # Check if in summary step
+        self.check_current_step(dialog.step_kw_summary)
+
+        # Click finish
+        dialog.pbnNext.click()
+
+        # Checking keyword created
+        expected_keyword = {
+            'scale': source_scale,
+            'hazard_category': hazard_category_multiple_event['key'],
+            'license': source_license,
+            'source': source,
+            'url': source_url,
+            'title': layer_title,
+            'hazard': hazard_earthquake['key'],
+            'inasafe_fields':
+                {
+                    hazard_value_field['key']: u'h_zone'
+                },
+            'value_map': assigned_values,
+            'date': source_date,
+            'classification': generic_hazard_classes['key'],
             'layer_geometry': layer_geometry_polygon['key'],
             'layer_purpose': layer_purpose_hazard['key'],
             'layer_mode': layer_mode_classified['key']


### PR DESCRIPTION
issue #3555
- add inasafe_field_for_the_layer function
- add condition to check if there are any fields on layer-purpose that can be the inasafe-field. if nothing were found, skip the inasafe-field step and set the next step to source step.