### PR TITLE
Optimize impact function for flooding on buildings

### DIFF
--- a/safe/gis/vector/smart_clip.py
+++ b/safe/gis/vector/smart_clip.py
@@ -70,7 +70,9 @@ def smart_clip(layer_to_clip, mask_layer, callback=None):
     engine = QgsGeometry.createGeometryEngine(geometries.geometry())
     engine.prepareGeometry()
 
-    for feature in layer_to_clip.getFeatures():
+    extent = mask_layer.extent()
+
+    for feature in layer_to_clip.getFeatures(QgsFeatureRequest(extent)):
 
         if engine.intersects(feature.geometry().geometry()):
             out_feat = QgsFeature()


### PR DESCRIPTION
Low hanging fruits:
- cache exposure features instead of fetching them directly from layer by ID
- use prepared geometry for repeated intersection tests of hazard geometries
- in smart clip, only fetch layers within extent of mask layer

For a small analysis area, the time on my laptop went from 12.4s down to 6.1s