### PR TITLE
Filter classification based on supported exposure.

### DIFF
--- a/safe/definitions/hazard.py
+++ b/safe/definitions/hazard.py
@@ -355,7 +355,6 @@ hazard_tsunami = {
         tsunami_hazard_population_classes,
         tsunami_hazard_classes_ITB,
         tsunami_hazard_population_classes_ITB,
-        generic_hazard_classes,
     ],
     'compulsory_fields': [hazard_value_field],
     'fields': hazard_fields,

--- a/safe/gui/tools/wizard/step_kw33_multi_classifications.py
+++ b/safe/gui/tools/wizard/step_kw33_multi_classifications.py
@@ -99,6 +99,10 @@ class StepKwMultiClassifications(WizardStep, FORM_CLASS):
         # GUI, good for testing
         self.save_button = None
 
+        # Has default threshold
+        # Trick for EQ raster for population #3853
+        self.default_thresholds = False
+
     def is_ready_to_next_step(self):
         """Check if the step is complete.
 
@@ -112,6 +116,9 @@ class StepKwMultiClassifications(WizardStep, FORM_CLASS):
             # Enable if there is one that has classification
             if combo_box.currentIndex() > 0:
                 return True
+        # Trick for EQ raster for population #3853
+        if self.default_thresholds:
+            return True
         return False
 
     def get_next_step(self):
@@ -190,6 +197,7 @@ class StepKwMultiClassifications(WizardStep, FORM_CLASS):
             # Trick for EQ raster for population #3853
             if exposure == exposure_population and hazard == hazard_earthquake:
                 if is_raster_layer(self.parent.layer):
+                    self.default_thresholds = True
                     continue
 
             # Add label

--- a/safe/gui/tools/wizard/step_kw33_multi_classifications.py
+++ b/safe/gui/tools/wizard/step_kw33_multi_classifications.py
@@ -179,9 +179,9 @@ class StepKwMultiClassifications(WizardStep, FORM_CLASS):
         left_panel_heading.setFont(big_font)
         self.left_layout.addWidget(left_panel_heading)
 
-        for exposure in exposure_all:
-            exposure_layout = QHBoxLayout()
+        self.inner_left_layout = QGridLayout()
 
+        for row, exposure in enumerate(exposure_all):
             # Add label
             # Hazard on Exposure Classifications
             label = tr('%s on %s Classifications' % (
@@ -196,8 +196,12 @@ class StepKwMultiClassifications(WizardStep, FORM_CLASS):
                 0, None, Qt.UserRole)
 
             current_index = 0
+            i = 0
             # Iterate through all available hazard classifications
-            for i, hazard_classification in enumerate(hazard_classifications):
+            for hazard_classification in hazard_classifications:
+                # Skip if the classification is not for the exposure
+                if exposure not in hazard_classification['exposures']:
+                    continue
                 exposure_combo_box.addItem(hazard_classification['name'])
                 exposure_combo_box.setItemData(
                     i + 1, hazard_classification, Qt.UserRole)
@@ -215,6 +219,7 @@ class StepKwMultiClassifications(WizardStep, FORM_CLASS):
                         is_active = current_hazard_classification.get('active')
                         if is_active:
                             current_index = i + 1
+                i += 1
             # Set current classification
             exposure_combo_box.setCurrentIndex(current_index)
 
@@ -239,15 +244,9 @@ class StepKwMultiClassifications(WizardStep, FORM_CLASS):
             )
 
             # Arrange in layout
-            exposure_layout.addWidget(exposure_label)
-            exposure_layout.addWidget(exposure_combo_box)
-            exposure_layout.addWidget(exposure_edit_button)
-
-            # Stretch
-            exposure_layout.setStretch(0, 0)
-            exposure_layout.setStretch(0, 0)
-            exposure_layout.setStretch(0, 1)
-            self.left_layout.addLayout(exposure_layout)
+            self.inner_left_layout.addWidget(exposure_label, row, 0)
+            self.inner_left_layout.addWidget(exposure_combo_box, row, 1)
+            self.inner_left_layout.addWidget(exposure_edit_button, row, 2)
 
             self.left_layout.addStretch(1)
 
@@ -256,6 +255,8 @@ class StepKwMultiClassifications(WizardStep, FORM_CLASS):
             self.exposure_combo_boxes.append(exposure_combo_box)
             self.exposure_edit_buttons.append(exposure_edit_button)
             self.exposure_labels.append(label)
+
+        self.left_layout.addLayout(self.inner_left_layout)
 
     # noinspection PyUnusedLocal
     def edit_button_clicked(self, edit_button, exposure_combo_box, exposure):

--- a/safe/gui/tools/wizard/test/test_keyword_wizard.py
+++ b/safe/gui/tools/wizard/test/test_keyword_wizard.py
@@ -26,7 +26,9 @@ from safe.definitions.exposure import (
     exposure_land_cover)
 from safe.definitions.hazard_category import hazard_category_multiple_event
 from safe.definitions.hazard_classifications import (
-    flood_hazard_classes, volcano_hazard_classes)
+    flood_hazard_classes,
+    volcano_hazard_classes,
+    earthquake_mmi_hazard_classes,)
 from safe.definitions.constants import no_field
 from safe.definitions.fields import (
     aggregation_name_field,
@@ -38,10 +40,11 @@ from safe.definitions.layer_geometry import (
     layer_geometry_polygon, layer_geometry_raster)
 from safe.definitions.exposure_classifications import (
     generic_structure_classes)
-from safe.definitions.units import count_exposure_unit, unit_metres
+from safe.definitions.units import count_exposure_unit, unit_metres, unit_mmi
 
 from safe.gui.tools.wizard.wizard_dialog import WizardDialog
-from safe.definitions.utilities import get_compulsory_fields
+from safe.definitions.utilities import (
+    get_compulsory_fields, default_classification_thresholds)
 from safe.utilities.unicode import byteify
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
@@ -2143,6 +2146,138 @@ class TestKeywordWizard(unittest.TestCase):
         num_item = dialog.step_kw_subcategory.lstSubcategories.count()
         self.assertTrue(num_item == 3)
 
+    def test_earthquake_raster(self):
+        """Test for Earthquake raster keyword wizard."""
+        path = standard_data_path('hazard', 'earthquake.tif')
+        message = "Path %s is not found" % path
+        self.assertTrue(os.path.exists(path), message)
+        layer = clone_raster_layer(
+            name='earthquake',
+            extension='.tif',
+            include_keywords=False,
+            source_directory=standard_data_path('hazard'))
+        self.assertIsNotNone(layer)
+        layer.keywords = {}
+
+        # noinspection PyTypeChecker
+        dialog = WizardDialog(iface=IFACE)
+        dialog.set_keywords_creation_mode(layer)
+
+        # Check if in select purpose step
+        self.check_current_step(dialog.step_kw_purpose)
+
+        # Select hazard
+        self.select_from_list_widget(
+            layer_purpose_hazard['name'], dialog.step_kw_purpose.lstCategories)
+
+        # Click next to select hazard
+        dialog.pbnNext.click()
+
+        # Check if in select hazard step
+        self.check_current_step(dialog.step_kw_subcategory)
+
+        # select EQ
+        self.select_from_list_widget(
+            hazard_earthquake['name'],
+            dialog.step_kw_subcategory.lstSubcategories)
+
+        # Click next to select EQ
+        dialog.pbnNext.click()
+
+        # Check if in select hazard category step
+        self.check_current_step(dialog.step_kw_hazard_category)
+
+        # select multiple_event
+        self.select_from_list_widget(
+            hazard_category_multiple_event['name'],
+            dialog.step_kw_hazard_category.lstHazardCategories)
+
+        # Click next to select multiple event
+        dialog.pbnNext.click()
+
+        # Check if in select layer mode step
+        self.check_current_step(dialog.step_kw_layermode)
+
+        # select continuous mode
+        self.select_from_list_widget(
+            layer_mode_continuous['name'],
+            dialog.step_kw_layermode.lstLayerModes)
+
+        # Click next to select continuous
+        dialog.pbnNext.click()
+
+        # Check if in unit step
+        self.check_current_step(dialog.step_kw_unit)
+
+        # select MMI
+        self.select_from_list_widget(
+            unit_mmi['name'],
+            dialog.step_kw_unit.lstUnits)
+
+        # Click next to select MMI
+        dialog.pbnNext.click()
+
+        # Check if in multi classification step
+        self.check_current_step(dialog.step_kw_multi_classifications)
+
+        # Click next to finish multi classifications step
+        dialog.pbnNext.click()
+
+        # Check if in source step
+        self.check_current_step(dialog.step_kw_source)
+
+        dialog.step_kw_source.leSource.setText(source)
+        dialog.step_kw_source.leSource_scale.setText(source_scale)
+        dialog.step_kw_source.leSource_url.setText(source_url)
+        dialog.step_kw_source.ckbSource_date.setChecked(True)
+        dialog.step_kw_source.dtSource_date.setDateTime(source_date)
+        dialog.step_kw_source.leSource_license.setText(source_license)
+
+        # Click next to finish source step and go to title step
+        dialog.pbnNext.click()
+
+        # Check if in title step
+        self.check_current_step(dialog.step_kw_title)
+
+        dialog.step_kw_title.leTitle.setText(layer_title)
+
+        # Click next to finish title step and go to kw summary step
+        dialog.pbnNext.click()
+
+        # Check if in title step
+        self.check_current_step(dialog.step_kw_summary)
+
+        # Click finish
+        dialog.pbnNext.click()
+
+        # Checking Keyword Created
+        expected_keyword = {
+            'continuous_hazard_unit': unit_mmi['key'],
+            'scale': source_scale,
+            'hazard_category': hazard_category_multiple_event['key'],
+            'license': source_license,
+            'source': source,
+            'url': source_url,
+            'title': layer_title,
+            'hazard': hazard_earthquake['key'],
+            'date': source_date,
+            'layer_geometry': layer_geometry_raster['key'],
+            'layer_purpose': layer_purpose_hazard['key'],
+            'layer_mode': layer_mode_continuous['key'],
+            'thresholds': {
+                exposure_population['key']: {
+                    earthquake_mmi_hazard_classes['key']: {
+                        'active': True,
+                        'classes': default_classification_thresholds(
+                            earthquake_mmi_hazard_classes)
+                    }
+                }
+            }
+        }
+
+        real_keywords = dialog.get_keywords()
+        self.assertDictEqual(real_keywords, expected_keyword)
+
     def check_radio_button_behaviour(self, inasafe_default_dialog):
         """Test radio button behaviour so they are disabled when user set the
            ratio field and enabled when there is no field selected.
