### PR TITLE
manage default ratios with a raster exposure

### DIFF
--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -1658,6 +1658,26 @@ class ImpactFunction(object):
                 self.exposure, self._aggregate_hazard_impacted)
             self.debug_layer(self._aggregate_hazard_impacted)
 
+            # We can monkey patch keywords here for global defaults.
+            keywords = self._aggregate_hazard_impacted.keywords
+            keywords['inasafe_default_values'] = {}
+            for ratio in count_ratio_mapping.itervalues():
+                ratio_field = definition(ratio)
+                default = ratio_field['default_value']['default_value']
+                key = ratio_field['key']
+                keywords['inasafe_default_values'][key] = default
+                LOGGER.info(
+                    'Adding default {value} for {type} into keywords'.format(
+                        value=default, type=key))
+
+            # We add ratios to the agrgegate hazard layer, we do not need them
+            # for post processing as we will use the population count. It's
+            # easier for user to see this field in the attribute tabler.
+            self.set_state_process('impact function', 'Add default values')
+            self._aggregate_hazard_impacted = add_default_values(
+                self._aggregate_hazard_impacted)
+            self.debug_layer(self._aggregate_hazard_impacted)
+
             # I know it's redundant, it's just to be sure that we don't have
             # any impact layer for that IF.
             self._exposure_impacted = None

--- a/safe/test/data/scenario/raster_continuous_on_raster_population.json
+++ b/safe/test/data/scenario/raster_continuous_on_raster_population.json
@@ -14,6 +14,7 @@
       "info": {},
       "process":[
         "Zonal stats between exposure and aggregate hazard",
+        "Add default values",
         "Aggregate the aggregation summary",
         "Aggregate the analysis summary"
       ]


### PR DESCRIPTION
### What does it fix ?
* Ticket #3851 
* Funded by : DFAT
* Description : 
  * Manage default ratios with a raster exposure

Wait for 3889 to be merged