### PR TITLE
fix issue #3824 Map extent not properly used in Map Report

### DIFF
--- a/safe/report/extractors/composer.py
+++ b/safe/report/extractors/composer.py
@@ -222,12 +222,16 @@ def qgis_composer_extractor(impact_report, component_metadata):
         # place exposure at the bottom
         layers.append(impact_report.impact_function.exposure)
 
+    # default extent is analysis extent
+    if not qgis_context.extent:
+        qgis_context.extent = impact_report.impact_function.analysis_extent
+
     map_elements = [
         {
             'id': 'impact-map',
             'extent': qgis_context.extent,
             'grid_split_count': 5,
-            'layers': layers
+            'layers': layers,
         }
     ]
     context.map_elements = map_elements

--- a/safe/report/impact_report.py
+++ b/safe/report/impact_report.py
@@ -302,7 +302,7 @@ class ImpactReport(object):
         map_settings = self._iface.mapCanvas().mapSettings()
 
         self._qgis_composition_context = QGISCompositionContext(
-            self._iface.mapCanvas().extent(),
+            None,
             map_settings,
             ImpactReport.DEFAULT_PAGE_DPI)
         self._keyword_io = KeywordIO()

--- a/safe/report/processors/default.py
+++ b/safe/report/processors/default.py
@@ -268,25 +268,33 @@ def qgis_composer_renderer(impact_report, component):
         item_id = map_el.get('id')
         split_count = map_el.get('grid_split_count')
         layers = map_el.get('layers')
+        map_extent_option = map_el.get('extent')
         composer_map = composition.getComposerItemById(item_id)
         """:type: qgis.core.QgsComposerMap"""
         if composer_map:
             composer_map.setKeepLayerSet(True)
             composer_map.setLayerSet(
                 [l.id() for l in layers])
-            # composer_map.zoomToExtent(square_extent)
-            extent = QgsRectangle()
-            extent.setMinimal()
-            for l in layers:
-                extent.combineExtentWith(l.extent())
+            if map_extent_option and isinstance(
+                    map_extent_option, QgsRectangle):
+                # use provided map extent
+                extent = map_extent_option
+            else:
+                # if map extent not provided, try to calculate extent
+                # from list of given layers. Combine it so all layers were
+                # shown properly
+                extent = QgsRectangle()
+                extent.setMinimal()
+                for l in layers:
+                    # combine extent if different layer is provided.
+                    extent.combineExtentWith(l.extent())
 
-            canvas_extent = extent
-            width = canvas_extent.width()
-            height = canvas_extent.height()
+            width = extent.width()
+            height = extent.height()
             longest_width = width if width > height else height
             half_length = longest_width / 2
             margin = half_length / 5
-            center = canvas_extent.center()
+            center = extent.center()
             min_x = center.x() - half_length - margin
             max_x = center.x() + half_length + margin
             min_y = center.y() - half_length - margin

--- a/safe/report/test/test_impact_report.py
+++ b/safe/report/test/test_impact_report.py
@@ -977,8 +977,9 @@ class TestImpactReport(unittest.TestCase):
         # insert layer to registry
         layer_registry = QgsMapLayerRegistry.instance()
         layer_registry.removeAllMapLayers()
-        rendered_layer = impact_function.exposure_impacted
-        layer_registry.addMapLayer(rendered_layer)
+        rendered_layer = impact_function.impact
+        for layer in impact_function.outputs:
+            layer_registry.addMapLayer(layer)
 
         # Create impact report
         report_metadata = ReportMetadata(


### PR DESCRIPTION
Map report now auto zoom in to analysis extent only, instead of all included layers.

<img width="940" alt="screen shot 2017-02-13 at 22 57 32" src="https://cloud.githubusercontent.com/assets/831865/22890754/e7ea9e56-f23f-11e6-8594-a08f9d532fde.png">
