### PR TITLE
add thousand separator

### DIFF
--- a/safe/common/test/test_utilities.py
+++ b/safe/common/test/test_utilities.py
@@ -28,10 +28,7 @@ from safe.common.utilities import (
     get_significant_decimal,
     humanize_class,
     format_decimal,
-    format_int,
     create_label,
-    get_thousand_separator,
-    get_decimal_separator,
     get_utm_epsg,
     temp_dir,
     log_file_path,
@@ -202,41 +199,6 @@ class TestUtilities(unittest.TestCase):
         # print my_result
         assert my_result == '10,000.09', \
             'Format decimal is not valid %s' % my_result
-
-    def test_format_int(self):
-        """Test formatting integer"""
-        number = 10000000
-        lang = os.getenv('LANG')
-        formatted_int = format_int(number)
-        if lang == 'id':
-            expected_str = '10.000.000'
-        else:
-            expected_str = '10,000,000'
-        message = 'Format integer is not valid'
-        assert (formatted_int == expected_str or
-                formatted_int == str(number)), message
-
-        number = 1234
-        lang = os.getenv('LANG')
-        formatted_int = format_int(number)
-        if lang == 'id':
-            expected_str = '1.234'
-        else:
-            expected_str = '1,234'
-        message = 'Format integer %s is not valid' % formatted_int
-        assert (formatted_int == expected_str or
-                formatted_int == str(number)), message
-
-    def test_separator(self):
-        """Test decimal and thousand separator
-        """
-        os.environ['LANG'] = 'en'
-        assert ',' == get_thousand_separator()
-        assert '.' == get_decimal_separator()
-        os.environ['LANG'] = 'id'
-        assert '.' == get_thousand_separator()
-        assert ',' == get_decimal_separator()
-        os.environ['LANG'] = 'en'
 
     def test_create_label(self):
         """Test create label.

--- a/safe/common/utilities.py
+++ b/safe/common/utilities.py
@@ -1,6 +1,5 @@
 # coding=utf-8
-"""Utilities for InaSAFE
-"""
+"""Utilities for InaSAFE."""
 import os
 import sys
 import platform
@@ -23,7 +22,8 @@ from qgis.core import (
     QgsPoint)
 
 from safe.common.exceptions import VerificationError
-from safe.utilities.i18n import locale
+from safe.utilities.rounding import (
+    thousand_separator, decimal_separator, add_separators)
 
 
 import logging
@@ -264,42 +264,6 @@ def get_free_memory_osx():
         return int(inactive) + int(free)
 
 
-def format_int(x):
-    """Format integer with separator between thousands.
-
-    :param x: A number to be formatted in a locale friendly way.
-    :type x: int
-
-    :returns: A locale friendly formatted string e.g. 1,000,0000.00
-        representing the original x. If a ValueError exception occurs,
-        x is simply returned.
-    :rtype: basestring
-
-
-    From http://stackoverflow.com/questions/5513615/
-                add-thousands-separators-to-a-number
-
-    # FIXME (Ole)
-    Currently not using locale coz broken
-
-    Instead use this:
-    http://docs.python.org/library/string.html#formatspec
-
-    """
-    try:
-        s = '{0:,}'.format(x)
-        # s = '{0:n}'.format(x)  # n means locale aware (read up on this)
-    # see issue #526
-    except ValueError:
-        return x
-
-    # Quick solution for the moment
-    if locale() == 'id':
-        # Replace commas with dots
-        s = s.replace(',', '.')
-    return s
-
-
 def humanize_min_max(min_value, max_value, interval):
     """Return humanize value format for max and min.
 
@@ -324,8 +288,8 @@ def humanize_min_max(min_value, max_value, interval):
     current_interval = max_value - min_value
     if interval > 1:
         # print 'case 1. Current interval : ', current_interval
-        humanize_min_value = format_int(int(round(min_value)))
-        humanize_max_value = format_int(int(round(max_value)))
+        humanize_min_value = add_separators(int(round(min_value)))
+        humanize_max_value = add_separators(int(round(max_value)))
 
     else:
         # print 'case 2. Current interval : ', current_interval
@@ -345,7 +309,7 @@ def format_decimal(interval, value):
     """
     interval = get_significant_decimal(interval)
     if isinstance(interval, Integral) or isinstance(value, Integral):
-        return format_int(int(value))
+        return add_separators(int(value))
     if interval != interval:
         # nan
         return str(value)
@@ -357,26 +321,8 @@ def format_decimal(interval, value):
     my_number_decimal = str(value).split('.')[1][:decimal_places]
     if len(set(my_number_decimal)) == 1 and my_number_decimal[-1] == '0':
         return my_number_int
-    return (format_int(int(my_number_int)) + get_decimal_separator() +
+    return (add_separators(int(my_number_int)) + decimal_separator() +
             my_number_decimal)
-
-
-def get_decimal_separator():
-    """Return decimal separator according to the locale."""
-    lang = os.getenv('LANG')
-    if lang == 'id':
-        return ','
-    else:
-        return '.'
-
-
-def get_thousand_separator():
-    """Return decimal separator according to the locale."""
-    lang = os.getenv('LANG')
-    if lang == 'id':
-        return '.'
-    else:
-        return ','
 
 
 def get_significant_decimal(my_decimal):
@@ -479,7 +425,7 @@ def unhumanize_number(number):
     @param number:
     """
     try:
-        number = number.replace(get_thousand_separator(), '')
+        number = number.replace(thousand_separator(), '')
         number = int(float(number))
     except (AttributeError, ValueError):
         pass

--- a/safe/gui/widgets/test/test_dock.py
+++ b/safe/gui/widgets/test/test_dock.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Test Dock"""
+"""Test Dock."""
 
 import codecs
 import logging
@@ -25,8 +25,9 @@ from safe.test.utilities import get_qgis_app, get_dock
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 from safe.definitions.constants import (
     HAZARD_EXPOSURE_VIEW, HAZARD_EXPOSURE, HAZARD_EXPOSURE_BOUNDINGBOX)
-from safe.common.utilities import format_int, unique_filename
+from safe.common.utilities import unique_filename
 from safe.utilities.qgis_utilities import add_above_layer, layer_legend_index
+from safe.utilities.rounding import add_separators
 from safe.test.utilities import (
     standard_data_path,
     load_standard_layers,
@@ -272,7 +273,7 @@ class TestDock(TestCase):
 
         message = 'Result not as expected: %s' % result
         # searching for values 6700 clean water [l] in result
-        self.assertTrue(format_int(6700) in result, message)
+        self.assertTrue(add_separators(6700) in result, message)
 
     @unittest.expectedFailure
     def test_issue306(self):
@@ -488,7 +489,7 @@ class TestDock(TestCase):
         result = self.dock.results_webview.page_to_text()
 
         message = 'Result not as expected: %s' % result
-        self.assertTrue(format_int(33) in result, message)
+        self.assertTrue(add_separators(33) in result, message)
 
     @unittest.expectedFailure
     def test_issue581(self):

--- a/safe/impact_function/style.py
+++ b/safe/impact_function/style.py
@@ -23,7 +23,7 @@ from safe.definitions.fields import hazard_class_field, hazard_count_field
 from safe.definitions.hazard_classifications import not_exposed_class
 from safe.definitions.utilities import definition
 from safe.utilities.gis import is_line_layer
-from safe.utilities.rounding import round_affected_number
+from safe.utilities.rounding import format_number
 
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
@@ -146,7 +146,7 @@ def generate_classified_legend(
             # The field might not exist if no feature impacted in this hazard
             # zone.
             value = 0
-        value = round_affected_number(value, enable_rounding, True)
+        value = format_number(value, enable_rounding)
 
         minimum = None
         maximum = None
@@ -201,7 +201,7 @@ def _add_not_exposed(analysis_row, enable_rounding, exposure_unit):
     except KeyError:
         # The field might not exist if there is not feature not exposed.
         value = 0
-    value = round_affected_number(value, enable_rounding, True)
+    value = format_number(value, enable_rounding)
     label = _format_label(
         hazard_class=not_exposed_class['name'],
         value=value,

--- a/safe/impact_function/test/test_impact_function.py
+++ b/safe/impact_function/test/test_impact_function.py
@@ -387,7 +387,7 @@ class TestImpactFunction(unittest.TestCase):
         }
 
         # If we want to invert the selection.
-        invert = True
+        invert = False
 
         path = standard_data_path('scenario')
         for scenario, enabled in scenarii.iteritems():

--- a/safe/impact_function/test/test_impact_function.py
+++ b/safe/impact_function/test/test_impact_function.py
@@ -365,7 +365,7 @@ class TestImpactFunction(unittest.TestCase):
     @unittest.skipIf(
         os.environ.get('ON_TRAVIS', False),
         'Duplicate test of test_scenario_directory.')
-    def test_scenarii(self):
+    def test_scenarios(self):
         """Test manually a directory.
 
         This function is like test_directory, but you can control manually
@@ -373,7 +373,7 @@ class TestImpactFunction(unittest.TestCase):
 
         Let's keep booleans to False by default.
         """
-        scenarii = {
+        scenarios = {
             'polygon_classified_on_line': False,
             'polygon_classified_on_point': False,
             'polygon_classified_on_vector_population': False,
@@ -390,7 +390,7 @@ class TestImpactFunction(unittest.TestCase):
         invert = False
 
         path = standard_data_path('scenario')
-        for scenario, enabled in scenarii.iteritems():
+        for scenario, enabled in scenarios.iteritems():
             if (not invert and enabled) or (invert and not enabled):
                 self.test_scenario(join(path, scenario + '.json'))
 
@@ -398,7 +398,7 @@ class TestImpactFunction(unittest.TestCase):
             join(path, f) for f in listdir(path)
             if isfile(join(path, f)) and f.endswith('.json')
         ]
-        self.assertEqual(len(json_files), len(scenarii))
+        self.assertEqual(len(json_files), len(scenarios))
 
     def test_scenario_directory(self):
         """Run test scenario in directory."""

--- a/safe/test/utilities.py
+++ b/safe/test/utilities.py
@@ -1,6 +1,5 @@
 # coding=utf-8
-"""Helper module for gui test suite
-"""
+"""Helper module for gui test suite."""
 import os
 import re
 import sys
@@ -61,6 +60,11 @@ TESTDATA = os.path.join(DATADIR, 'test')  # Artificial datasets
 HAZDATA = os.path.join(DATADIR, 'hazard')  # Real hazard layers
 EXPDATA = os.path.join(DATADIR, 'exposure')  # Real exposure layers
 BOUNDDATA = os.path.join(DATADIR, 'boundaries')  # Real exposure layers
+
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
 
 
 def qgis_iface():

--- a/safe/utilities/i18n.py
+++ b/safe/utilities/i18n.py
@@ -1,21 +1,4 @@
 # coding=utf-8
-"""
-InaSAFE Disaster risk assessment tool by AusAid -**Internationalisation
-utilities.**
-
-The module provides utilities function to convert between unicode and byte
-string for Python 2.x. When we move to Python 3, this module and its usage
-should be removed as string in Python 3 is already stored in unicode.
-
-Contact : ole.moller.nielsen@gmail.com
-
-.. note:: This program is free software; you can redistribute it and/or modify
-     it under the terms of the GNU General Public License as published by
-     the Free Software Foundation; either version 2 of the License, or
-     (at your option) any later version.
-
-"""
-
 
 # This import is to enable SIP API V2
 # noinspection PyUnresolvedReferences
@@ -26,11 +9,10 @@ import logging
 
 from safe.utilities.unicode import get_unicode
 
-__author__ = 'tim@kartoza.com'
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
 __revision__ = '$Format:%H$'
-__date__ = '02/24/15'
-__copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
-                 'Disaster Reduction')
 
 LOGGER = logging.getLogger('InaSAFE')
 

--- a/safe/utilities/i18n.py
+++ b/safe/utilities/i18n.py
@@ -80,18 +80,25 @@ def tr(text, context='@default'):
 def locale():
     """Get the name of the currently active locale.
 
-    :returns: Name of hte locale e.g. 'id'
+    :returns: Name of the locale e.g. 'id'
     :rtype: str
     """
     override_flag = QSettings().value(
         'locale/overrideFlag', True, type=bool)
 
+    default = 'en_US'
+
     if override_flag:
-        locale_name = QSettings().value('locale/userLocale', 'en_US', type=str)
+        locale_name = QSettings().value('locale/userLocale', default, type=str)
     else:
         # noinspection PyArgumentList
         locale_name = QLocale.system().name()
-        # NOTES: we split the locale name because we need the first two
-        # character i.e. 'id', 'af, etc
-        locale_name = str(locale_name).split('_')[0]
+
+    if locale_name == 'C':
+        # On travis, locale/userLocale is equal to C. We want 'en'.
+        locale_name = default
+
+    # NOTES: we split the locale name because we need the first two
+    # character i.e. 'id', 'af, etc
+    locale_name = str(locale_name).split('_')[0]
     return locale_name

--- a/safe/utilities/osm_downloader.py
+++ b/safe/utilities/osm_downloader.py
@@ -1,21 +1,5 @@
 # coding=utf-8
-"""
-InaSAFE Disaster risk assessment tool developed by AusAid -
-**Import Dialog.**
-
-Contact : etienne@kartoza.com
-
-.. note:: This program is free software; you can redistribute it and/or modify
-     it under the terms of the GNU General Public License as published by
-     the Free Software Foundation; either version 2 of the License, or
-     (at your option) any later version.
-
-"""
-__author__ = 'etienne@kartoza.com'
-__revision__ = '$Format:%H$'
-__date__ = '25/06/2015'
-__copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
-                 'Disaster Reduction')
+"""OSM Downloader tool."""
 
 import zipfile
 import os
@@ -26,11 +10,16 @@ from PyQt4.QtNetwork import QNetworkReply
 from PyQt4.QtGui import QDialog
 from PyQt4.QtCore import QSettings
 
-from safe.utilities.i18n import tr
+from safe.utilities.i18n import tr, locale
 from safe.utilities.gis import qgis_version
 from safe.utilities.file_downloader import FileDownloader
 from safe.common.exceptions import DownloadError, CanceledImportDialogError
 from safe.common.version import get_version, release_status
+
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
 
 # If it's not a final release and the developer mode is ON, we use the staging
 # version for OSM-Reporter.
@@ -67,7 +56,6 @@ def download(feature_type, output_base_path, extent, progress_dialog=None):
 
     :raises: ImportDialogError, CanceledImportDialogError
     """
-
     # preparing necessary data
     min_longitude = extent[0]
     min_latitude = extent[1]
@@ -83,16 +71,22 @@ def download(feature_type, output_base_path, extent, progress_dialog=None):
             max_latitude=max_latitude
     )
 
