### PR TITLE
Implementation of earthquake impact calculation

### DIFF
--- a/safe/definitionsv4/processing_steps.py
+++ b/safe/definitionsv4/processing_steps.py
@@ -114,6 +114,12 @@ quick_clip_steps = {
     'output_layer_name': '%s_clipped_bbox',
 }
 
+rasterize_steps = {
+    'step_name': tr('Rasterize'),
+    'output_layer_name': '%s_rasterized',
+    'gdal_layer_name': 'rasterize'
+}
+
 reclassify_raster_steps = {
     'step_name': tr('Reclassifying'),
     'output_layer_name': '%s_reclassified',

--- a/safe/gisv4/raster/rasterize.py
+++ b/safe/gisv4/raster/rasterize.py
@@ -1,0 +1,40 @@
+
+from qgis.core import QgsRasterLayer
+
+from processing.core.Processing import Processing
+
+from safe.common.utilities import unique_filename
+
+
+def rasterize_vector_layer(layer, attr_name, width, height, extent):
+    """Rasterize a vector layer to the grid given by extent and
+    width/height of the output raster."""
+
+    output_filename = unique_filename(prefix='rasterized', suffix='.tif')
+
+    extent_str = "%f,%f,%f,%f" % (extent.xMinimum(), extent.xMaximum(),
+                                  extent.yMinimum(), extent.yMaximum())
+    Processing.runAlgorithm("gdalogr:rasterize", None,
+                            layer,
+                            attr_name,
+                            0,      # output size is given in pixels
+                            width,
+                            height,
+                            extent_str,
+                            False,  # force generation of ESRI TFW
+                            # advanced options
+                            1,      # raster type: Int16
+                            '-1',   # nodata value
+                            4,      # GeoTIFF compression: DEFLATE
+                            75,     # JPEG compression level: 75
+                            6,      # DEFLATE compression level
+                            1,      # predictor for JPEG/DEFLATE
+                            False,  # Tiled GeoTIFF?
+                            0,      # whether to make big TIFF
+                            '',     # additional creation parameters
+                            # output
+                            output_filename)
+
+    layer_aligned = QgsRasterLayer(output_filename, "rasterized", "gdal")
+    assert layer_aligned.isValid()
+    return layer_aligned

--- a/safe/gisv4/raster/rasterize.py
+++ b/safe/gisv4/raster/rasterize.py
@@ -1,40 +1,72 @@
+# coding=utf-8
 
 from qgis.core import QgsRasterLayer
 
 from processing.core.Processing import Processing
 
 from safe.common.utilities import unique_filename
+from safe.definitionsv4.processing_steps import rasterize_steps
+
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
 
 
-def rasterize_vector_layer(layer, attr_name, width, height, extent):
+def rasterize_vector_layer(layer, attribute_name, width, height, extent):
     """Rasterize a vector layer to the grid given by extent and
-    width/height of the output raster."""
+    width/height of the output raster.
 
-    output_filename = unique_filename(prefix='rasterized', suffix='.tif')
+    :param layer: The vector layer.
+    :type layer: QgsVectorLayer
 
-    extent_str = "%f,%f,%f,%f" % (extent.xMinimum(), extent.xMaximum(),
+    :param attribute_name: The attribute name to be created.
+    :type attribute_name: basestring
+
+    :param width: The width of the output.
+    :type width: int
+
+    :param height: The height of the output.
+    :type height: int
+
+    :param extent: The extent to use.
+    :type extent: QgsRectangle
+
+    :return: The new raster layer.
+    :rtype: QgsRasterLayer
+    """
+
+    output_filename = unique_filename(
+        prefix=rasterize_steps['gdal_layer_name'], suffix='.tif')
+
+    extent_str = '%f,%f,%f,%f' % (extent.xMinimum(), extent.xMaximum(),
                                   extent.yMinimum(), extent.yMaximum())
-    Processing.runAlgorithm("gdalogr:rasterize", None,
-                            layer,
-                            attr_name,
-                            0,      # output size is given in pixels
-                            width,
-                            height,
-                            extent_str,
-                            False,  # force generation of ESRI TFW
-                            # advanced options
-                            1,      # raster type: Int16
-                            '-1',   # nodata value
-                            4,      # GeoTIFF compression: DEFLATE
-                            75,     # JPEG compression level: 75
-                            6,      # DEFLATE compression level
-                            1,      # predictor for JPEG/DEFLATE
-                            False,  # Tiled GeoTIFF?
-                            0,      # whether to make big TIFF
-                            '',     # additional creation parameters
-                            # output
-                            output_filename)
+    Processing.runAlgorithm(
+        'gdalogr:rasterize',
+        None,
+        layer,
+        attribute_name,
+        0,      # output size is given in pixels
+        width,
+        height,
+        extent_str,
+        False,  # force generation of ESRI TFW
+        # advanced options
+        1,      # raster type: Int16
+        '-1',   # nodata value
+        4,      # GeoTIFF compression: DEFLATE
+        75,     # JPEG compression level: 75
+        6,      # DEFLATE compression level
+        1,      # predictor for JPEG/DEFLATE
+        False,  # Tiled GeoTIFF?
+        0,      # whether to make big TIFF
+        '',     # additional creation parameters
+        # output
+        output_filename)
 
-    layer_aligned = QgsRasterLayer(output_filename, "rasterized", "gdal")
+    layer_aligned = QgsRasterLayer(
+        output_filename, rasterize_steps['output_layer_name'], 'gdal')
+
     assert layer_aligned.isValid()
+
     return layer_aligned

--- a/safe/gisv4/raster/write_raster.py
+++ b/safe/gisv4/raster/write_raster.py
@@ -1,50 +1,93 @@
+# coding=utf-8
 
 import numpy
 from osgeo import gdal
 
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
 
-def array_to_raster_raw(array, dst_filename, top_left, pixel_size, wkt_projection):
-    """Save a raster TIF file from a numpy array.
 
-    :param array: array with data
-    :param dst_filename: where to store the raster
-    :param top_left: tuple (x,y) of top-left point in map units
-    :param pixel_size: size of pixel in map units
-    :param wkt_projection: WKT string of the raster's CRS
+def array_to_raster_raw(
+        array, destination_filename, top_left, pixel_size, wkt_projection):
+    """Save a raster TIF file from a numpy array using GDAL.
+
+    :param array: Array with data.
+    :type array: numpy.array
+
+    :param destination_filename: where to store the raster.
+    :type destination_filename: basestring
+
+    :param top_left: tuple (x,y) of top-left point in map units.
+    :type top_left: tuple
+
+    :param pixel_size: size of pixel in map units.
+    :type pixel_size: int
+
+    :param wkt_projection: WKT string of the raster's CRS.
+    :type wkt_projection: basestring
+
+    :return: The new GDAL dataset.
+    :rtype: GDALDataset
     """
     raster_size = array.shape[1], array.shape[0]
 
     driver = gdal.GetDriverByName('GTiff')
 
     dataset = driver.Create(
-        dst_filename,
+        destination_filename,
         raster_size[0],
         raster_size[1],
         1,
         gdal.GDT_Float32, )
 
-    dataset.SetGeoTransform((top_left[0], pixel_size, 0,
-                             top_left[1], 0, -pixel_size))
+    dataset.SetGeoTransform(
+        (top_left[0], pixel_size, 0, top_left[1], 0, -pixel_size))
     dataset.SetProjection(wkt_projection)
     dataset.GetRasterBand(1).WriteArray(array)
     dataset.FlushCache()  # Write to disk.
     return dataset
 
 
-def array_to_raster(array, dst_filename, other_layer):
+def array_to_raster(array, destination_filename, other_layer):
     """Save a raster TIF file from a numpy array.
-    The geo metadata will be the same as the other given QGIS raster layer."""
+
+    The geo metadata will be the same as the other given QGIS raster layer.
+
+    :param array: The array to write.
+    :type array: numpy.array
+
+    :param destination_filename: The destination file name.
+    :type destination_filename: basestring
+
+    :param other_layer: The other layer.
+    :type other_layer: QgsRasterLayer
+    """
 
     provider = other_layer.dataProvider()
-    assert provider.xSize() == array.shape[1] and provider.ySize() == array.shape[0]
-    top_left = (other_layer.extent().xMinimum(),
-                other_layer.extent().yMaximum())
+    assert provider.xSize() == array.shape[1]
+    assert provider.ySize() == array.shape[0]
+    top_left = (
+        other_layer.extent().xMinimum(), other_layer.extent().yMaximum())
     pixel_size = other_layer.extent().width() / provider.xSize()
     wkt_projection = str(other_layer.crs().toWkt())
-    return array_to_raster_raw(array, dst_filename, top_left, pixel_size, wkt_projection)
+    raster = array_to_raster_raw(
+        array, destination_filename, top_left, pixel_size, wkt_projection)
+    return raster
 
 
 def make_array(width, height):
-    """Create a numpy array we can later use in array_to_raster() method."""
+    """Create a numpy array we can later use in array_to_raster() method.
+
+    :param width: The width.
+    :type width: int
+
+    :param height: The height.
+    :type height: int
+
+    :return: The empty numpy array with zeros.
+    :rtype: numpy.array
+    """
     # numpy indexing order is rows, cols
     return numpy.zeros((height, width))

--- a/safe/gisv4/raster/write_raster.py
+++ b/safe/gisv4/raster/write_raster.py
@@ -1,0 +1,50 @@
+
+import numpy
+from osgeo import gdal
+
+
+def array_to_raster_raw(array, dst_filename, top_left, pixel_size, wkt_projection):
+    """Save a raster TIF file from a numpy array.
+
+    :param array: array with data
+    :param dst_filename: where to store the raster
+    :param top_left: tuple (x,y) of top-left point in map units
+    :param pixel_size: size of pixel in map units
+    :param wkt_projection: WKT string of the raster's CRS
+    """
+    raster_size = array.shape[1], array.shape[0]
+
+    driver = gdal.GetDriverByName('GTiff')
+
+    dataset = driver.Create(
+        dst_filename,
+        raster_size[0],
+        raster_size[1],
+        1,
+        gdal.GDT_Float32, )
+
+    dataset.SetGeoTransform((top_left[0], pixel_size, 0,
+                             top_left[1], 0, -pixel_size))
+    dataset.SetProjection(wkt_projection)
+    dataset.GetRasterBand(1).WriteArray(array)
+    dataset.FlushCache()  # Write to disk.
+    return dataset
+
+
+def array_to_raster(array, dst_filename, other_layer):
+    """Save a raster TIF file from a numpy array.
+    The geo metadata will be the same as the other given QGIS raster layer."""
+
+    provider = other_layer.dataProvider()
+    assert provider.xSize() == array.shape[1] and provider.ySize() == array.shape[0]
+    top_left = (other_layer.extent().xMinimum(),
+                other_layer.extent().yMaximum())
+    pixel_size = other_layer.extent().width() / provider.xSize()
+    wkt_projection = str(other_layer.crs().toWkt())
+    return array_to_raster_raw(array, dst_filename, top_left, pixel_size, wkt_projection)
+
+
+def make_array(width, height):
+    """Create a numpy array we can later use in array_to_raster() method."""
+    # numpy indexing order is rows, cols
+    return numpy.zeros((height, width))

--- a/safe/impact_function/earthquake.py
+++ b/safe/impact_function/earthquake.py
@@ -1,0 +1,297 @@
+
+from qgis.core import (
+    QGis,
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsFeature,
+    QgsField,
+    QgsFields,
+    QgsGeometry,
+    QgsRasterLayer,
+    QgsVectorLayer,
+    QgsVectorFileWriter,
+)
+
+from PyQt4.QtCore import QVariant
+
+from safe.gis.numerics import log_normal_cdf
+from safe.gisv4.raster.align import align_rasters
+from safe.gisv4.raster.write_raster import array_to_raster, make_array
+from safe.gisv4.raster.rasterize import rasterize_vector_layer
+from safe.common.utilities import unique_filename
+
+
+def itb_fatality_rates():
+    """ITB method to compute fatality rate.
+    """
+    # As per email discussion with Ole, Trevor, Hadi, mmi < 4 will have
+    # a fatality rate of 0 - Tim
+    mmi_range = range(2, 11)
+    # Model coefficients
+    x = 0.62275231
+    y = 8.03314466
+    fatality_rate = {mmi: 0 if mmi < 4 else 10 ** (x * mmi - y)
+                     for mmi in mmi_range}
+    return fatality_rate
+
+
+def pager_fatality_rates():
+    """Pager method to compute fatality rate.
+
+    :returns: Fatality rate calculated as:
+        lognorm.cdf(mmi, shape=Beta, scale=Theta)
+    :rtype: dic
+    """
+    # Model coefficients
+    theta = 13.249
+    beta = 0.151
+    mmi_range = range(2, 11)
+    fatality_rate = {mmi: 0 if mmi < 4 else log_normal_cdf(
+        mmi, median=theta, sigma=beta) for mmi in mmi_range}
+    return fatality_rate
+
+
+def bayesian_fatality_rates():
+    """Fatality rate by MMI from Bayesian approach.
+
+    :returns: Fatality rates as medians from worden_berngamma_log_fat_rate_inasafe_10.csv
+    :rtype: dict
+    """
+    fatality_rate = {
+        2: 0.0, 3: 0.0, 4: 0.0, 5: 0.0,
+        6: 3.41733122522e-05,
+        7: 0.000387804494226,
+        8: 0.001851451786,
+        9: 0.00787294191661,
+        10: 0.0314512157378,
+    }
+    return fatality_rate
+
+
+def make_aggregation_layer(crs, extent):
+    """Create a polygon layer with single geometry covering the given extent.
+    This is to generate aggregation layer if none was given to us."""
+
+    output_filename = unique_filename(prefix='aggregation_extent', suffix='.shp')
+
+    fields = QgsFields()
+    fields.append(QgsField("name", QVariant.String))
+    QgsVectorFileWriter.deleteShapeFile(output_filename)
+    writer = QgsVectorFileWriter(output_filename, "utf-8", fields, QGis.WKBPolygon, crs)
+    feature = QgsFeature(fields)
+    feature.setGeometry(QgsGeometry.fromRect(extent))
+    feature["name"] = "all"
+    writer.addFeature(feature)
+    del writer
+
+    layer = QgsVectorLayer(output_filename, "agg extent", "ogr")
+    assert layer.isValid()
+    return layer
+
+
+def temporary_aggregation_layer(aggregation_layer, aggregation_field, crs):
+    """Add integer attribute to the aggregation layer if the aggregation field is not integer
+    and also reproject aggregation layer if not in the same CRS.
+    Returns layer and dictionary of mapping { name: index } """
+    aggregation_name_to_index = {}
+    last_feature_index = 0
+    ct = None
+
+    if crs != aggregation_layer.crs():
+        ct = QgsCoordinateTransform(aggregation_layer.crs(), crs)
+
+    output_filename = unique_filename(prefix='aggregation_tmp', suffix='.shp')
+
+    fields = QgsFields()
+    fields.append(QgsField("name_index", QVariant.Int))
+    writer = QgsVectorFileWriter(output_filename, "utf-8", fields, aggregation_layer.wkbType(), aggregation_layer.crs())
+
+    for f in aggregation_layer.getFeatures():
+        feature_name = f[aggregation_field]
+        if feature_name not in aggregation_name_to_index:
+            last_feature_index += 1
+            aggregation_name_to_index[feature_name] = last_feature_index
+
+        f2 = QgsFeature(fields)
+        f2["name_index"] = aggregation_name_to_index[feature_name]
+        geom = f.geometry()
+        if ct:
+            geom.transform(ct)
+        f2.setGeometry(geom)
+
+        writer.addFeature(f2)
+
+    del writer
+    aggregation_layer_tmp = QgsVectorLayer(output_filename, "agg tmp", "memory")
+
+    return aggregation_layer_tmp, aggregation_name_to_index
+
+
+def exposed_people_stats(hazard, exposure, aggregation):
+    """Calculate the number of exposed people per MMI level per aggregation zone
+    and prepare raster layer outputs."""
+
+    exposed_raster_filename = unique_filename(prefix='exposed', suffix='.tif')
+
+    hazard_provider = hazard.dataProvider()
+    extent = hazard.extent()
+    width, height = hazard_provider.xSize(), hazard_provider.ySize()
+    hazard_block = hazard_provider.block(1, extent, width, height)
+
+    exposure_provider = exposure.dataProvider()
+    exposure_block = exposure_provider.block(1, extent, width, height)
+
+    agg_provider = aggregation.dataProvider()
+    agg_block = agg_provider.block(1, extent, width, height)
+
+    exposed = {}  # key: tuple (mmi, agg_zone), value: number of exposed people
+
+    exposed_array = make_array(width, height)
+
+    # walk through the rasters pixel by pixel and aggregate numbers
+    # of people in the combination of hazard zones and aggregation zones
+    for i in xrange(width*height):
+        hazard_mmi = hazard_block.value(long(i))
+        hazard_mmi = int(round(hazard_mmi))
+
+        people_count = exposure_block.value(long(i))
+
+        agg_zone_index = int(agg_block.value(long(i)))
+
+        key = (hazard_mmi, agg_zone_index)
+        if key not in exposed:
+            exposed[key] = 0
+
+        exposed[key] += people_count
+
+        exposed_array[i/width,i%width] = people_count
+
+    # output raster data - e.g. displaced people
+    array_to_raster(exposed_array, exposed_raster_filename, hazard)
+
+    exposed_raster = QgsRasterLayer(exposed_raster_filename, "exposed", "gdal")
+    assert exposed_raster.isValid()
+
+    return exposed, exposed_raster
+
+
+def make_summary_layer(exposed, aggregation_layer, aggregation_field, aggregation_name_to_index, fatality_rate):
+    """Given the dictionary of affected people counts per hazard and aggregation zones,
+    create a copy of the aggregation layer with statistics"""
+
+    output_filename = unique_filename(prefix='summary', suffix='.shp')
+
+    displacement_rate = {
+        2: 0.0, 3: 0.0, 4: 0.0, 5: 0.0, 6: 1.0,
+        7: 1.0, 8: 1.0, 9: 1.0, 10: 1.0
+    }
+
+    fields = QgsFields()
+    fields.append(QgsField("name", QVariant.String))
+    fields.append(QgsField("total_exposed", QVariant.Int))
+    fields.append(QgsField("total_fatalities", QVariant.Int))
+    fields.append(QgsField("total_displaced", QVariant.Int))
+    for mmi in xrange(2,11):
+        fields.append(QgsField("mmi_%d_exposed" % mmi, QVariant.Int))
+        fields.append(QgsField("mmi_%d_fatalities" % mmi, QVariant.Int))
+        fields.append(QgsField("mmi_%d_displaced" % mmi, QVariant.Int))
+
+    exposed_per_agg_zone = {}
+    for (mmi, agg), count in exposed.iteritems():
+        if agg not in exposed_per_agg_zone:
+            exposed_per_agg_zone[agg] = {}
+        exposed_per_agg_zone[agg][mmi] = count
+
+    # sums over the whole area
+    grand_total_exposed = 0
+    grand_total_fatalities = 0
+    grand_total_displaced = 0
+
+    writer = QgsVectorFileWriter(output_filename, "utf-8", fields, aggregation_layer.wkbType(), aggregation_layer.crs())
+
+    for agg_feature in aggregation_layer.getFeatures():
+        agg_zone_name = agg_feature[aggregation_field]
+        agg_zone = aggregation_name_to_index[agg_zone_name]
+
+        feature = QgsFeature(fields)
+        feature.setGeometry(agg_feature.geometry())
+
+        total_exposed = 0
+        total_fatalities = 0
+        total_displaced = 0
+
+        for mmi, mmi_exposed in exposed_per_agg_zone[agg_zone].iteritems():
+            mmi_fatalities = int(mmi_exposed * fatality_rate[mmi])  # rounding down
+            mmi_displaced = (mmi_exposed - mmi_fatalities) * displacement_rate[mmi]
+
+            feature["mmi_%d_exposed" % mmi] = mmi_exposed
+            feature["mmi_%d_fatalities" % mmi] = mmi_fatalities
+            feature["mmi_%d_displaced" % mmi] = mmi_displaced
+
+            total_exposed += mmi_exposed
+            total_fatalities += mmi_fatalities
+            total_displaced += mmi_displaced
+
+        feature["name"] = agg_zone_name
+        feature["total_exposed"] = total_exposed
+        feature["total_fatalities"] = total_fatalities
+        feature["total_displaced"] = total_displaced
+
+        grand_total_exposed += total_exposed
+        grand_total_fatalities += total_fatalities
+        grand_total_displaced += total_displaced
+
+        writer.addFeature(feature)
+
+    totals = {
+        'exposed': grand_total_exposed,
+        'fatalities': grand_total_fatalities,
+        'displaced': grand_total_displaced,
+    }
+
+    del writer
+    layer = QgsVectorLayer(output_filename, "summary", "ogr")
+    assert layer.isValid()
+    return layer, totals
+
+
+def calc_impact(hazard_layer, exposure_layer, aggregation_layer, aggregation_field, extent, fatality_rate):
+    """Main function to calculate the impact of earthquake on population:
+    1. prepare hazard, exposure, aggregation raster layers to common grid
+    2. get sums of exposed people per hazard MMI level and aggregation zone
+    3. create vector output based on aggregation layer with statistics
+       of fatalities and displaced people for each aggregation zone and MMI level."""
+
+    # STEP 1: prepare data
+
+    hazard_aligned, exposure_aligned = align_rasters(hazard_layer,
+                                                     exposure_layer,
+                                                     extent)
+
+    if not aggregation_layer:
+        # if we didn't get an aggregation layer, we will make one ourselves
+        # covering the whole analysis area
+        aggregation_layer = make_aggregation_layer(hazard_aligned.crs(),
+                                                   hazard_aligned.extent())
+        aggregation_field = "name"
+
+    aggregation_layer_tmp, mapping = temporary_aggregation_layer(aggregation_layer,
+                                                                 aggregation_field,
+                                                                 hazard_aligned.crs())
+
+    hazard_provider = hazard_aligned.dataProvider()
+    aggregation_aligned = rasterize_vector_layer(aggregation_layer_tmp,
+                                                 "name_index",
+                                                 hazard_provider.xSize(),
+                                                 hazard_provider.ySize(),
+                                                 hazard_aligned.extent())
+
+    # STEP 2: calculate statistics
+
+    exposed, exposed_raster = exposed_people_stats(hazard_aligned, exposure_aligned, aggregation_aligned)
+
+    # STEP 3: make output vector layer with aggregate counts
+
+    summary_vector, totals = make_summary_layer(exposed, aggregation_layer, aggregation_field, mapping, fatality_rate)
+
+    return summary_vector, exposed_raster, totals

--- a/safe/impact_function/earthquake.py
+++ b/safe/impact_function/earthquake.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+
+from PyQt4.QtCore import QVariant
 
 from qgis.core import (
     QGis,
@@ -12,17 +15,23 @@ from qgis.core import (
     QgsVectorFileWriter,
 )
 
-from PyQt4.QtCore import QVariant
-
 from safe.gis.numerics import log_normal_cdf
 from safe.gisv4.raster.align import align_rasters
 from safe.gisv4.raster.write_raster import array_to_raster, make_array
 from safe.gisv4.raster.rasterize import rasterize_vector_layer
 from safe.common.utilities import unique_filename
 
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
+
 
 def itb_fatality_rates():
     """ITB method to compute fatality rate.
+
+    :returns: Fatality rate.
+    :rtype: dic
     """
     # As per email discussion with Ole, Trevor, Hadi, mmi < 4 will have
     # a fatality rate of 0 - Tim
@@ -30,8 +39,8 @@ def itb_fatality_rates():
     # Model coefficients
     x = 0.62275231
     y = 8.03314466
-    fatality_rate = {mmi: 0 if mmi < 4 else 10 ** (x * mmi - y)
-                     for mmi in mmi_range}
+    fatality_rate = {
+        mmi: 0 if mmi < 4 else 10 ** (x * mmi - y) for mmi in mmi_range}
     return fatality_rate
 
 
@@ -54,7 +63,8 @@ def pager_fatality_rates():
 def bayesian_fatality_rates():
     """Fatality rate by MMI from Bayesian approach.
 
-    :returns: Fatality rates as medians from worden_berngamma_log_fat_rate_inasafe_10.csv
+    :returns: Fatality rates as medians
+        It comes worden_berngamma_log_fat_rate_inasafe_10.csv in InaSAFE 3.
     :rtype: dict
     """
     fatality_rate = {
@@ -70,29 +80,41 @@ def bayesian_fatality_rates():
 
 def make_aggregation_layer(crs, extent):
     """Create a polygon layer with single geometry covering the given extent.
-    This is to generate aggregation layer if none was given to us."""
 
-    output_filename = unique_filename(prefix='aggregation_extent', suffix='.shp')
+    This is to generate aggregation layer if none was given to us.
+
+    TODO We will remove this function and use the function in
+        safe.impact_function.create_extra_layers
+    """
+    output_filename = unique_filename(
+        prefix='aggregation_extent', suffix='.shp')
 
     fields = QgsFields()
-    fields.append(QgsField("name", QVariant.String))
+    fields.append(QgsField('name', QVariant.String))
     QgsVectorFileWriter.deleteShapeFile(output_filename)
-    writer = QgsVectorFileWriter(output_filename, "utf-8", fields, QGis.WKBPolygon, crs)
+    writer = QgsVectorFileWriter(
+        output_filename, 'utf-8', fields, QGis.WKBPolygon, crs)
     feature = QgsFeature(fields)
     feature.setGeometry(QgsGeometry.fromRect(extent))
-    feature["name"] = "all"
+    feature['name'] = 'all'
     writer.addFeature(feature)
     del writer
 
-    layer = QgsVectorLayer(output_filename, "agg extent", "ogr")
+    layer = QgsVectorLayer(output_filename, 'agg extent', 'ogr')
     assert layer.isValid()
     return layer
 
 
 def temporary_aggregation_layer(aggregation_layer, aggregation_field, crs):
-    """Add integer attribute to the aggregation layer if the aggregation field is not integer
-    and also reproject aggregation layer if not in the same CRS.
-    Returns layer and dictionary of mapping { name: index } """
+    """Add integer attribute to the aggregation layer if the aggregation field
+    is not integer and also reproject aggregation layer if not in the same CRS.
+
+    TODO : We will remove this function and use the function in
+        safe.impact_function.create_extra_layers
+
+    :returns: The layer and dictionary of mapping { name: index }.
+    :rtype: (QgsVectorLayer, dict)
+    """
     aggregation_name_to_index = {}
     last_feature_index = 0
     ct = None
@@ -103,8 +125,13 @@ def temporary_aggregation_layer(aggregation_layer, aggregation_field, crs):
     output_filename = unique_filename(prefix='aggregation_tmp', suffix='.shp')
 
     fields = QgsFields()
-    fields.append(QgsField("name_index", QVariant.Int))
-    writer = QgsVectorFileWriter(output_filename, "utf-8", fields, aggregation_layer.wkbType(), aggregation_layer.crs())
+    fields.append(QgsField('name_index', QVariant.Int))
+    writer = QgsVectorFileWriter(
+        output_filename,
+        'utf-8',
+        fields,
+        aggregation_layer.wkbType(),
+        aggregation_layer.crs())
 
     for f in aggregation_layer.getFeatures():
         feature_name = f[aggregation_field]
@@ -113,7 +140,7 @@ def temporary_aggregation_layer(aggregation_layer, aggregation_field, crs):
             aggregation_name_to_index[feature_name] = last_feature_index
 
         f2 = QgsFeature(fields)
-        f2["name_index"] = aggregation_name_to_index[feature_name]
+        f2['name_index'] = aggregation_name_to_index[feature_name]
         geom = f.geometry()
         if ct:
             geom.transform(ct)
@@ -122,15 +149,28 @@ def temporary_aggregation_layer(aggregation_layer, aggregation_field, crs):
         writer.addFeature(f2)
 
     del writer
-    aggregation_layer_tmp = QgsVectorLayer(output_filename, "agg tmp", "memory")
+    aggregation_layer_tmp = QgsVectorLayer(
+        output_filename, 'agg tmp', 'memory')
 
     return aggregation_layer_tmp, aggregation_name_to_index
 
 
 def exposed_people_stats(hazard, exposure, aggregation):
-    """Calculate the number of exposed people per MMI level per aggregation zone
-    and prepare raster layer outputs."""
+    """Calculate the number of exposed people per MMI level per aggregation
+    zone and prepare raster layer outputs.
 
+    :param hazard: The earthquake raster layer.
+    :type hazard: QgsRasterLayer
+
+    :param exposure: The population raster layer.
+    :type exposure: QgsVectorLayer
+
+    :param aggregation: The aggregation layer.
+    :type aggregation: QgsVectorLayer
+
+    :return: A tuple with the aggregation vector layer and the exposed raster.
+    :rtype: (QgsVectorLayer, QgsRasterLayer)
+    """
     exposed_raster_filename = unique_filename(prefix='exposed', suffix='.tif')
 
     hazard_provider = hazard.dataProvider()
@@ -150,7 +190,7 @@ def exposed_people_stats(hazard, exposure, aggregation):
 
     # walk through the rasters pixel by pixel and aggregate numbers
     # of people in the combination of hazard zones and aggregation zones
-    for i in xrange(width*height):
+    for i in xrange(width * height):
         hazard_mmi = hazard_block.value(long(i))
         hazard_mmi = int(round(hazard_mmi))
 
@@ -164,20 +204,26 @@ def exposed_people_stats(hazard, exposure, aggregation):
 
         exposed[key] += people_count
 
-        exposed_array[i/width,i%width] = people_count
+        exposed_array[i / width, i % width] = people_count
 
     # output raster data - e.g. displaced people
     array_to_raster(exposed_array, exposed_raster_filename, hazard)
 
-    exposed_raster = QgsRasterLayer(exposed_raster_filename, "exposed", "gdal")
+    exposed_raster = QgsRasterLayer(exposed_raster_filename, 'exposed', 'gdal')
     assert exposed_raster.isValid()
 
     return exposed, exposed_raster
 
 
-def make_summary_layer(exposed, aggregation_layer, aggregation_field, aggregation_name_to_index, fatality_rate):
-    """Given the dictionary of affected people counts per hazard and aggregation zones,
-    create a copy of the aggregation layer with statistics"""
+def make_summary_layer(
+        exposed,
+        aggregation_layer,
+        aggregation_field,
+        aggregation_name_to_index,
+        fatality_rate):
+    """Given the dictionary of affected people counts per hazard and
+    aggregation zones, create a copy of the aggregation layer with statistics.
+    """
 
     output_filename = unique_filename(prefix='summary', suffix='.shp')
 
@@ -187,14 +233,14 @@ def make_summary_layer(exposed, aggregation_layer, aggregation_field, aggregatio
     }
 
     fields = QgsFields()
-    fields.append(QgsField("name", QVariant.String))
-    fields.append(QgsField("total_exposed", QVariant.Int))
-    fields.append(QgsField("total_fatalities", QVariant.Int))
-    fields.append(QgsField("total_displaced", QVariant.Int))
-    for mmi in xrange(2,11):
-        fields.append(QgsField("mmi_%d_exposed" % mmi, QVariant.Int))
-        fields.append(QgsField("mmi_%d_fatalities" % mmi, QVariant.Int))
-        fields.append(QgsField("mmi_%d_displaced" % mmi, QVariant.Int))
+    fields.append(QgsField('name', QVariant.String))
+    fields.append(QgsField('total_exposed', QVariant.Int))
+    fields.append(QgsField('total_fatalities', QVariant.Int))
+    fields.append(QgsField('total_displaced', QVariant.Int))
+    for mmi in xrange(2, 11):
+        fields.append(QgsField('mmi_%d_exposed' % mmi, QVariant.Int))
+        fields.append(QgsField('mmi_%d_fatalities' % mmi, QVariant.Int))
+        fields.append(QgsField('mmi_%d_displaced' % mmi, QVariant.Int))
 
     exposed_per_agg_zone = {}
     for (mmi, agg), count in exposed.iteritems():
@@ -207,7 +253,12 @@ def make_summary_layer(exposed, aggregation_layer, aggregation_field, aggregatio
     grand_total_fatalities = 0
     grand_total_displaced = 0
 
-    writer = QgsVectorFileWriter(output_filename, "utf-8", fields, aggregation_layer.wkbType(), aggregation_layer.crs())
+    writer = QgsVectorFileWriter(
+        output_filename,
+        'utf-8',
+        fields,
+        aggregation_layer.wkbType(),
+        aggregation_layer.crs())
 
     for agg_feature in aggregation_layer.getFeatures():
         agg_zone_name = agg_feature[aggregation_field]
@@ -221,21 +272,23 @@ def make_summary_layer(exposed, aggregation_layer, aggregation_field, aggregatio
         total_displaced = 0
 
         for mmi, mmi_exposed in exposed_per_agg_zone[agg_zone].iteritems():
-            mmi_fatalities = int(mmi_exposed * fatality_rate[mmi])  # rounding down
-            mmi_displaced = (mmi_exposed - mmi_fatalities) * displacement_rate[mmi]
+            mmi_fatalities = (
+                int(mmi_exposed * fatality_rate[mmi]))  # rounding down
+            mmi_displaced = (
+                (mmi_exposed - mmi_fatalities) * displacement_rate[mmi])
 
-            feature["mmi_%d_exposed" % mmi] = mmi_exposed
-            feature["mmi_%d_fatalities" % mmi] = mmi_fatalities
-            feature["mmi_%d_displaced" % mmi] = mmi_displaced
+            feature['mmi_%d_exposed' % mmi] = mmi_exposed
+            feature['mmi_%d_fatalities' % mmi] = mmi_fatalities
+            feature['mmi_%d_displaced' % mmi] = mmi_displaced
 
             total_exposed += mmi_exposed
             total_fatalities += mmi_fatalities
             total_displaced += mmi_displaced
 
-        feature["name"] = agg_zone_name
-        feature["total_exposed"] = total_exposed
-        feature["total_fatalities"] = total_fatalities
-        feature["total_displaced"] = total_displaced
+        feature['name'] = agg_zone_name
+        feature['total_exposed'] = total_exposed
+        feature['total_fatalities'] = total_fatalities
+        feature['total_displaced'] = total_displaced
 
         grand_total_exposed += total_exposed
         grand_total_fatalities += total_fatalities
@@ -250,48 +303,60 @@ def make_summary_layer(exposed, aggregation_layer, aggregation_field, aggregatio
     }
 
     del writer
-    layer = QgsVectorLayer(output_filename, "summary", "ogr")
+    layer = QgsVectorLayer(output_filename, 'summary', 'ogr')
     assert layer.isValid()
     return layer, totals
 
 
-def calc_impact(hazard_layer, exposure_layer, aggregation_layer, aggregation_field, extent, fatality_rate):
-    """Main function to calculate the impact of earthquake on population:
-    1. prepare hazard, exposure, aggregation raster layers to common grid
-    2. get sums of exposed people per hazard MMI level and aggregation zone
-    3. create vector output based on aggregation layer with statistics
-       of fatalities and displaced people for each aggregation zone and MMI level."""
+def calc_impact(
+        hazard,
+        exposure,
+        aggregation,
+        aggregation_field,
+        extent,
+        fatality_rate):
+    """Main function to calculate the impact of earthquake on population.
+
+    1. Prepare hazard, exposure, aggregation raster layers to common grid.
+
+    2. Get sums of exposed people per hazard MMI level and aggregation zone.
+
+    3. Create vector output based on aggregation layer with statistics of
+        fatalities and displaced people for each aggregation zone and MMI
+        level.
+    """
 
     # STEP 1: prepare data
 
-    hazard_aligned, exposure_aligned = align_rasters(hazard_layer,
-                                                     exposure_layer,
-                                                     extent)
+    hazard_aligned, exposure_aligned = align_rasters(
+        hazard, exposure, extent)
 
-    if not aggregation_layer:
-        # if we didn't get an aggregation layer, we will make one ourselves
-        # covering the whole analysis area
-        aggregation_layer = make_aggregation_layer(hazard_aligned.crs(),
-                                                   hazard_aligned.extent())
-        aggregation_field = "name"
+    if not aggregation:
+        # If we didn't get an aggregation layer, we will make one ourselves
+        # covering the whole analysis area.
+        aggregation = make_aggregation_layer(
+            hazard_aligned.crs(), hazard_aligned.extent())
+        aggregation_field = 'name'
 
-    aggregation_layer_tmp, mapping = temporary_aggregation_layer(aggregation_layer,
-                                                                 aggregation_field,
-                                                                 hazard_aligned.crs())
+    aggregation_layer_tmp, mapping = temporary_aggregation_layer(
+        aggregation, aggregation_field, hazard_aligned.crs())
 
     hazard_provider = hazard_aligned.dataProvider()
-    aggregation_aligned = rasterize_vector_layer(aggregation_layer_tmp,
-                                                 "name_index",
-                                                 hazard_provider.xSize(),
-                                                 hazard_provider.ySize(),
-                                                 hazard_aligned.extent())
+    aggregation_aligned = rasterize_vector_layer(
+        aggregation_layer_tmp,
+        'name_index',
+        hazard_provider.xSize(),
+        hazard_provider.ySize(),
+        hazard_aligned.extent())
 
     # STEP 2: calculate statistics
 
-    exposed, exposed_raster = exposed_people_stats(hazard_aligned, exposure_aligned, aggregation_aligned)
+    exposed, exposed_raster = exposed_people_stats(
+        hazard_aligned, exposure_aligned, aggregation_aligned)
 
     # STEP 3: make output vector layer with aggregate counts
 
-    summary_vector, totals = make_summary_layer(exposed, aggregation_layer, aggregation_field, mapping, fatality_rate)
+    summary_vector, totals = make_summary_layer(
+        exposed, aggregation, aggregation_field, mapping, fatality_rate)
 
     return summary_vector, exposed_raster, totals


### PR DESCRIPTION
- this is resurrection/rewrite of code from InaSAFE 3.5
- operations are done using QGIS API
- aggregation is now included in the algorithm

Not yet integrated into InaSAFE pipeline, just calculation functions...

A test script that can be run from QGIS to use the new code:
```
from qgis.core import QgsMapLayerRegistry, QgsRectangle
from inasafe.safe.impact_function.earthquake import calc_impact, itb_fatality_rates, pager_fatality_rates, bayesian_fatality_rates
from inasafe.safe.test.utilities import load_layer

path = "/home/martin/tmp/earthquake/West Sumatera"
layer_exp, _ = load_layer(path+"/02 Exposure Data/Sumatera_Population_WGS84.tif")
layer_haz, _ = load_layer(path+"/01 Hazard Data/Padang_EQ_2009_WGS84.tif")
layer_agg = None  # no aggregation
#layer_agg, _ = load_layer(path+"/03 Aggregation Data/Padang_Village_Boundary_WGS84.shp")
field_agg = "lev3_name"   # field in the aggregation layer to identify zone
extent = QgsRectangle(100.2077, -1.0384, 100.5444, -0.7960)

summary, exposed, totals = calc_impact(layer_haz, layer_exp, layer_agg, field_agg, extent, itb_fatality_rates())

print totals
QgsMapLayerRegistry.instance().addMapLayers([summary, exposed])
```

TODO:
- dealing with Bayesian ITB fatality rate (now just simplified to use medians)
- probability of fatality magnitudes (e.g. 30% hundreds of fatalities / 70% tens of fatalities) not ported yet (not used anywhere in GUI, InaSAFE 3.5 adds that to impact layer metadata)
- decision how to report fatalities - #3559 - just single estimated number or a probability distribution?
- unit tests
- nodata handling