@@ -2168,6 +2303,7 @@ class TestKeywordWizard(unittest.TestCase):
 
             parameter_widget.input.setCurrentIndex(current_index)
             self.assertTrue(dont_use_button.isChecked())
+
 
 if __name__ == '__main__':
     suite = unittest.makeSuite(TestKeywordWizard)

--- a/safe/gui/tools/wizard/wizard_dialog.py
+++ b/safe/gui/tools/wizard/wizard_dialog.py
@@ -21,8 +21,12 @@ from safe.definitions.layer_geometry import (
 from safe.definitions.layer_modes import (
     layer_mode_continuous, layer_mode_classified)
 from safe.definitions.units import exposure_unit
-from safe.definitions.hazard import continuous_hazard_unit
-from safe.definitions.utilities import get_compulsory_fields
+from safe.definitions.hazard import continuous_hazard_unit, hazard_earthquake
+from safe.definitions.hazard_classifications import (
+    earthquake_mmi_hazard_classes)
+from safe.definitions.exposure import exposure_population
+from safe.definitions.utilities import (
+    get_compulsory_fields, default_classification_thresholds)
 from safe.definitions.constants import RECENT
 
 from safe.common.exceptions import (
@@ -804,6 +808,20 @@ class WizardDialog(QDialog, FORM_CLASS):
 
         if inasafe_default_values:
             keywords['inasafe_default_values'] = inasafe_default_values
+
+        # For 3853
+        if keywords['layer_purpose'] == layer_purpose_hazard['key']:
+            if keywords['hazard'] == hazard_earthquake['key']:
+                if keywords['layer_geometry'] == layer_geometry_raster['key']:
+                    layer_mode = self.step_kw_layermode.selected_layermode()
+                    if layer_mode == layer_mode_continuous:
+                        keywords['thresholds'][exposure_population['key']] = {
+                            earthquake_mmi_hazard_classes['key']: {
+                                'classes': default_classification_thresholds(
+                                    earthquake_mmi_hazard_classes),
+                                'active': True
+                            }
+                        }
 
         return keywords
 

--- a/safe/gui/ui/wizard/step_kw33_multi_classifications.ui
+++ b/safe/gui/ui/wizard/step_kw33_multi_classifications.ui
@@ -50,19 +50,6 @@
      </item>
     </layout>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
### What does it fix ?
* Ticket #3853 #3854 
* Description : 
   - Filter out classification based on exposure
![multihazard_wizard_special_classification](https://cloud.githubusercontent.com/assets/1421861/23004216/fc3d79c0-f427-11e6-86cf-b39aacd9a0b5.gif)
   - Do special filter for EQ hazard
![multihazard_wizard_3853](https://cloud.githubusercontent.com/assets/1421861/23004919/e2c435c0-f42b-11e6-9c1d-97b1c9171159.gif)
    - Remove generic classification from tsunami hazard
![multihazard_wizard_3854](https://cloud.githubusercontent.com/assets/1421861/23007763/5f9aa3f2-f43d-11e6-865a-bf1bf9f7f733.gif)
