### PR TITLE
fix issue #3822: QPT should be made available

### DIFF
--- a/safe/definitions/__init__.py
+++ b/safe/definitions/__init__.py
@@ -26,3 +26,4 @@ from safe.definitions.minimum_needs import *
 from safe.definitions.post_processors import *
 from safe.definitions.units import *
 from safe.definitions.versions import *
+from safe.definitions.reports import *

--- a/safe/definitions/reports/__init__.py
+++ b/safe/definitions/reports/__init__.py
@@ -1,0 +1,121 @@
+# coding=utf-8
+"""
+Definitions for basic report
+"""
+from __future__ import absolute_import
+
+from safe.utilities.i18n import tr
+
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
+
+# Meta description about component
+
+# component generation type
+jinja2_component_type = {
+    'key': 'jinja2_component_type',
+    'name': 'Jinja2',
+    'description': tr('A component that is generated using Jinja2 API.')
+}
+
+qgis_composer_component_type = {
+    'key': 'qgis_composer_component_type',
+    'name': 'QGISComposer',
+    'description': tr('A component that is generated using QGISComposer API.')
+}
+
+qt_renderer_component_type = {
+    'key': 'qt_renderer_component_type',
+    'name': 'QtRenderer',
+    'description': tr('A component that is generated using QtRenderer API.')
+}
+
+available_component_type = [
+    jinja2_component_type,
+    qgis_composer_component_type,
+    qt_renderer_component_type
+]
+
+# Tags
+# Tags is a way to categorize different component quickly for easy
+# retrieval
+final_product_tag = {
+    'key': 'final_product_tag',
+    'name': tr('Final Product'),
+    'description': tr(
+        'Tag this component as a Final Product of report generation.')
+}
+
+infographic_product_tag = {
+    'key': 'infographic_product_tag',
+    'name': tr('Infographic'),
+    'description': tr(
+        'Tag this component as an Infographic related product.')
+}
+
+map_product_tag = {
+    'key': 'map_product_tag',
+    'name': tr('Map'),
+    'description': tr(
+        'Tag this component as a product mainly to show map.')
+}
+
+table_product_tag = {
+    'key': 'table_product_tag',
+    'name': tr('Table'),
+    'description': tr(
+        'Tag this component as a product mainly with table.')
+}
+
+template_product_tag = {
+    'key': 'template_product_tag',
+    'name': tr(
+        'Tag this component as a QGIS Template product.')
+}
+
+product_type_tag = [
+    table_product_tag,
+    map_product_tag,
+    template_product_tag,
+    infographic_product_tag
+]
+
+
+html_product_tag = {
+    'key': 'html_product_tag',
+    'name': tr('HTML'),
+    'description': tr('Tag this product as HTML output.')
+}
+
+pdf_product_tag = {
+    'key': 'pdf_product_tag',
+    'name': tr('PDF'),
+    'description': tr('Tag this product as PDF output.')
+}
+
+qpt_product_tag = {
+    'key': 'qpt_product_tag',
+    'name': tr('QPT'),
+    'description': tr('Tag this product as QPT output.')
+}
+
+png_product_tag = {
+    'key': 'png_product_tag',
+    'name': tr('PNG'),
+    'description': tr('Tag this product as PNG output.')
+}
+
+svg_product_tag = {
+    'key': 'svg_product_tag',
+    'name': tr('SVG'),
+    'description': tr('Tag this product as SVG output.')
+}
+
+product_output_type_tag = [
+    html_product_tag,
+    pdf_product_tag,
+    qpt_product_tag,
+    png_product_tag,
+]

--- a/safe/definitions/reports/components.py
+++ b/safe/definitions/reports/components.py
@@ -1,9 +1,23 @@
 # coding=utf-8
+"""Contains definitions about Report components.
 
 """
