### PR TITLE
revamp of the hazard conditional styling

### DIFF
--- a/safe/definitions/default_settings.py
+++ b/safe/definitions/default_settings.py
@@ -14,6 +14,7 @@ inasafe_default_settings = {
     'showOrganisationLogoInDockFlag': False,
     'developer_mode': False,
     'generate_report': True,
+    'add_conditional_styling': False,
 
     'ISO19115_ORGANIZATION': 'InaSAFE.org',
     'ISO19115_URL': 'http://inasafe.org',

--- a/safe/gui/tools/options_dialog.py
+++ b/safe/gui/tools/options_dialog.py
@@ -94,6 +94,7 @@ class OptionsDialog(QtGui.QDialog, FORM_CLASS):
             'showOrganisationLogoInDockFlag':
                 self.organisation_on_dock_checkbox,
             'developer_mode': self.cbxDevMode,
+            'add_conditional_styling': self.add_conditional_styling,
             'generate_report': self.checkbox_generate_reports,
         }
         self.text_settings = {

--- a/safe/gui/ui/options_dialog_base.ui
+++ b/safe/gui/ui/options_dialog_base.ui
@@ -47,7 +47,7 @@
        <item row="0" column="0">
         <widget class="QTabWidget" name="tabWidget">
          <property name="currentIndex">
-          <number>4</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="tab_basic">
           <attribute name="title">
@@ -126,6 +126,13 @@
                 <widget class="QCheckBox" name="cbxUseSelectedFeaturesOnly">
                  <property name="text">
                   <string>Use selected features only with the aggregation layer</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="add_conditional_styling">
+                 <property name="text">
+                  <string>Add icon for the hazard class in the attribute table (may break the alignment)</string>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
### What does it fix ?
* Description : Revamp of the hazard conditional styling.

![screen shot 2017-02-13 at 19 49 20](https://cloud.githubusercontent.com/assets/1609292/22897864/9262caea-f225-11e6-91f6-6c9ff97acde3.png)

As it breaks the alignment (bug in QGIS), it's not enabled by default. You need to go in inasafe settings to enable this feature.
