### PR TITLE
make pep8 at the end of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ install:
   - docker exec -it qgis-testing-environment sh -c "qgis_setup.sh inasafe"
 
 script:
-  - make pep8
   - docker exec -it qgis-testing-environment sh -c "qgis_testrunner.sh test_suite.test_package"
+  - make pep8
 
 notifications:
   irc:


### PR DESCRIPTION
As we often scroll to the bottom in travis to see which tests are failing, it's better to have the test pep8 at the end.