-Definitions for basic report
-"""
 from __future__ import absolute_import
+
+from safe.definitions.reports import (
+    jinja2_component_type,
+    qgis_composer_component_type,
+    qt_renderer_component_type,
+    svg_product_tag,
+    png_product_tag,
+    infographic_product_tag,
+    final_product_tag,
+    html_product_tag,
+    table_product_tag,
+    map_product_tag,
+    pdf_product_tag,
+    template_product_tag,
+    qpt_product_tag)
 
 from safe.common.utilities import safe_dir
 from safe.definitions.fields import (
@@ -39,7 +53,6 @@ from safe.report.processors.default import (
     qgis_composer_html_renderer,
     qt_svg_to_png_renderer)
 from safe.report.report_metadata import (
-    ReportComponentsMetadata,
     Jinja2ComponentsMetadata,
     QgisComposerComponentsMetadata)
 from safe.utilities.i18n import tr
@@ -50,10 +63,11 @@ __license__ = "GPL version 3"
 __email__ = "info@inasafe.org"
 __revision__ = '$Format:%H$'
 
+
 # Individual report component
 analysis_result_component = {
     'key': 'analysis-result',
-    'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
+    'type': jinja2_component_type,
     'processor': jinja2_renderer,
     'extractor': analysis_result_extractor,
     'output_format': Jinja2ComponentsMetadata.OutputFormat.String,
@@ -91,7 +105,7 @@ analysis_result_component = {
 
 analysis_breakdown_component = {
     'key': 'analysis-breakdown',
-    'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
+    'type': jinja2_component_type,
     'processor': jinja2_renderer,
     'extractor': analysis_detail_extractor,
     'output_format': Jinja2ComponentsMetadata.OutputFormat.String,
@@ -111,7 +125,7 @@ analysis_breakdown_component = {
 
 action_checklist_component = {
     'key': 'action-checklist',
-    'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
+    'type': jinja2_component_type,
     'processor': jinja2_renderer,
     'extractor': action_checklist_extractor,
     'output_format': Jinja2ComponentsMetadata.OutputFormat.String,
@@ -126,7 +140,7 @@ action_checklist_component = {
 
 notes_assumptions_component = {
     'key': 'notes-assumptions',
-    'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
+    'type': jinja2_component_type,
     'processor': jinja2_renderer,
     'extractor': notes_assumptions_extractor,
     'output_format': Jinja2ComponentsMetadata.OutputFormat.String,
@@ -141,7 +155,7 @@ notes_assumptions_component = {
 
 minimum_needs_component = {
     'key': 'minimum-needs',
-    'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
+    'type': jinja2_component_type,
     'processor': jinja2_renderer,
     'extractor': minimum_needs_extractor,
     'output_format': Jinja2ComponentsMetadata.OutputFormat.String,
@@ -160,7 +174,7 @@ minimum_needs_component = {
 
 aggregation_result_component = {
     'key': 'aggregation-result',
-    'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
+    'type': jinja2_component_type,
     'processor': jinja2_renderer,
     'extractor': aggregation_result_extractor,
     'output_format': Jinja2ComponentsMetadata.OutputFormat.String,
@@ -181,7 +195,7 @@ aggregation_result_component = {
 
 aggregation_postprocessors_component = {
     'key': 'aggregation-postprocessors',
-    'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
+    'type': jinja2_component_type,
     'processor': jinja2_renderer,
     'extractor': aggregation_postprocessors_extractor,
     'output_format': Jinja2ComponentsMetadata.OutputFormat.String,
@@ -215,7 +229,7 @@ aggregation_postprocessors_component = {
 
 population_chart_svg_component = {
     'key': 'population-chart',
-    'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
+    'type': jinja2_component_type,
     'processor': jinja2_renderer,
     'extractor': population_chart_extractor,
     'output_format': Jinja2ComponentsMetadata.OutputFormat.File,
@@ -223,6 +237,7 @@ population_chart_svg_component = {
     'template': 'standard-template'
                 '/jinja2/svg'
                 '/donut-chart.svg',
+    'tags': [svg_product_tag],
     'extra_args': {
         'chart_title': tr('Estimated total population'),
         'total_header': tr('Population')
@@ -232,11 +247,12 @@ population_chart_svg_component = {
 population_chart_png_component = {
     # This component depends on population_chart_svg_component
     'key': 'population-chart-png',
-    'type': ReportComponentsMetadata.AvailableComponent.QtRenderer,
+    'type': qt_renderer_component_type,
     'processor': qt_svg_to_png_renderer,
     'extractor': population_chart_to_png_extractor,
     'output_format': Jinja2ComponentsMetadata.OutputFormat.File,
     'output_path': 'population-chart.png',
+    'tags': [png_product_tag],
     'extra_args': {
         'width': 256,
         'height': 256
@@ -246,7 +262,7 @@ population_chart_png_component = {
 population_infographic_component = {
     # This component depends on population_chart_png_component
     'key': 'population-infographic',
-    'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
+    'type': jinja2_component_type,
     'processor': jinja2_renderer,
     'extractor': population_infographic_extractor,
     'output_format': Jinja2ComponentsMetadata.OutputFormat.String,
@@ -327,7 +343,7 @@ standard_impact_report_metadata_html = {
         # Infographic Layout HTML
         {
             'key': 'infographic-layout',
-            'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
+            'type': jinja2_component_type,
             'processor': jinja2_renderer,
             'extractor': infographic_layout_extractor,
             'output_format': Jinja2ComponentsMetadata.OutputFormat.File,
@@ -342,10 +358,15 @@ standard_impact_report_metadata_html = {
             'template': 'standard-template/'
                         'jinja2/'
                         'infographic-layout.html',
+            'tags': [
+                final_product_tag,
+                infographic_product_tag,
+                html_product_tag
+            ]
         },
         {
             'key': 'impact-report',
-            'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
+            'type': jinja2_component_type,
             'processor': jinja2_renderer,
             'extractor': impact_table_extractor,
             'output_format': Jinja2ComponentsMetadata.OutputFormat.File,
@@ -353,11 +374,26 @@ standard_impact_report_metadata_html = {
             'template': 'standard-template/'
                         'jinja2/'
                         'impact-report-layout.html',
+            'tags': [
+                final_product_tag,
+                table_product_tag,
+                html_product_tag
+            ],
             'extra_args': {
                 'defaults': {
                     'source': tr('source not available'),
                     'reference': tr('reference unspecified'),
                     'aggregation_not_used': tr('not used')
+                },
+                'components_list': {
+                    'analysis_result': analysis_result_component,
+                    'analysis_breakdown': analysis_breakdown_component,
+                    'action_checklist': action_checklist_component,
+                    'notes_assumptions': notes_assumptions_component,
+                    'minimum_needs': minimum_needs_component,
+                    'aggregation_result': aggregation_result_component,
+                    'aggregation_postprocessors': (
+                        aggregation_postprocessors_component)
                 },
                 'provenance_format': {
                     'hazard_header': tr(
@@ -394,16 +430,21 @@ standard_impact_report_metadata_pdf = {
         # Impact Report PDF
         {
             'key': 'impact-report-pdf',
-            'type': ReportComponentsMetadata.AvailableComponent.QGISComposer,
+            'type': qgis_composer_component_type,
             'processor': qgis_composer_html_renderer,
             'extractor': impact_table_pdf_extractor,
             'output_format': QgisComposerComponentsMetadata.OutputFormat.PDF,
             'output_path': 'impact-report-output.pdf',
+            'tags': [
+                final_product_tag,
+                table_product_tag,
+                pdf_product_tag
+            ]
         },
         # Infographic Layout PDF
         {
             'key': 'infographic-pdf',
-            'type': ReportComponentsMetadata.AvailableComponent.QGISComposer,
+            'type': qgis_composer_component_type,
             'processor': qgis_composer_html_renderer,
             'extractor': infographic_pdf_extractor,
             'output_format': QgisComposerComponentsMetadata.OutputFormat.PDF,
@@ -411,40 +452,11 @@ standard_impact_report_metadata_pdf = {
             'page_dpi': 300,
             'page_width': 297,
             'page_height': 210,
-        }
-    ]
-}
-
-# Standard PDF Output for infographic report
-standard_infographic_report_metadata_pdf = {
-    'key': 'infographic-result-pdf',
-    'name': 'infographic-result-pdf',
-    'template_folder': safe_dir(sub_dir='../resources/report-templates/'),
-    'components': [
-        population_chart_svg_component,
-        population_chart_png_component,
-        population_infographic_component,
-        {
-            'key': 'infographic-layout',
-            'type': ReportComponentsMetadata.AvailableComponent.Jinja2,
-            'processor': jinja2_renderer,
-            'extractor': infographic_layout_extractor,
-            'output_format': Jinja2ComponentsMetadata.OutputFormat.File,
-            'output_path': 'infographic.html',
-            'extra_args': {
-                'infographics': [population_infographic_component['key']]
-            },
-        },
-        {
-            'key': 'infographic-pdf',
-            'type': ReportComponentsMetadata.AvailableComponent.QGISComposer,
-            'processor': qgis_composer_html_renderer,
-            'extractor': infographic_pdf_extractor,
-            'output_format': QgisComposerComponentsMetadata.OutputFormat.PDF,
-            'output_path': 'infographic.pdf',
-            'page_dpi': 300,
-            'page_width': 297,
-            'page_height': 210,
+            'tags': [
+                final_product_tag,
+                infographic_product_tag,
+                pdf_product_tag
+            ]
         }
     ]
 }
@@ -483,24 +495,50 @@ report_a4_blue = {
     'components': [
         {
             'key': 'a4-portrait-blue',
-            'type': ReportComponentsMetadata.AvailableComponent.QGISComposer,
+            'type': qgis_composer_component_type,
             'processor': qgis_composer_renderer,
             'extractor': qgis_composer_extractor,
-            'output_format': QgisComposerComponentsMetadata.OutputFormat.PDF,
+            'output_format': {
+                'map': QgisComposerComponentsMetadata.OutputFormat.PDF,
+                'template': QgisComposerComponentsMetadata.OutputFormat.QPT
+            },
             'template': '../qgis-composer-templates/'
                         'a4-portrait-blue.qpt',
-            'output_path': 'a4-portrait-blue.pdf',
+            'tags': [
+                final_product_tag,
+                map_product_tag,
+                template_product_tag,
+                pdf_product_tag,
+                qpt_product_tag
+            ],
+            'output_path': {
+                'map': 'a4-portrait-blue.pdf',
+                'template': 'a4-portrait-blue.qpt'
+            },
             'extra_args': map_report_extra_args
         },
         {
             'key': 'a4-landscape-blue',
-            'type': ReportComponentsMetadata.AvailableComponent.QGISComposer,
+            'type': qgis_composer_component_type,
             'processor': qgis_composer_renderer,
             'extractor': qgis_composer_extractor,
-            'output_format': QgisComposerComponentsMetadata.OutputFormat.PDF,
+            'output_format': {
+                'map': QgisComposerComponentsMetadata.OutputFormat.PDF,
+                'template': QgisComposerComponentsMetadata.OutputFormat.QPT
+            },
             'template': '../qgis-composer-templates/'
                         'a4-landscape-blue.qpt',
-            'output_path': 'a4-landscape-blue.pdf',
+            'tags': [
+                final_product_tag,
+                map_product_tag,
+                template_product_tag,
+                pdf_product_tag,
+                qpt_product_tag
+            ],
+            'output_path': {
+                'map': 'a4-landscape-blue.pdf',
+                'template': 'a4-landscape-blue.qpt'
+            },
             'orientation': 'landscape',
             'page_dpi': 300,
             'page_width': 297,

--- a/safe/gui/analysis_utilities.py
+++ b/safe/gui/analysis_utilities.py
@@ -3,12 +3,11 @@
 import os
 from collections import OrderedDict
 from PyQt4.QtCore import QDir, Qt
-from PyQt4.QtCore import QSettings
 from qgis.core import QgsMapLayerRegistry, QgsProject, QgsMapLayer, QGis
 
 from safe.definitions.utilities import definition
 from safe.definitions.fields import hazard_class_field
-from safe.definitions.report import (
+from safe.definitions.reports.components import (
     standard_impact_report_metadata_pdf,
     report_a4_blue)
 from safe.impact_function.style import hazard_class_style

--- a/safe/gui/tools/batch/batch_dialog.py
+++ b/safe/gui/tools/batch/batch_dialog.py
@@ -53,7 +53,7 @@ from safe.definitions.layer_purposes import (
     layer_purpose_hazard,
     layer_purpose_exposure,
     layer_purpose_aggregation)
-from safe.definitions.report import (
+from safe.definitions.reports.components import (
     standard_impact_report_metadata_pdf,
     report_a4_blue)
 from safe.utilities.gis import extent_string_to_array

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -38,7 +38,16 @@ from safe.definitions.constants import (
     PREPARE_SUCCESS,
 )
 from safe.defaults import supporters_logo_path
+from safe.definitions.reports import (
+    final_product_tag,
+    pdf_product_tag,
+    html_product_tag,
+    qpt_product_tag)
+from safe.definitions.reports.components import (
+    standard_impact_report_metadata_pdf,
+    report_a4_blue)
 from safe.report.impact_report import ImpactReport
+from safe.report.report_metadata import ReportMetadata
 from safe.utilities.gis import wkt_to_rectangle
 from safe.utilities.i18n import tr
 from safe.utilities.keyword_io import KeywordIO
@@ -1039,37 +1048,90 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         # Get output path from datastore
         # Fetch report for pdfs report
         report_path = os.path.dirname(impact_layer.source())
-        output_paths = [
-            os.path.join(
-                report_path,
-                'output/impact-report-output.pdf'),
-            os.path.join(
-                report_path,
-                'output/a4-portrait-blue.pdf'),
-            os.path.join(
-                report_path,
-                'output/a4-landscape-blue.pdf'),
+
+        # TODO: temporary hack until Impact Function becomes serializable
+        # need to have impact report
+        standard_impact_report_metadata = ReportMetadata(
+            metadata_dict=standard_impact_report_metadata_pdf)
+        standard_map_report_metadata = ReportMetadata(
+            metadata_dict=report_a4_blue)
+
+        standard_report_metadata = [
+            standard_impact_report_metadata,
+            standard_map_report_metadata
         ]
 
-        # Make sure the file paths can wrap nicely:
-        wrapped_output_paths = [
-            path.replace(os.sep, '<wbr>' + os.sep) for path in
-            output_paths]
+        def retrieve_components(tags):
+            products = []
+            for report_metadata in standard_report_metadata:
+                products += (report_metadata.component_by_tags(tags))
+            return products
+
+        def retrieve_paths(products, suffix=None):
+            paths = []
+            for c in products:
+                path = ImpactReport.absolute_output_path(
+                    os.path.join(report_path, 'output'),
+                    products,
+                    c.key)
+                if isinstance(path, list):
+                    for p in path:
+                        paths.append(p)
+                elif isinstance(path, dict):
+                    for p in path.itervalues():
+                        paths.append(p)
+                else:
+                    paths.append(path)
+            if suffix:
+                paths = [p for p in paths if p.endswith(suffix)]
+
+            paths = [p for p in paths if os.path.exists(p)]
+            return paths
+
+        def wrap_output_paths(paths):
+            """Make sure the file paths can wrap nicely."""
+            return [p.replace(os.sep, '<wbr>' + os.sep) for p in paths]
+
+        pdf_products = retrieve_components(
+            [final_product_tag, pdf_product_tag])
+        pdf_output_paths = retrieve_paths(pdf_products, '.pdf')
+
+        html_products = retrieve_components(
+                [final_product_tag, html_product_tag])
+        html_output_paths = retrieve_paths(html_products, '.html')
+
+        qpt_products = retrieve_components(
+            [final_product_tag, qpt_product_tag])
+        qpt_output_paths = retrieve_paths(qpt_products, '.qpt')
 
         # create message to user
         status = m.Message(
             m.Heading(self.tr('Map Creator'), **INFO_STYLE),
             m.Paragraph(self.tr(
                 'Your PDF was created....opening using the default PDF '
-                'viewer on your system. The generated pdfs were saved '
+                'viewer on your system.')),
+            m.ImportantText(self.tr(
+                'The generated pdfs were saved '
                 'as:')))
 
-        for path in wrapped_output_paths:
+        for path in wrap_output_paths(pdf_output_paths):
+            status.add(m.Paragraph(path))
+
+        status.add(m.Paragraph(
+            m.ImportantText(self.tr('The generated htmls were saved as:'))))
+
+        for path in wrap_output_paths(html_output_paths):
+            status.add(m.Paragraph(path))
+
+        status.add(m.Paragraph(
+            m.ImportantText(self.tr('The generated qpts were saved as:'))))
+
+        for path in wrap_output_paths(qpt_output_paths):
             status.add(m.Paragraph(path))
 
         send_static_message(self, status)
 
-        for path in output_paths:
+        for path in pdf_output_paths:
             # noinspection PyCallByClass,PyTypeChecker,PyTypeChecker
             QtGui.QDesktopServices.openUrl(
                 QtCore.QUrl.fromLocalFile(path))

--- a/safe/report/extractors/impact_table.py
+++ b/safe/report/extractors/impact_table.py
@@ -37,40 +37,14 @@ def impact_table_extractor(impact_report, component_metadata):
     context = {}
     extra_args = component_metadata.extra_args
 
-    # Imported here to avoid cyclic dependencies
-    from safe.definitions.report import (
-        analysis_result_component,
-        analysis_breakdown_component,
-        action_checklist_component,
-        notes_assumptions_component,
-        minimum_needs_component,
-        aggregation_result_component,
-        aggregation_postprocessors_component)
-
-    analysis_result = jinja2_output_as_string(
-        impact_report, analysis_result_component['key'])
-    analysis_breakdown = jinja2_output_as_string(
-        impact_report, analysis_breakdown_component['key'])
-    action_checklist = jinja2_output_as_string(
-        impact_report, action_checklist_component['key'])
-    notes_assumptions = jinja2_output_as_string(
-        impact_report, notes_assumptions_component['key'])
-    minimum_needs = jinja2_output_as_string(
-        impact_report, minimum_needs_component['key'])
-    aggregation_result = jinja2_output_as_string(
-        impact_report, aggregation_result_component['key'])
-    aggregation_postprocessors = jinja2_output_as_string(
-        impact_report, aggregation_postprocessors_component['key'])
+    components_list = resolve_from_dictionary(
+        extra_args, 'components_list')
 
     context['brand_logo'] = resource_url(
             resources_path('img', 'logos', 'inasafe-logo-white.png'))
-    context['analysis_result'] = analysis_result
-    context['analysis_breakdown'] = analysis_breakdown
-    context['action_checklist'] = action_checklist
-    context['notes_assumptions'] = notes_assumptions
-    context['minimum_needs'] = minimum_needs
-    context['aggregation_result'] = aggregation_result
-    context['aggregation_postprocessors'] = aggregation_postprocessors
+    for key, component in components_list.iteritems():
+        context[key] = jinja2_output_as_string(
+            impact_report, component['key'])
 
     default_source = resolve_from_dictionary(
         extra_args, ['defaults', 'source'])

--- a/safe/report/impact_report.py
+++ b/safe/report/impact_report.py
@@ -351,20 +351,56 @@ class ImpactReport(object):
         if not os.path.exists(self._output_folder):
             os.makedirs(self._output_folder)
 
+    @staticmethod
+    def absolute_output_path(
+            output_folder, components, component_key):
+        """Return absolute output path of component.
+
+        :param output_folder: The base output folder
+        :type output_folder: str
+
+        :param components: The list of components to look up
+        :type components: list[ReportMetadata]
+
+        :param component_key: The component key
+        :type component_key: str
+
+        :return:
+        """
+        comp_keys = [c.key for c in components]
+
+        if component_key in comp_keys:
+            idx = comp_keys.index(component_key)
+            output_path = components[idx].output_path
+            if isinstance(output_path, str):
+                return os.path.abspath(
+                    os.path.join(output_folder, output_path))
+            elif isinstance(output_path, list):
+                output_list = []
+                for path in output_path:
+                    output_list.append(os.path.abspath(
+                        os.path.join(output_folder, path)))
+                return output_list
+            elif isinstance(output_path, dict):
+                output_dict = {}
+                for key, path in output_path.iteritems():
+                    output_dict[key] = os.path.abspath(
+                        os.path.join(output_folder, path))
+                return output_dict
+        return None
+
     def component_absolute_output_path(self, component_key):
         """Return absolute output path of component.
 