-    url = URL_OSM_PREFIX + feature_type + URL_OSM_SUFFIX
-    url = '{url}?bbox={box}&qgis_version={qgis}'.format(
-        url=url, box=box, qgis=qgis_version())
-
-    url += '&inasafe_version=%s' % get_version()
-
-    if 'LANG' in os.environ:
-        # Get the language only : eg 'en_US' -> 'en'
-        env_lang = os.environ['LANG'].split('_')[0]
-        url += '&lang=%s' % env_lang
+    url = (
+        '{url_osm_prefix}'
+        '{feature_type}'
+        '{url_osm_suffix}?'
+        'bbox={box}&'
+        'qgis_version={qgis}&'
+        'lang={lang}&'
+        'inasafe_version={inasafe_version}'.format(
+            url_osm_prefix=URL_OSM_PREFIX,
+            feature_type=feature_type,
+            url_osm_suffix=URL_OSM_SUFFIX,
+            url=url,
+            box=box,
+            qgis=qgis_version(),
+            lang=locale(),
+            inasafe_version=get_version()))
 
     path = tempfile.mktemp('.shp.zip')
 

--- a/safe/utilities/rounding.py
+++ b/safe/utilities/rounding.py
@@ -1,9 +1,98 @@
+# coding=utf-8
 from math import ceil
