### PR TITLE
add notes in report when aggregation layer is not used

### DIFF
--- a/safe/definitions/report.py
+++ b/safe/definitions/report.py
@@ -356,7 +356,8 @@ standard_impact_report_metadata_html = {
             'extra_args': {
                 'defaults': {
                     'source': tr('source not available'),
-                    'reference': tr('reference unspecified')
+                    'reference': tr('reference unspecified'),
+                    'aggregation_not_used': tr('not used')
                 },
                 'provenance_format': {
                     'hazard_header': tr(
@@ -377,7 +378,7 @@ standard_impact_report_metadata_html = {
                     'impact_function_header': tr(
                         'Impact Function'),
                     'impact_function_format': tr(
-                        '{impact_function_name} - {reference} - '),
+                        '{impact_function_name}'),
                 }
             }
         }

--- a/safe/report/extractors/impact_table.py
+++ b/safe/report/extractors/impact_table.py
@@ -107,20 +107,24 @@ def impact_table_extractor(impact_report, component_metadata):
 
     aggregation_keywords = impact_report.impact_function.provenance[
         'aggregation_keywords']
+    header = resolve_from_dictionary(
+        provenance_format_args, 'aggregation_header')
+    provenance_format = resolve_from_dictionary(
+        provenance_format_args, 'aggregation_format')
     # only if aggregation layer used
     if aggregation_keywords:
-        header = resolve_from_dictionary(
-            provenance_format_args, 'aggregation_header')
-        provenance_format = resolve_from_dictionary(
-            provenance_format_args, 'aggregation_format')
-        aggregation_provenance = {
-            'header': header,
-            'provenance': provenance_format.format(
-                layer_name=aggregation_keywords.get('title'),
-                source=aggregation_keywords.get('source') or default_source)
-        }
+        provenance_string = provenance_format.format(
+            layer_name=aggregation_keywords.get('title'),
+            source=aggregation_keywords.get('source') or default_source)
     else:
-        aggregation_provenance = None
+        aggregation_not_used = resolve_from_dictionary(
+            extra_args, ['defaults', 'aggregation_not_used'])
+        provenance_string = aggregation_not_used
+
+    aggregation_provenance = {
+        'header': header,
+        'provenance': provenance_string
+    }
 
     impact_function_name = impact_report.impact_function.name
     header = resolve_from_dictionary(


### PR DESCRIPTION
### What does it fix ?
* Description : Show notes in report provenance when aggregation layer is not used

<img width="464" alt="screen shot 2017-02-15 at 00 11 37" src="https://cloud.githubusercontent.com/assets/831865/22940091/59b186ca-f313-11e6-894d-bdbc2a59333b.png">

Small fix. Please merge when passed.