### PR TITLE
fix issue #3879: Make maps showing all layer related with analysis

### DIFF
--- a/safe/definitions/default_settings.py
+++ b/safe/definitions/default_settings.py
@@ -7,6 +7,7 @@ inasafe_default_settings = {
     'visibleLayersOnlyFlag': True,
     'set_layer_from_title_flag': True,
     'setZoomToImpactFlag': True,
+    'set_show_only_impact_on_report': False,
     'setHideExposureFlag': False,
     'useSelectedFeaturesOnly': False,
     'useSentry': False,

--- a/safe/gui/tools/options_dialog.py
+++ b/safe/gui/tools/options_dialog.py
@@ -87,6 +87,7 @@ class OptionsDialog(QtGui.QDialog, FORM_CLASS):
             'visibleLayersOnlyFlag': self.cbxVisibleLayersOnly,
             'set_layer_from_title_flag': self.cbxSetLayerNameFromTitle,
             'setZoomToImpactFlag': self.cbxZoomToImpact,
+            'set_show_only_impact_on_report': self.cbx_show_only_impact,
             'setHideExposureFlag': self.cbxHideExposure,
             'useSelectedFeaturesOnly': self.cbxUseSelectedFeaturesOnly,
             'useSentry': self.cbxUseSentry,

--- a/safe/gui/ui/options_dialog_base.ui
+++ b/safe/gui/ui/options_dialog_base.ui
@@ -29,8 +29,8 @@
         <number>0</number>
        </property>
        <item row="0" column="0">
-        <widget class="QWebView" name="help_web_view">
-         <property name="url">
+        <widget class="QWebView" name="help_web_view" native="true">
+         <property name="url" stdset="0">
           <url>
            <string>about:blank</string>
           </url>
@@ -47,7 +47,7 @@
        <item row="0" column="0">
         <widget class="QTabWidget" name="tabWidget">
          <property name="currentIndex">
-          <number>4</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="tab_basic">
           <attribute name="title">
@@ -119,6 +119,13 @@
                  </property>
                  <property name="text">
                   <string>Hide exposure layer on scenario estimate completion</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="cbx_show_only_impact">
+                 <property name="text">
+                  <string>Show only impact layer on report map</string>
                  </property>
                 </widget>
                </item>

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -1156,6 +1156,15 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         # Add result layer to QGIS
         add_impact_layers_to_canvas(self.impact_function, self.iface)
 
+        # execute this before generating report
+        if self.zoom_to_impact_flag:
+            self.iface.zoomToActiveLayer()
+
+        if self.hide_exposure_flag:
+            legend = self.iface.legendInterface()
+            qgis_exposure = self.get_exposure_layer()
+            legend.setLayerVisible(qgis_exposure, False)
+
         if setting('generate_report', True, bool):
             # Generate impact report
             error_code, message = generate_impact_report(
@@ -1182,16 +1191,8 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
                 self.validate_impact_function()
                 return ANALYSIS_FAILED_BAD_CODE, message
 
-        if self.zoom_to_impact_flag:
-            self.iface.zoomToActiveLayer()
-
         if self.impact_function.debug_mode:
             add_debug_layers_to_canvas(self.impact_function)
-
-        if self.hide_exposure_flag:
-            legend = self.iface.legendInterface()
-            qgis_exposure = self.get_exposure_layer()
-            legend.setLayerVisible(qgis_exposure, False)
 
         self.extent.set_last_analysis_extent(
             self.impact_function.analysis_extent,

--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -756,6 +756,11 @@ class ImpactFunction(object):
         :rtype: (int, m.Message)
         """
         self._provenance_ready = False
+        # save layer reference before preparing.
+        # used to display it in maps
+        original_exposure = self.exposure
+        original_hazard = self.hazard
+        original_aggregation = self.aggregation
         try:
             if not self.exposure:
                 message = generate_input_error_message(
@@ -879,11 +884,21 @@ class ImpactFunction(object):
             # Everything was fine.
             self._is_ready = True
             self._provenance['exposure_layer'] = self.exposure.source()
+            # reference to original layer being used
+            self._provenance['exposure_layer_id'] = original_exposure.id()
             self._provenance['exposure_keywords'] = deepcopy(
                 self.exposure.keywords)
             self._provenance['hazard_layer'] = self.hazard.source()
+            # reference to original layer being used
+            self._provenance['hazard_layer_id'] = original_hazard.id()
             self._provenance['hazard_keywords'] = deepcopy(
                 self.hazard.keywords)
+            # reference to original layer being used
+            if original_aggregation:
+                self._provenance['aggregation_layer_id'] = (
+                    original_aggregation.id())
+            else:
+                self._provenance['aggregation_layer_id'] = None
             self._provenance['aggregation_layer'] = aggregation_source
             self._provenance['aggregation_keywords'] = aggregation_keywords
 

--- a/safe/impact_function/test/test_impact_function.py
+++ b/safe/impact_function/test/test_impact_function.py
@@ -681,10 +681,13 @@ class TestImpactFunction(unittest.TestCase):
             'inasafe_version': get_version(),
             'aggregation_keywords': deepcopy(aggregation_layer.keywords),
             'aggregation_layer': aggregation_layer.source(),
+            'aggregation_layer_id': aggregation_layer.id(),
             'exposure_keywords': deepcopy(exposure_layer.keywords),
             'exposure_layer': exposure_layer.source(),
+            'exposure_layer_id': exposure_layer.id(),
             'hazard_keywords': deepcopy(hazard_layer.keywords),
             'hazard_layer': hazard_layer.source(),
+            'hazard_layer_id': hazard_layer.id(),
             'analysis_question': get_analysis_question(hazard, exposure),
             'report_question': get_report_question(exposure)
         }
@@ -740,10 +743,13 @@ class TestImpactFunction(unittest.TestCase):
             'os': platform.version(),
             'aggregation_keywords': None,
             'aggregation_layer': None,
+            'aggregation_layer_id': None,
             'exposure_keywords': deepcopy(exposure_layer.keywords),
             'exposure_layer': exposure_layer.source(),
+            'exposure_layer_id': exposure_layer.id(),
             'hazard_keywords': deepcopy(hazard_layer.keywords),
             'hazard_layer': hazard_layer.source(),
+            'hazard_layer_id': hazard_layer.id(),
             'analysis_question': get_analysis_question(hazard, exposure),
             'report_question': get_report_question(exposure)
         }

--- a/safe/report/extractors/composer.py
+++ b/safe/report/extractors/composer.py
@@ -1,11 +1,13 @@
 # coding=utf-8
 import datetime
 
+from qgis.core import QgsMapLayerRegistry
 from safe.common.version import get_version
 from safe.definitions.fields import analysis_name_field
 from safe.report.extractors.util import (
     value_from_field_name,
-    resolve_from_dictionary, value_from_inasafe_settings)
+    resolve_from_dictionary)
+from safe.utilities.settings import setting
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -214,13 +216,30 @@ def qgis_composer_extractor(impact_report, component_metadata):
     context.html_frame_elements = html_frame_elements
 
     # Set default map to resize
+
+    # check show only impact
+    show_only_impact = setting('set_show_only_impact_on_report', False, bool)
     layers = [impact_report.impact_function.impact]
+    layer_registry = QgsMapLayerRegistry.instance()
+    if not show_only_impact:
+        hazard_layer = layer_registry.mapLayers().get(
+            provenance['hazard_layer_id'], None)
+
+        aggregation_layer_id = provenance['aggregation_layer_id']
+        if aggregation_layer_id:
+            aggregation_layer = layer_registry.mapLayers().get(
+                aggregation_layer_id, None)
+            layers.insert(0, aggregation_layer)
+
+        layers.append(hazard_layer)
+
     # check hide exposure settings
-    hide_exposure_flag = value_from_inasafe_settings(
-        'setHideExposureFlag')
+    hide_exposure_flag = setting('setHideExposureFlag', False, bool)
     if not hide_exposure_flag:
         # place exposure at the bottom
-        layers.append(impact_report.impact_function.exposure)
+        exposure_layer = layer_registry.mapLayers().get(
+            provenance['exposure_layer_id'])
+        layers.append(exposure_layer)
 
     # default extent is analysis extent
     if not qgis_context.extent:

--- a/safe/report/extractors/util.py
+++ b/safe/report/extractors/util.py
@@ -120,17 +120,3 @@ def resolve_from_dictionary(dictionary, key_list, default_value=None):
         return current_value
     except KeyError:
         return default_value
-
-
-def value_from_inasafe_settings(key):
-    """Take value from InaSAFE settings.
-
-    :param key: settings key
-    :type key: str
-
-    :return: intended value
-    """
-    qsettings = QtCore.QSettings()
-    namespace = 'inasafe/{key}'
-    return qsettings.value(
-        namespace.format(key=key), inasafe_default_settings[key])

--- a/safe/report/processors/default.py
+++ b/safe/report/processors/default.py
@@ -21,6 +21,7 @@ from PyQt4.QtSvg import QSvgRenderer
 from jinja2.environment import Environment
 from jinja2.loaders import FileSystemLoader
 from qgis.core import (
+    QgsMapLayer,
     QgsComposerFrame,
     QgsComposition,
     QgsComposerHtml,
@@ -274,8 +275,8 @@ def qgis_composer_renderer(impact_report, component):
         """:type: qgis.core.QgsComposerMap"""
         if composer_map:
             composer_map.setKeepLayerSet(True)
-            composer_map.setLayerSet(
-                [l.id() for l in layers])
+            layer_set = [l.id() for l in layers if isinstance(l, QgsMapLayer)]
+            composer_map.setLayerSet(layer_set)
             if map_extent_option and isinstance(
                     map_extent_option, QgsRectangle):
                 # use provided map extent

--- a/safe/report/test/test_impact_report.py
+++ b/safe/report/test/test_impact_report.py
@@ -1280,10 +1280,10 @@ class TestImpactReport(unittest.TestCase):
 
         # insert layer to registry
         layer_registry = QgsMapLayerRegistry.instance()
-        layer_registry.removeAllMapLayers()
+        layer_registry.addMapLayers(
+            [hazard_layer, exposure_layer, aggregation_layer])
         rendered_layer = impact_function.impact
-        for layer in impact_function.outputs:
-            layer_registry.addMapLayer(layer)
+        layer_registry.addMapLayers(impact_function.outputs)
 
         # Create impact report
         report_metadata = ReportMetadata(


### PR DESCRIPTION
### What does it fix ?
* Ticket #3879
* Funded by : DFAT
* Description : 
   - Add new InaSAFE option: show only impact layer
   - Add new provenance items: original hazard, exposure, and aggregation layer. This is needed to draw map. Since after analysis, hazard, exposure and aggregation were cleaned up, we can't show it using that layer.