-        :param component_key:
+        :param component_key: The component key
+        :type component_key: str
+
         :return:
         """
-        comp_keys = [c.key for c in self.metadata.components]
-        if component_key in comp_keys:
-            idx = comp_keys.index(component_key)
-            return os.path.abspath(
-                os.path.join(
-                    self.output_folder,
-                    self.metadata.components[idx].output_path))
-        return None
+        return ImpactReport.absolute_output_path(
+            self.output_folder,
+            self.metadata.components,
+            component_key)
 
     @property
     def impact_function(self):

--- a/safe/report/processors/default.py
+++ b/safe/report/processors/default.py
@@ -30,6 +30,7 @@ from qgis.core import (
 
 from safe.common.exceptions import TemplateLoadingError
 from safe.common.utilities import temp_dir
+from safe.report.report_metadata import QgisComposerComponentsMetadata
 from safe.utilities.i18n import tr
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
@@ -79,8 +80,8 @@ def jinja2_renderer(impact_report, component):
     elif component.output_format == 'file':
         if impact_report.output_folder is None:
             impact_report.output_folder = mkdtemp(dir=temp_dir())
-        output_path = os.path.join(
-            impact_report.output_folder, component.output_path)
+        output_path = impact_report.component_absolute_output_path(
+            component.key)
 
         # make sure directory is created
         dirname = os.path.dirname(output_path)
@@ -163,8 +164,8 @@ def qgis_composer_html_renderer(impact_report, component):
     # in case output folder not specified
     if impact_report.output_folder is None:
         impact_report.output_folder = mkdtemp(dir=temp_dir())
-    output_path = os.path.join(
-        impact_report.output_folder, component.output_path)
+    output_path = impact_report.component_absolute_output_path(
+        component.key)
 
     # make sure directory is created
     dirname = os.path.dirname(output_path)
@@ -351,30 +352,126 @@ def qgis_composer_renderer(impact_report, component):
     # in case output folder not specified
     if impact_report.output_folder is None:
         impact_report.output_folder = mkdtemp(dir=temp_dir())
-    output_path = os.path.join(
-        impact_report.output_folder, component.output_path)
 
-    # make sure directory is created
-    dirname = os.path.dirname(output_path)
-    if not os.path.exists(dirname):
-        os.makedirs(dirname, exist_ok=True)
+    def create_map_output(output_path, file_format, metadata):
+        """Produce PDF Map output.
+
+        :param output_path: the output path
+        :type output_path: str
+
+        :param file_format: file format of map output, PDF or PNG
+        :type file_format: 'pdf', 'png'
+
+        :param metadata: the component metadata
+        :type metadata: QgisComposerComponentsMetadata
+
+        :return: generated output path
+        :rtype: str
+        """
+
+        # make sure directory is created
+        dirname = os.path.dirname(output_path)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname, exist_ok=True)
+
+        # for QGIS composer only pdf and png output are available
+        if file_format == QgisComposerComponentsMetadata.OutputFormat.PDF:
+            try:
+                composition.setPlotStyle(
+                    impact_report.qgis_composition_context.plot_style)
+                composition.setPrintResolution(metadata.page_dpi)
+                composition.setPaperSize(
+                    metadata.page_width, metadata.page_height)
+                composition.setPrintAsRaster(
+                    impact_report.qgis_composition_context.save_as_raster)
+
+                composition.exportAsPDF(output_path)
+            except Exception as exc:
+                LOGGER.error(exc)
+                return None
+        elif file_format == QgisComposerComponentsMetadata.OutputFormat.PNG:
+            # TODO: implement PNG generations
+            raise Exception('Not yet supported')
+        return output_path
+
+    def create_qgis_template_output(output_path, qgis_composition):
+        """Produce QGIS Template output.
+
+        :param output_path: the output path
+        :type output_path: str
+
+        :param qgis_composition: QGIS Composition object to get template
+            values
+        :type qgis_composition: QgsComposition
+
+        :return: generated output path
+        :rtype: str
+        """
+
+        # make sure directory is created
+        dirname = os.path.dirname(output_path)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname, exist_ok=True)
+
+        template_document = QtXml.QDomDocument()
+        element = template_document.createElement('Composer')
+        qgis_composition.writeXML(element, template_document)
+        template_document.appendChild(element)
+
+        with open(output_path, 'w') as f:
+            f.write(template_document.toByteArray())
+
+        return output_path
 
     output_format = component.output_format
-    # for QGIS composer only pdf and png output are available
-    if output_format == 'pdf':
-        try:
-            composition.setPlotStyle(
-                impact_report.qgis_composition_context.plot_style)
-            composition.setPrintResolution(component.page_dpi)
-            composition.setPaperSize(
-                component.page_width, component.page_height)
-            composition.setPrintAsRaster(
-                impact_report.qgis_composition_context.save_as_raster)
+    component_output_path = impact_report.component_absolute_output_path(
+        component.key)
+    component_output = None
 
-            composition.exportAsPDF(output_path)
-            component.output = output_path
-        except Exception as exc:
-            LOGGER.error(exc)
+    map_format = QgisComposerComponentsMetadata.OutputFormat.MAP_OUTPUT
+    template_format = QgisComposerComponentsMetadata.OutputFormat.QPT
+    if isinstance(output_format, list):
+        component_output = []
+        for i in range(len(output_format)):
+            each_format = output_format[i]
+            each_path = component_output_path[i]
+
+            if each_format in map_format:
+                result_path = create_map_output(
+                    each_path, each_format, component)
+                component_output.append(result_path)
+            elif each_format == template_format:
+                result_path = create_qgis_template_output(
+                    each_path, composition)
+                component_output.append(result_path)
+    elif isinstance(output_format, dict):
+        component_output = {}
+        for key, each_format in output_format.iteritems():
+            each_path = component_output_path[key]
+
+            if each_format in map_format:
+                result_path = create_map_output(
+                    each_path, each_format, component)
+                component_output[key] = result_path
+            elif each_format == template_format:
+                result_path = create_qgis_template_output(
+                    each_path, composition)
+                component_output[key] = result_path
+    elif (output_format in
+            QgisComposerComponentsMetadata.OutputFormat.SUPPORTED_OUTPUT):
+        component_output = None
+
+        if output_format in map_format:
+            result_path = create_map_output(
+                component_output_path, output_format, component)
+            component_output = result_path
+        elif output_format == template_format:
+            result_path = create_qgis_template_output(
+                component_output_path, composition)
+            component_output = result_path
+
+    component.output = component_output
+
     return component.output
 
 
@@ -408,10 +505,10 @@ def qt_svg_to_png_renderer(impact_report, component):
     # in case output folder not specified
     if impact_report.output_folder is None:
         impact_report.output_folder = mkdtemp(dir=temp_dir())
-    output_path = os.path.join(
-        impact_report.output_folder, component.output_path)
+    output_path = impact_report.component_absolute_output_path(
+        component.key)
 
     qimage.save(output_path)
 
     component.output = output_path
-    return component.output_path
+    return component.output

--- a/safe/report/test/test_impact_report.py
+++ b/safe/report/test/test_impact_report.py
@@ -27,7 +27,7 @@ from safe.test.utilities import (
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 
 from qgis.core import QgsMapLayerRegistry
-from safe.definitions.report import (
+from safe.definitions.reports.components import (
     report_a4_blue,
     standard_impact_report_metadata_html,
     standard_impact_report_metadata_pdf,
@@ -1216,11 +1216,13 @@ class TestImpactReport(unittest.TestCase):
             'a4-portrait-blue')
 
         # for now, test that output exists
-        self.assertTrue(os.path.exists(output_path))
+        for path in output_path.itervalues():
+            self.assertTrue(os.path.exists(path), msg=path)
 
         output_path = impact_report.component_absolute_output_path(
             'a4-landscape-blue')
 
-        self.assertTrue(os.path.exists(output_path))
+        for path in output_path.itervalues():
+            self.assertTrue(os.path.exists(path), msg=path)
 
         shutil.rmtree(output_folder, ignore_errors=True)


### PR DESCRIPTION
### What does it fix ?
* Ticket #3822 
* Description : 
QPT should be made available to user after report generations.

Changes:

- Different output now categorized:
<img width="587" alt="screen shot 2017-02-15 at 01 00 16" src="https://cloud.githubusercontent.com/assets/831865/22941974/26659890-f31a-11e6-9e10-5025e2df35d6.png">

- Template produced, with all string variable generated, default extent set, and images resolved.
<img width="1430" alt="screen shot 2017-02-15 at 01 03 09" src="https://cloud.githubusercontent.com/assets/831865/22942092/a685fe84-f31a-11e6-986e-9917d6d3f982.png">