+
+from safe.utilities.i18n import locale
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
 __email__ = "info@inasafe.org"
 __revision__ = '$Format:%H$'
+
+
+def format_number(x, enable_rounding=True):
+    """Format a number according to the standards.
+
+    :param x: A number to be formatted in a locale friendly way.
+    :type x: int
+
+    :param enable_rounding: Flag to enable a population rounding.
+    :type enable_rounding: bool
+
+    :returns: A locale friendly formatted string e.g. 1,000,0000.00
+        representing the original x. If a ValueError exception occurs,
+        x is simply returned.
+    :rtype: basestring
+    """
+    if enable_rounding:
+        x = population_rounding(x)
+
+    number = add_separators(x)
+    return number
+
+
+def add_separators(x):
+    """Format integer with separator between thousands.
+
+    :param x: A number to be formatted in a locale friendly way.
+    :type x: int
+
+    :returns: A locale friendly formatted string e.g. 1,000,0000.00
+        representing the original x. If a ValueError exception occurs,
+        x is simply returned.
+    :rtype: basestring
+
+
+    From http://
+    stackoverflow.com/questions/5513615/add-thousands-separators-to-a-number
+
+    Instead use this:
+    http://docs.python.org/library/string.html#formatspec
+    """
+    try:
+        s = '{0:,}'.format(x)
+        # s = '{0:n}'.format(x)  # n means locale aware (read up on this)
+    # see issue #526
+    except ValueError:
+        return x
+
+    # Quick solution for the moment
+    if locale() in ['id', 'fr']:
+        # Replace commas with the correct thousand separator.
+        s = s.replace(',', thousand_separator())
+    return s
+
+
+def decimal_separator():
+    """Return decimal separator according to the locale.
+
+    :return: The decimal separator.
+    :rtype: basestring
+    """
+    lang = locale()
+
+    if lang in ['id', 'fr']:
+        return ','
+
+    else:
+        return '.'
+
+
+def thousand_separator():
+    """Return thousand separator according to the locale.
+
+    :return: The thousand separator.
+    :rtype: basestring
+    """
+    lang = locale()
+
+    if lang in ['id']:
+        return '.'
+
+    elif lang in ['fr']:
+        return ' '
+
+    else:
+        return ','
 
 
 def round_affected_number(

--- a/safe/utilities/rounding.py
+++ b/safe/utilities/rounding.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+"""Rounding and number formatting."""
+
+
 from math import ceil
 
 from safe.utilities.i18n import locale

--- a/safe/utilities/test/test_rounding.py
+++ b/safe/utilities/test/test_rounding.py
@@ -1,16 +1,17 @@
 # coding=utf-8
 
-__copyright__ = "Copyright 2016, The InaSAFE Project"
-__license__ = "GPL version 3"
-__email__ = "info@inasafe.org"
-__revision__ = '$Format:%H$'
-
 import logging
 import random
 import unittest
 
 from safe.utilities.rounding import (
-    population_rounding_full, population_rounding)
+    population_rounding_full, population_rounding, add_separators)
+from safe.utilities.i18n import locale
+
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
 
 LOGGER = logging.getLogger('InaSAFE')
 
