### PR TITLE
Disable EQ Raster Population classification.

### DIFF
--- a/safe/gui/tools/wizard/wizard_dialog.py
+++ b/safe/gui/tools/wizard/wizard_dialog.py
@@ -6,9 +6,7 @@ from sqlite3 import OperationalError
 
 from PyQt4 import QtGui
 from PyQt4.QtCore import pyqtSignature, QSettings
-from PyQt4.QtGui import (
-    QDialog,
-    QPixmap)
+from PyQt4.QtGui import QDialog, QPixmap
 from qgis.core import QgsMapLayerRegistry
 
 from safe.definitions.layer_purposes import (
@@ -21,12 +19,8 @@ from safe.definitions.layer_geometry import (
 from safe.definitions.layer_modes import (
     layer_mode_continuous, layer_mode_classified)
 from safe.definitions.units import exposure_unit
-from safe.definitions.hazard import continuous_hazard_unit, hazard_earthquake
-from safe.definitions.hazard_classifications import (
-    earthquake_mmi_hazard_classes)
-from safe.definitions.exposure import exposure_population
-from safe.definitions.utilities import (
-    get_compulsory_fields, default_classification_thresholds)
+from safe.definitions.hazard import continuous_hazard_unit
+from safe.definitions.utilities import get_compulsory_fields
 from safe.definitions.constants import RECENT
 
 from safe.common.exceptions import (
@@ -38,12 +32,13 @@ from safe.common.exceptions import (
     InaSAFEError,
     MetadataReadError,
     InvalidWizardStep)
+
 from safe.gui.tools.wizard.wizard_strings import (
     category_question_hazard,
     category_question_exposure,
     category_question_aggregation)
-from safe.gui.tools.wizard.wizard_utils import (
-    layer_description_html)
+from safe.gui.tools.wizard.wizard_utils import layer_description_html
+
 from safe.utilities.settings import set_inasafe_default_value_qsetting
 from safe.utilities.gis import (
     is_raster_layer,
@@ -87,8 +82,7 @@ from step_kw43_threshold import StepKwThreshold
 from step_kw45_inasafe_fields import StepKwInaSAFEFields
 from step_kw47_default_inasafe_fields import StepKwDefaultInaSAFEFields
 from step_kw49_inasafe_raster_default_values import (
-    StepKwInaSAFERasterDefaultValues
-)
+    StepKwInaSAFERasterDefaultValues)
 from step_kw55_source import StepKwSource
 from step_kw60_title import StepKwTitle
 from step_kw65_summary import StepKwSummary
@@ -808,20 +802,6 @@ class WizardDialog(QDialog, FORM_CLASS):
 
         if inasafe_default_values:
             keywords['inasafe_default_values'] = inasafe_default_values
-
-        # For 3853
-        if keywords['layer_purpose'] == layer_purpose_hazard['key']:
-            if keywords['hazard'] == hazard_earthquake['key']:
-                if keywords['layer_geometry'] == layer_geometry_raster['key']:
-                    layer_mode = self.step_kw_layermode.selected_layermode()
-                    if layer_mode == layer_mode_continuous:
-                        keywords['thresholds'][exposure_population['key']] = {
-                            earthquake_mmi_hazard_classes['key']: {
-                                'classes': default_classification_thresholds(
-                                    earthquake_mmi_hazard_classes),
-                                'active': True
-                            }
-                        }
 
         return keywords
 


### PR DESCRIPTION
### What does it fix ?
* Ticket #3853 (enhanced)
* Funded by : DFAT
* Description : 
   - Disable Earthquake Raster for Population (previously removed)
![multihazard_wizard_eq_raster_population](https://cloud.githubusercontent.com/assets/1421861/23055548/0f42a580-f519-11e6-8b40-0e3468896bd1.gif)
