### PR TITLE
disable not_exposed in the map for landcover and population exposures

### DIFF
--- a/safe/definitions/exposure.py
+++ b/safe/definitions/exposure.py
@@ -148,6 +148,7 @@ exposure_population = {
         elderly_count_field
     ],
     'layer_modes': [layer_mode_continuous],
+    'display_not_exposed': False,
     'layer_legend_title': tr('Number of people'),
     'measure_question': tr('how many')
 }
@@ -206,6 +207,7 @@ exposure_road = {
         feature_rate_field
     ],
     'layer_modes': [layer_mode_classified],
+    'display_not_exposed': True,
     'layer_legend_title': tr('Length of roads'),
     'measure_question': tr('what length of')
 }
@@ -264,6 +266,7 @@ exposure_structure = {
         feature_rate_field
     ],
     'layer_modes': [layer_mode_classified],
+    'display_not_exposed': True,
     'layer_legend_title': tr('Number of buildings'),
     'measure_question': tr('how many')
 }
@@ -302,6 +305,7 @@ exposure_place = {
         exposure_name_field
     ],
     'layer_modes': [layer_mode_classified],
+    'display_not_exposed': True,
     'layer_legend_title': tr('Number of places'),
     'measure_question': tr('how many')
 }
@@ -361,6 +365,7 @@ exposure_land_cover = {
         feature_rate_field
     ],
     'layer_modes': [layer_mode_classified],
+    'display_not_exposed': False,
     'layer_legend_title': tr('Area of landcover'),
     'measure_question': tr('what area of')
 }

--- a/safe/definitions/hazard_classifications.py
+++ b/safe/definitions/hazard_classifications.py
@@ -32,6 +32,8 @@ __revision__ = '$Format:%H$'
 # We do not include it in the classes below because we do not want the user
 # to be presented with not exposed in the keywords when setting up
 # their classes.
+# This class is not displayed if it's a polygon exposure (landcover and
+# population) in the legend.
 not_exposed_class = {
     'key': 'not exposed',
     'name': tr('Not exposed'),

--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -1622,31 +1622,11 @@ class ImpactFunction(object):
 
     def style(self):
         """Function to apply some styles to the layers."""
-        # Let's style the hazard class in each layers.
-        classification = self.hazard.keywords['classification']
-        classification = definition(classification)
-
-        # Let's check if there is some thresholds:
-        thresholds = self.hazard.keywords.get('thresholds')
-        if thresholds:
-            hazard_unit = self.hazard.keywords.get('continuous_hazard_unit')
-            hazard_unit = definition(hazard_unit)
-        else:
-            hazard_unit = None
-
-        # TODO We need to work on the unit from the exposure.
-        exposure = self.exposure.keywords['exposure']
-        exposure_unit = definition(exposure)['units'][0]
-
-        # In debug mode we don't round number.
-        enable_rounding = not self.debug_mode
         classes = generate_classified_legend(
             self.analysis_impacted,
-            classification,
-            thresholds,
-            exposure_unit,
-            hazard_unit,
-            enable_rounding)
+            self.exposure,
+            self.hazard,
+            self.debug_mode)
 
         # Let's style layers which have a geometry and have hazard_class
         hazard_class = hazard_class_field['key']


### PR DESCRIPTION
Same hazard, but different exposure : 
![screen shot 2017-01-26 at 11 00 35](https://cloud.githubusercontent.com/assets/1609292/22327276/b3a5ba78-e3b6-11e6-80b6-b7960c8db559.png)

CC : @Charlotte-Morgan @felix-yew 