@@ -41,6 +42,25 @@ class TestCore(unittest.TestCase):
                 population_rounding(n),
                 population_rounding_full(n)[0])
 
+    def test_format_int(self):
+        """Test formatting integer"""
+        lang = locale()
+
+        number = 10000000
+        formatted_int = add_separators(number)
+        if lang == 'id':
+            expected_str = '10.000.000'
+        else:
+            expected_str = '10,000,000'
+        self.assertEqual(expected_str, formatted_int)
+
+        number = 1234
+        formatted_int = add_separators(number)
+        if lang == 'id':
+            expected_str = '1.234'
+        else:
+            expected_str = '1,234'
+        self.assertEqual(expected_str, formatted_int)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* FR
![screen shot 2017-01-30 at 14 16 31](https://cloud.githubusercontent.com/assets/1609292/22424567/55a73282-e6f7-11e6-89f4-eacac6a1857a.png)

* EN
![screen shot 2017-01-30 at 14 17 35](https://cloud.githubusercontent.com/assets/1609292/22424569/55df79d0-e6f7-11e6-9e3a-1eea470267ed.png)

* ID
![screen shot 2017-01-30 at 14 18 28](https://cloud.githubusercontent.com/assets/1609292/22424568/55d85d26-e6f7-11e6-8d4e-28dd3f8d0519.png)

@lucernae You should be able to use `format_number` in the report. It adds the thousand separator and apply the rounding if needed.
