### PR TITLE
Improvements to definitions help to add glossary and notes to explain roundings.

### DIFF
--- a/safe/definitions/concepts.py
+++ b/safe/definitions/concepts.py
@@ -503,10 +503,10 @@ concepts['thresholds'] = {
     'group': tr('Data representation'),
     'key': 'thresholds',
     'description': tr(
-        'A range that defined with minimum and maximum value. In InaSAFE '
+        'A range defined with a minimum and maximum value. In InaSAFE '
         'we exclude the minimum value but include the maximum value. In '
         'mathematical expression: minimum value < x <= maximum value. It '
-        'is used for doing classification for continuous data.'),
+        'is used for doing classification of continuous data.'),
     'citations': [
         {
             'text': '',
@@ -561,4 +561,3 @@ concepts['rounding_methodology'] = {
 #        }
 #    ],
 #  },
-

--- a/safe/definitions/concepts.py
+++ b/safe/definitions/concepts.py
@@ -6,6 +6,7 @@ and in other places like the wizard to ensure that the user will have adequate
 contextual information to accompany the data shown to them.
 """
 
+from collections import OrderedDict
 from safe.utilities.i18n import tr
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
@@ -13,504 +14,551 @@ __license__ = "GPL version 3"
 __email__ = "info@inasafe.org"
 __revision__ = '$Format:%H$'
 
-concepts = {
-    'analysis': {
-        'key': 'analysis',
-        'description': tr(
-            '<p>An <b>analysis</b> from the point of view of using InaSAFE is '
-            'the process whereby a hazard layer, an exposure layer and '
-            'an optional aggregation layer are used to determine the '
-            'potential impact of the hazard data on the exposure. The '
-            'analysis results are grouped by region (as defined in the '
-            'aggregation layer).</p> '
-            '<p>In InaSAFE the analysis process commences with a preparation '
-            'phase where each input layer is pre-processed to ensure that it '
-            'is in a consistent state. The hazard and aggregation are '
-            'reprojected to the same coordinate reference system of the '
-            'exposure dataset. Any data that is not within the selected '
-            'aggregation areas is removed. Note that any modifications made '
-            'are done on copies of the original data - the original data are '
-            'not modified in any way.</p>'
-            '<p>Any continuous datasets are reclassified into classfied (also '
-            'sometimes referred to as categorical) datasets.</p>'
-            '<p>The aggregation layer and the hazard are combined using a GIS '
-            'union operation and then each exposure within these areas is '
-            'counted to arrive at a total number, length or area of '
-            'exposure features per aggregation area. These processes are '
-            'defined in more detail below. After the primary GIS processing '
-            'has been carried out, one or more post-processors are applied '
-            'to the resulting datasets in order to compute statistics like '
-            'the breakdown of buildings or the area of each land use type '
-            'in the affected areas.</p>'
-            '<p>The final part of the analysis process is report generation '
-            'whereby InaSAFE generates various tables and cartographic '
-            'products to represent the result summaries. InaSAFE will '
-            'also create a number of spatial and non-spatial products which '
-            'you can use to generate your own reports - for example by '
-            'importing the data into a spreadsheet and further analysing it '
-            'there.</p>'),
-        'citations': [
-            {
-                'text': tr(
-                    ''),
-                'link': u''
-            }
-        ],
-    },
-    'hazard': {
-        'key': 'hazard',
-        'description': tr(
-            'A <b>hazard</b> represents a natural process or phenomenon '
-            'that may cause loss of life, injury or other health impacts, '
-            'property damage, loss of livelihoods and services, social and '
-            'economic disruption, or environmental damage. For example; '
-            'flood, earthquake, tsunami and volcano are all examples of '
-            'hazards.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2009) Terminology on disaster risk reduction.'),
-                'link': u'https://www.unisdr.org/we/inform/terminology'
-            }
-        ],
-    },
-    'exposure': {
-        'key': 'exposure',
-        'description': tr(
-            '<b>Exposure</b> represents people, property, systems, or '
-            'other elements present in hazard zones that are subject to '
-            'potential losses in the event of a flood, earthquake, volcano '
-            'etc.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2009) Terminology on disaster risk reduction.'),
-                'link': u'https://www.unisdr.org/we/inform/terminology'
-            }
-        ],
-    },
-    'generic_hazard': {
-        'key': 'generic_hazard',
-        'description': tr(
-            'A generic hazard is any dataset where the areas within the '
-            'data set have been classified as either <b>low</b>, '
-            '<b>medium</b>, or <b>high</b> hazard level. Use generic hazard '
-            'in cases where InaSAFE does not have an existing hazard concept '
-            'for the data you are using.'),
-        'citations': [
-            {
-                'text': tr(
-                    ''),
-                'link': u''
-            }
-        ],
-    },
-    'affected': {
-        'key': 'affected',
-        'description': tr(
-            'An exposure element (e.g. people, roads, buildings, land '
-            'cover) that experiences a hazard (e.g. tsunami, flood, '
-            'earthquake) and endures consequences (e.g. damage, evacuation, '
-            'displacement, death) due to that hazard.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2015)Proposed Updated Terminology on Disaster '
-                    'Risk Reduction: A Technical Review'),
-                'link': u'http://www.preventionweb.net/files/'
-                        u'45462_backgoundpaperonterminologyaugust20.pdf'
-            }
-        ],
-    },
-    'exposed_people': {
-        'key': 'exposed_people',
-        'description': tr(
-            'People who are present in hazard zones and are thereby subject '
-            'to potential losses. In InaSAFE, people who are exposed are '
-            'those people who are within the extent of the hazard.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2009)Terminology on Disaster'),
-                'link': u'https://www.unisdr.org/we/inform/terminology'
-            }
-        ],
-    },
-    'affected_people': {
-        'key': 'affected_people',
-        'description': tr(
-            'People who are affected by a hazardous event. People can be '
-            'affected directly or indirectly. Affected people may experience '
-            'short-term or long-term consequences to their lives, livelihoods '
-            'or health and in the economic, physical, social, cultural and '
-            'environmental assets. In InaSAFE, people who are killed during '
-            'the event are also considered affected.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2015)Proposed Updated Terminology on Disaster '
-                    'Risk Reduction: A Technical Review'),
-                'link': u'http://www.preventionweb.net/files/'
-                        u'45462_backgoundpaperonterminologyaugust20.pdf'
-            }
-        ],
-    },
-    'directly_affected_people': {
-        'key': 'directly_affected_people',
-        'description': tr(
-            'People who have suffered injury, illness or other health effects '
-            'who were evacuated, displaced,relocated; or have suffered direct '
-            'damage to their livelihoods, economic, physical, social,cultural '
-            'and environmental assets. In InaSAFE, people who are missing or '
-            'dead may be considered as directly affected.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2015)Proposed Updated Terminology on Disaster '
-                    'Risk Reduction: A Technical Review'),
-                'link': u'http://www.preventionweb.net/files/'
-                        u'45462_backgoundpaperonterminologyaugust20.pdf'
-            }
-        ],
-    },
-    'indirectly_affected_people': {
-        'key': 'indirectly_affected_people',
-        'description': tr(
-            'People who have suffered consequences, other than or in addition '
-            'to direct effects, over time due to disruption or changes in '
-            'economy, critical infrastructures, basic services, commerce,work '
-            'or social, health and psychological consequences. In InaSAFE, '
-            'people who are indirectly affected are not included in minimum '
-            'needs reports.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2015)Proposed Updated Terminology on Disaster '
-                    'Risk Reduction: A Technical Review'),
-                'link': u'http://www.preventionweb.net/files/'
-                        u'45462_backgoundpaperonterminologyaugust20.pdf'
-            }
-        ],
-    },
-    'displaced_people': {
-        'key': 'displaced_people',
-        'description': tr(
-            'Displaced people are people who, for different reasons and '
-            'circumstances because of risk or disaster, have to leave their '
-            'place of residence. In InaSAFE, demographic and minimum'
-            'needs reports are based on displaced / evacuated people.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2015)Proposed Updated Terminology on Disaster '
-                    'Risk Reduction: A Technical Review'),
-                'link': u'http://www.preventionweb.net/files/'
-                        u'45462_backgoundpaperonterminologyaugust20.pdf'
-            }
-        ],
-    },
-    'evacuated_people': {
-        'key': 'evacuated_people',
-        'description': tr(
-            'Evacuated people are people who, for different reasons and '
-            'circumstances because of risk conditions or disaster, move '
-            'temporarily to safer places before, during or after the '
-            'occurrence of a hazardous event. Evacuation can occur from '
-            'places of residence, workplaces, schools and hospitals to other '
-            'places. Evacuation is usually a planned and organised '
-            'mobilisation of persons, animals and goods for eventual return.'
-            'In InaSAFE, demographic and minimum needs reports are based on '
-            'displaced / evacuated people.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2015)Proposed Updated Terminology on Disaster '
-                    'Risk Reduction: A Technical Review'),
-                'link': u'http://www.preventionweb.net/files/'
-                        u'45462_backgoundpaperonterminologyaugust20.pdf'
-            }
-        ],
-    },
-    'relocated_people': {
-        'key': 'relocated_people',
-        'description': tr(
-            'Relocated people are people who, for different reasons or '
-            'circumstances because of risk or disaster, have moved '
-            'permanently from their places of residence to new sites.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2015)Proposed Updated Terminology on Disaster '
-                    'Risk Reduction: A Technical Review'),
-                'link': u'http://www.preventionweb.net/files/'
-                        u'45462_backgoundpaperonterminologyaugust20.pdf'
-            }
-        ],
-    },
-    'injured_people': {
-        'key': 'injured_people',
-        'description': tr(
-            'People suffering from a new or exacerbated physical or '
-            'psychological harm, trauma or an illness as a result of a '
-            'hazardous event.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2015)Proposed Updated Terminology on Disaster '
-                    'Risk Reduction: A Technical Review'),
-                'link': u'http://www.preventionweb.net/files/'
-                        u'45462_backgoundpaperonterminologyaugust20.pdf'
-            }
-        ],
-    },
-    'killed_people': {
-        'key': 'killed_people',
-        'description': tr(
-            'People who lost their lives as a consequence of a hazardous '
-            'event.'),
-        'citations': [
-            {
-                'text': tr(
-                    'UNISDR (2015)Proposed Updated Terminology on Disaster '
-                    'Risk Reduction: A Technical Review'),
-                'link': u'http://www.preventionweb.net/files/'
-                        u'45462_backgoundpaperonterminologyaugust20.pdf'
-            }
-        ],
-    },
-    'youth': {
-        'key': 'youth',
-        'description': tr(
-            'A person aged between 0 and 14 years.'),
-        'citations': [
-            {
-                'text': tr(
-                    'CIA (2016)The World Factbook.'),
-                'link': u'https://www.cia.gov/library/publications/'
-                        u'resources/the-world-factbook/'
-            }
-        ],
-    },
-    'adult': {
-        'key': 'adult',
-        'description': tr(
-            'Person aged between 15 and 64 years, usually of working age.'),
-        'citations': [
-            {
-                'text': tr(
-                    'CIA (2016)The World Factbook.'),
-                'link': u'https://www.cia.gov/library/publications/'
-                        u'resources/the-world-factbook/'
-            }
-        ],
-    },
-    'elderly': {
-        'key': 'elderly',
-        'description': tr(
-            'Person aged 64 years and over.'),
-        'citations': [
-            {
-                'text': tr(
-                    'CIA (2016)The World Factbook.'),
-                'link': u'https://www.cia.gov/library/publications/'
-                        u'resources/the-world-factbook/'
-            }
-        ],
-    },
-    'people': {
-        'key': 'people',
-        'description': tr(
-            'Human beings in general or considered collectively.'),
-        'citations': [
-            {
-                'text': tr(
-                    'Oxford Dictionary.'),
-                'link': u'https://en.oxforddictionaries.com/definition/people'
-            }
-        ],
-    },
-    'female': {
-        'key': 'female',
-        'description': tr(
-            'Relating to the characteristics of women.'),
-        'citations': [
-            {
-                'text': tr(
-                    'Oxford Dictionary.'),
-                'link': u'https://en.oxforddictionaries.com/definition/female'
-            }
-        ],
-    },
-    'male': {
-        'key': 'male',
-        'description': tr(
-            'Relating to the characteristics of men.'),
-        'citations': [
-            {
-                'text': tr(
-                    'Oxford Dictionary.'),
-                'link': u'https://en.oxforddictionaries.com/definition/male'
-            }
-        ],
-    },
-    'infant': {
-        'key': 'infant',
-        'description': tr(
-            'A very young child or baby.'),
-        'citations': [
-            {
-                'text': tr(
-                    'Oxford Dictionary.'),
-                'link': u'https://en.oxforddictionaries.com/definition/infant'
-            }
-        ],
-    },
-    'disabled': {
-        'key': 'disabled',
-        'description': tr(
-            'A person having a physical or mental condition that limits their '
-            'movements, senses, or activities.'),
-        'citations': [
-            {
-                'text': tr(
-                    'Oxford Dictionary.'),
-                'link': u'https://en.oxforddictionaries.com/definition/'
-                        u'disabled'
-            }
-        ],
-    },
-    'pregnant': {
-        'key': 'pregnant',
-        'description': tr(
-            'A female having a child developing in the uterus.'),
-        'citations': [
-            {
-                'text': tr(
-                    'Oxford Dictionary.'),
-                'link': u'https://en.oxforddictionaries.com/definition/'
-                        u'pregnant'
-            }
-        ],
-    },
-    'rice': {
-        'key': 'rice',
-        'description': tr(
-            'Grains of rice used as food.'),
-        'citations': [
-            {
-                'text': tr(
-                    'Oxford Dictionary.'),
-                'link': u'https://en.oxforddictionaries.com/definition/rice'
-            }
-        ],
-    },
-    'drinking_water': {
-        'key': 'drinking_water',
-        'description': tr(
-            'Water pure enough for drinking.'),
-        'citations': [
-            {
-                'text': tr(
-                    'Oxford Dictionary.'),
-                'link': u'https://en.oxforddictionaries.com/definition/'
-                        u'drinking_water'
-            }
-        ],
-    },
-    'clean_water': {
-        'key': 'clean_water',
-        'description': tr(
-            'Water suitable for washing and other purposes but not suitable '
-            'for drinking.'),
-        'citations': [
-            {
-                'text': tr(
-                    ''),
-                'link': u''
-            }
-        ],
-    },
-    'family_kit': {
-        'key': 'family_kit',
-        'description': tr(
-            'Relief supplies such as clothing to support families.'),
-        'citations': [
-            {
-                'text': tr(
-                    'BNPB Perka 7/2008'),
-                'link': u'http://tinyurl.com/BNPB-Perka-7-2008'
-            }
-        ],
-    },
-    'hygiene_pack': {
-        'key': 'hygiene_pack',
-        'description': tr(
-            'Relief supplies to promote practices conducive to maintaining '
-            'health and preventing disease.'),
-        'citations': [
-            {
-                'text': tr(
-                    'Oxford Dictionary.'),
-                'link': u'https://en.oxforddictionaries.com/definition/hygiene'
-            }
-        ],
-    },
-    'toilet': {
-        'key': 'toilet',
-        'description': tr(
-            'A room, building or cubicle with facilities to collect and '
-            'dispose of human waste.'),
-        'citations': [
-            {
-                'text': tr(
-                    'Oxford Dictionary.'),
-                'link': u'https://en.oxforddictionaries.com/definition/'
-                        u'toilet'
-            }
-        ],
-    },
-    'thresholds': {
-        'key': 'thresholds',
-        'description': tr(
-            'A range that defined with minimum and maximum value. In InaSAFE '
-            'we exclude the minimum value but include the maximum value. In '
-            'mathematical expression: minimum value < x <= maximum value. It '
-            'is used for doing classification for continuous data.'),
-        'citations': [
-            {
-                'text': '',
-                'link': u''
-            }
-        ],
-    },
-    'value_maps': {
-        'key': 'value_maps',
-        'description': tr(
-            'A conceptual mapping between one set of unique values and '
-            'another set of unique values. Each unique value represents a '
-            'particular class. It is used to express terms or concepts from '
-            'one classification system in another classification system and '
-            'only applies to non-continuous data. For example a value map can '
-            'be used to express local names for entities (e.g.street type: '
-            '"jalan") into generic concepts (e.g.street type: "residential").'
-        ),
-        'citations': [
-            {
-                'text': '',
-                'link': u''
-            }
-        ],
-    },
-    # Boilerplate for adding a new concept...
-    #  '': {
-    #    'description': tr(
-    #    ),
-    #    'citations': [
-    #        {
-    #            'text': tr(
-    #                ''),
-    #            'link': ''
-    #        }
-    #    ],
-    #  },
+concepts = OrderedDict()
+concepts['analysis'] = {
+    'group': tr('Basic concepts'),
+    'key': 'analysis',
+    'description': tr(
+        '<p>An <b>analysis</b> from the point of view of using InaSAFE is '
+        'the process whereby a hazard layer, an exposure layer and '
+        'an optional aggregation layer are used to determine the '
+        'potential impact of the hazard data on the exposure. The '
+        'analysis results are grouped by region (as defined in the '
+        'aggregation layer).</p> '
+        '<p>In InaSAFE the analysis process commences with a preparation '
+        'phase where each input layer is pre-processed to ensure that it '
+        'is in a consistent state. The hazard and aggregation are '
+        'reprojected to the same coordinate reference system of the '
+        'exposure dataset. Any data that is not within the selected '
+        'aggregation areas is removed. Note that any modifications made '
+        'are done on copies of the original data - the original data are '
+        'not modified in any way.</p>'
+        '<p>Any continuous datasets are reclassified into classfied (also '
+        'sometimes referred to as categorical) datasets.</p>'
+        '<p>The aggregation layer and the hazard are combined using a GIS '
+        'union operation and then each exposure within these areas is '
+        'counted to arrive at a total number, length or area of '
+        'exposure features per aggregation area. These processes are '
+        'defined in more detail below. After the primary GIS processing '
+        'has been carried out, one or more post-processors are applied '
+        'to the resulting datasets in order to compute statistics like '
+        'the breakdown of buildings or the area of each land use type '
+        'in the affected areas.</p>'
+        '<p>The final part of the analysis process is report generation '
+        'whereby InaSAFE generates various tables and cartographic '
+        'products to represent the result summaries. InaSAFE will '
+        'also create a number of spatial and non-spatial products which '
+        'you can use to generate your own reports - for example by '
+        'importing the data into a spreadsheet and further analysing it '
+        'there.</p>'),
+    'citations': [
+        {
+            'text': tr(
+                ''),
+            'link': u''
+        }
+    ],
 }
+concepts['hazard'] = {
+    'group': tr('Basic concepts'),
+    'key': 'hazard',
+    'description': tr(
+        'A <b>hazard</b> represents a natural process or phenomenon '
+        'that may cause loss of life, injury or other health impacts, '
+        'property damage, loss of livelihoods and services, social and '
+        'economic disruption, or environmental damage. For example; '
+        'flood, earthquake, tsunami and volcano are all examples of '
+        'hazards.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2009) Terminology on disaster risk reduction.'),
+            'link': u'https://www.unisdr.org/we/inform/terminology'
+        }
+    ],
+}
+concepts['generic_hazard'] = {
+    'group': tr('Basic concepts'),
+    'key': 'generic_hazard',
+    'description': tr(
+        'A generic hazard is any dataset where the areas within the '
+        'data set have been classified as either <b>low</b>, '
+        '<b>medium</b>, or <b>high</b> hazard level. Use generic hazard '
+        'in cases where InaSAFE does not have an existing hazard concept '
+        'for the data you are using.'),
+    'citations': [
+        {
+            'text': tr(
+                ''),
+            'link': u''
+        }
+    ],
+}
+concepts['exposure'] = {
+    'group': tr('Basic concepts'),
+    'key': 'exposure',
+    'description': tr(
+        '<b>Exposure</b> represents people, property, systems, or '
+        'other elements present in hazard zones that are subject to '
+        'potential losses in the event of a flood, earthquake, volcano '
+        'etc.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2009) Terminology on disaster risk reduction.'),
+            'link': u'https://www.unisdr.org/we/inform/terminology'
+        }
+    ],
+}
+concepts['affected'] = {
+    'group': tr('Basic concepts'),
+    'key': 'affected',
+    'description': tr(
+        'An exposure element (e.g. people, roads, buildings, land '
+        'cover) that experiences a hazard (e.g. tsunami, flood, '
+        'earthquake) and endures consequences (e.g. damage, evacuation, '
+        'displacement, death) due to that hazard.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2015)Proposed Updated Terminology on Disaster '
+                'Risk Reduction: A Technical Review'),
+            'link': u'http://www.preventionweb.net/files/'
+                    u'45462_backgoundpaperonterminologyaugust20.pdf'
+        }
+    ],
+}
+concepts['exposed_people'] = {
+    'group': tr('Basic concepts'),
+    'key': 'exposed_people',
+    'description': tr(
+        'People who are present in hazard zones and are thereby subject '
+        'to potential losses. In InaSAFE, people who are exposed are '
+        'those people who are within the extent of the hazard.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2009)Terminology on Disaster'),
+            'link': u'https://www.unisdr.org/we/inform/terminology'
+        }
+    ],
+}
+concepts['affected_people'] = {
+    'group': tr('Basic concepts'),
+    'key': 'affected_people',
+    'description': tr(
+        'People who are affected by a hazardous event. People can be '
+        'affected directly or indirectly. Affected people may experience '
+        'short-term or long-term consequences to their lives, livelihoods '
+        'or health and in the economic, physical, social, cultural and '
+        'environmental assets. In InaSAFE, people who are killed during '
+        'the event are also considered affected.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2015)Proposed Updated Terminology on Disaster '
+                'Risk Reduction: A Technical Review'),
+            'link': u'http://www.preventionweb.net/files/'
+                    u'45462_backgoundpaperonterminologyaugust20.pdf'
+        }
+    ],
+}
+concepts['directly_affected_people'] = {
+    'group': tr('Basic concepts'),
+    'key': 'directly_affected_people',
+    'description': tr(
+        'People who have suffered injury, illness or other health effects '
+        'who were evacuated, displaced,relocated; or have suffered direct '
+        'damage to their livelihoods, economic, physical, social,cultural '
+        'and environmental assets. In InaSAFE, people who are missing or '
+        'dead may be considered as directly affected.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2015)Proposed Updated Terminology on Disaster '
+                'Risk Reduction: A Technical Review'),
+            'link': u'http://www.preventionweb.net/files/'
+                    u'45462_backgoundpaperonterminologyaugust20.pdf'
+        }
+    ],
+}
+concepts['indirectly_affected_people'] = {
+    'group': tr('Basic concepts'),
+    'key': 'indirectly_affected_people',
+    'description': tr(
+        'People who have suffered consequences, other than or in addition '
+        'to direct effects, over time due to disruption or changes in '
+        'economy, critical infrastructures, basic services, commerce,work '
+        'or social, health and psychological consequences. In InaSAFE, '
+        'people who are indirectly affected are not included in minimum '
+        'needs reports.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2015)Proposed Updated Terminology on Disaster '
+                'Risk Reduction: A Technical Review'),
+            'link': u'http://www.preventionweb.net/files/'
+                    u'45462_backgoundpaperonterminologyaugust20.pdf'
+        }
+    ],
+}
+concepts['displaced_people'] = {
+    'group': tr('Basic concepts'),
+    'key': 'displaced_people',
+    'description': tr(
+        'Displaced people are people who, for different reasons and '
+        'circumstances because of risk or disaster, have to leave their '
+        'place of residence. In InaSAFE, demographic and minimum'
+        'needs reports are based on displaced / evacuated people.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2015)Proposed Updated Terminology on Disaster '
+                'Risk Reduction: A Technical Review'),
+            'link': u'http://www.preventionweb.net/files/'
+                    u'45462_backgoundpaperonterminologyaugust20.pdf'
+        }
+    ],
+}
+concepts['evacuated_people'] = {
+    'group': tr('Basic concepts'),
+    'key': 'evacuated_people',
+    'description': tr(
+        'Evacuated people are people who, for different reasons and '
+        'circumstances because of risk conditions or disaster, move '
+        'temporarily to safer places before, during or after the '
+        'occurrence of a hazardous event. Evacuation can occur from '
+        'places of residence, workplaces, schools and hospitals to other '
+        'places. Evacuation is usually a planned and organised '
+        'mobilisation of persons, animals and goods for eventual return.'
+        'In InaSAFE, demographic and minimum needs reports are based on '
+        'displaced / evacuated people.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2015)Proposed Updated Terminology on Disaster '
+                'Risk Reduction: A Technical Review'),
+            'link': u'http://www.preventionweb.net/files/'
+                    u'45462_backgoundpaperonterminologyaugust20.pdf'
+        }
+    ],
+}
+concepts['relocated_people'] = {
+    'group': tr('Basic concepts'),
+    'key': 'relocated_people',
+    'description': tr(
+        'Relocated people are people who, for different reasons or '
+        'circumstances because of risk or disaster, have moved '
+        'permanently from their places of residence to new sites.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2015)Proposed Updated Terminology on Disaster '
+                'Risk Reduction: A Technical Review'),
+            'link': u'http://www.preventionweb.net/files/'
+                    u'45462_backgoundpaperonterminologyaugust20.pdf'
+        }
+    ],
+}
+concepts['injured_people'] = {
+    'group': tr('Basic concepts'),
+    'key': 'injured_people',
+    'description': tr(
+        'People suffering from a new or exacerbated physical or '
+        'psychological harm, trauma or an illness as a result of a '
+        'hazardous event.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2015)Proposed Updated Terminology on Disaster '
+                'Risk Reduction: A Technical Review'),
+            'link': u'http://www.preventionweb.net/files/'
+                    u'45462_backgoundpaperonterminologyaugust20.pdf'
+        }
+    ],
+}
+concepts['killed_people'] = {
+    'group': tr('Basic concepts'),
+    'key': 'killed_people',
+    'description': tr(
+        'People who lost their lives as a consequence of a hazardous '
+        'event.'),
+    'citations': [
+        {
+            'text': tr(
+                'UNISDR (2015)Proposed Updated Terminology on Disaster '
+                'Risk Reduction: A Technical Review'),
+            'link': u'http://www.preventionweb.net/files/'
+                    u'45462_backgoundpaperonterminologyaugust20.pdf'
+        }
+    ],
+}
+concepts['youth'] = {
+    'group': tr('Demographics'),
+    'key': 'youth',
+    'description': tr(
+        'A person aged between 0 and 14 years.'),
+    'citations': [
+        {
+            'text': tr(
+                'CIA (2016)The World Factbook.'),
+            'link': u'https://www.cia.gov/library/publications/'
+                    u'resources/the-world-factbook/'
+        }
+    ],
+}
+concepts['adult'] = {
+    'group': tr('Demographics'),
+    'key': 'adult',
+    'description': tr(
+        'Person aged between 15 and 64 years, usually of working age.'),
+    'citations': [
+        {
+            'text': tr(
+                'CIA (2016)The World Factbook.'),
+            'link': u'https://www.cia.gov/library/publications/'
+                    u'resources/the-world-factbook/'
+        }
+    ],
+}
+concepts['elderly'] = {
+    'group': tr('Demographics'),
+    'key': 'elderly',
+    'description': tr(
+        'Person aged 64 years and over.'),
+    'citations': [
+        {
+            'text': tr(
+                'CIA (2016)The World Factbook.'),
+            'link': u'https://www.cia.gov/library/publications/'
+                    u'resources/the-world-factbook/'
+        }
+    ],
+}
+concepts['people'] = {
+    'group': tr('Demographics'),
+    'key': 'people',
+    'description': tr(
+        'Human beings in general or considered collectively.'),
+    'citations': [
+        {
+            'text': tr(
+                'Oxford Dictionary.'),
+            'link': u'https://en.oxforddictionaries.com/definition/people'
+        }
+    ],
+}
+concepts['female'] = {
+    'group': tr('Demographics'),
+    'key': 'female',
+    'description': tr(
+        'Relating to the characteristics of women.'),
+    'citations': [
+        {
+            'text': tr(
+                'Oxford Dictionary.'),
+            'link': u'https://en.oxforddictionaries.com/definition/female'
+        }
+    ],
+}
+concepts['male'] = {
+    'group': tr('Demographics'),
+    'key': 'male',
+    'description': tr(
+        'Relating to the characteristics of men.'),
+    'citations': [
+        {
+            'text': tr(
+                'Oxford Dictionary.'),
+            'link': u'https://en.oxforddictionaries.com/definition/male'
+        }
+    ],
+}
+concepts['infant'] = {
+    'group': tr('Demographics'),
+    'key': 'infant',
+    'description': tr(
+        'A very young child or baby.'),
+    'citations': [
+        {
+            'text': tr(
+                'Oxford Dictionary.'),
+            'link': u'https://en.oxforddictionaries.com/definition/infant'
+        }
+    ],
+}
+concepts['disabled'] = {
+    'group': tr('Vulnerability'),
+    'key': 'disabled',
+    'description': tr(
+        'A person having a physical or mental condition that limits their '
+        'movements, senses, or activities.'),
+    'citations': [
+        {
+            'text': tr(
+                'Oxford Dictionary.'),
+            'link': u'https://en.oxforddictionaries.com/definition/'
+                    u'disabled'
+        }
+    ],
+}
+concepts['pregnant'] = {
+    'group': tr('Vulnerability'),
+    'key': 'pregnant',
+    'description': tr(
+        'A female having a child developing in the uterus.'),
+    'citations': [
+        {
+            'text': tr(
+                'Oxford Dictionary.'),
+            'link': u'https://en.oxforddictionaries.com/definition/'
+                    u'pregnant'
+        }
+    ],
+}
+concepts['rice'] = {
+    'group': tr('Minimum needs'),
+    'key': 'rice',
+    'description': tr(
+        'Grains of rice used as food.'),
+    'citations': [
+        {
+            'text': tr(
+                'Oxford Dictionary.'),
+            'link': u'https://en.oxforddictionaries.com/definition/rice'
+        }
+    ],
+}
+concepts['drinking_water'] = {
+    'group': tr('Minimum needs'),
+    'key': 'drinking_water',
+    'description': tr(
+        'Water pure enough for drinking.'),
+    'citations': [
+        {
+            'text': tr(
+                'Oxford Dictionary.'),
+            'link': u'https://en.oxforddictionaries.com/definition/'
+                    u'drinking_water'
+        }
+    ],
+}
+concepts['clean_water'] = {
+    'group': tr('Minimum needs'),
+    'key': 'clean_water',
+    'description': tr(
+        'Water suitable for washing and other purposes but not suitable '
+        'for drinking.'),
+    'citations': [
+        {
+            'text': tr(
+                ''),
+            'link': u''
+        }
+    ],
+}
+concepts['family_kit'] = {
+    'group': tr('Minimum needs'),
+    'key': 'family_kit',
+    'description': tr(
+        'Relief supplies such as clothing to support families.'),
+    'citations': [
+        {
+            'text': tr(
+                'BNPB Perka 7/2008'),
+            'link': u'http://tinyurl.com/BNPB-Perka-7-2008'
+        }
+    ],
+}
+concepts['hygiene_pack'] = {
+    'group': tr('Minimum needs'),
+    'key': 'hygiene_pack',
+    'description': tr(
+        'Relief supplies to promote practices conducive to maintaining '
+        'health and preventing disease.'),
+    'citations': [
+        {
+            'text': tr(
+                'Oxford Dictionary.'),
+            'link': u'https://en.oxforddictionaries.com/definition/hygiene'
+        }
+    ],
+}
+concepts['toilet'] = {
+    'group': tr('Minimum needs'),
+    'key': 'toilet',
+    'description': tr(
+        'A room, building or cubicle with facilities to collect and '
+        'dispose of human waste.'),
+    'citations': [
+        {
+            'text': tr(
+                'Oxford Dictionary.'),
+            'link': u'https://en.oxforddictionaries.com/definition/'
+                    u'toilet'
+        }
+    ],
+}
+concepts['thresholds'] = {
+    'group': tr('Data representation'),
+    'key': 'thresholds',
+    'description': tr(
+        'A range that defined with minimum and maximum value. In InaSAFE '
+        'we exclude the minimum value but include the maximum value. In '
+        'mathematical expression: minimum value < x <= maximum value. It '
+        'is used for doing classification for continuous data.'),
+    'citations': [
+        {
+            'text': '',
+            'link': u''
+        }
+    ],
+}
+concepts['value_maps'] = {
+    'group': tr('Data representation'),
+    'key': 'value_maps',
+    'description': tr(
+        'A conceptual mapping between one set of unique values and '
+        'another set of unique values. Each unique value represents a '
+        'particular class. It is used to express terms or concepts from '
+        'one classification system in another classification system and '
+        'only applies to non-continuous data. For example a value map can '
+        'be used to express local names for entities (e.g.street type: '
+        '"jalan") into generic concepts (e.g.street type: "residential").'
+    ),
+    'citations': [
+        {
+            'text': '',
+            'link': u''
+        }
+    ],
+}
+concepts['rounding_methodology'] = {
+    'group': tr('Data representation'),
+    'key': 'rounding_methodology',
+    'description': tr(
+        'Note that report rows containing totals are calculated from the '
+        'entire analysis area totals and then rounded, whereas the '
+        'subtotal rows are calculated from the aggregation areas and '
+        'then rounded. Using this approach we avoid adding already '
+        'rounded numbers and in so doing compounding the rounding.'),
+    'citations': [
+        {
+            'text': '',
+            'link': u''
+        }
+    ],
+}
+# Boilerplate for adding a new concept...
+#  concepts[''] = {
+#    'description': tr(
+#    ),
+#    'citations': [
+#        {
+#            'text': tr(
+#                ''),
+#            'link': ''
+#        }
+#    ],
+#  },
+

--- a/safe/definitions/exposure.py
+++ b/safe/definitions/exposure.py
@@ -13,9 +13,7 @@ from safe.definitions.fields import (
     female_count_field,
     youth_count_field,
     population_count_field,
-    exposure_type_field,
-    feature_value_field,
-    feature_rate_field)
+    exposure_type_field)
 from safe.definitions.layer_modes import (
     layer_mode_continuous, layer_mode_classified)
 from safe.definitions.exposure_classifications import (
@@ -45,7 +43,8 @@ exposure_population = {
            'people if more than 1,000 and less than 100,000; and nearest '
            '1000 if more than 100,000.'),
         tr('Rounding is applied to all population values, which may cause '
-           'discrepancies between subtotals and totals.'),
+           'discrepancies between subtotals and totals. '),
+        concepts['rounding_methodology']['description'],
     ],
     'earthquake_notes': [
         # these are earthquake specific notes for population
@@ -189,6 +188,7 @@ exposure_road = {
            'more than 100,000.'),
         tr('Rounding is applied to all road lengths, which may cause '
            'discrepancies between subtotals and totals.'),
+        concepts['rounding_methodology']['description'],
         tr('Roads marked as not affected may still be unusable due to network '
            'isolation. Roads marked as affected may still be usable if they '
            'are elevated above the local landscape.'),
@@ -247,10 +247,12 @@ exposure_structure = {
            'hazard status lower than that to which they are exposed outside '
            'the analysis area.'),
         tr('Numbers reported for structures have been rounded to the nearest '
-           '10 if the total is less than 1,000; nearest 100 if more than 1,000'
-           'and less than 100,000; and nearest 1000 if more than 100,000.'),
+           '10 if the total is less than 1,000; nearest 100 if more than '
+           '1,000 and less than 100,000; and nearest 1000 if more than '
+           '100,000.'),
         tr('Rounding is applied to all structure counts, which may cause '
            'discrepancies between subtotals and totals.'),
+        concepts['rounding_methodology']['description'],
     ],
     'continuous_notes': [  # notes specific to continuous data
     ],
@@ -347,6 +349,7 @@ exposure_land_cover = {
            'hectares if more than 100,000.'),
         tr('Rounding is applied to all land cover areas, which may cause '
            'discrepancies between subtotals and totals.'),
+        concepts['rounding_methodology']['description']
     ],
     'continuous_notes': [  # notes specific to continuous data
     ],

--- a/safe/definitions/fields.py
+++ b/safe/definitions/fields.py
@@ -36,10 +36,10 @@ exposure_id_field = {
     'type': qvariant_whole_numbers,
     'length': default_field_length,
     'precision': 0,
-    'help_text': tr(  # this is the short description
+    'description': tr(  # this is the short description
         'An ID attribute in the exposure layer'
     ),
-    'description': tr(
+    'help_text': tr(
         'A unique identifier for each exposure feature. If you provide this '
         'we will persist these identifiers in the output datasets so that '
         'you can do a table join back to the original exposure layer if '
@@ -142,9 +142,9 @@ hazard_id_field = {
     'type': qvariant_whole_numbers,
     'length': default_field_length,
     'precision': 0,
-    'description': tr(  # short description
+    'help_text': tr(  # short description
         'An ID attribute in the hazard layer.'),
-    'help_text': tr(
+    'description': tr(
         'A unique identifier for each hazard feature. If you provide this '
         'we will persist these identifiers in the output datasets so that '
         'you can do a table join back to the original hazard layer if '
@@ -248,9 +248,9 @@ aggregation_id_field = {
     'type': qvariant_whole_numbers,
     'length': default_field_length,
     'precision': 0,
-    'help_text': tr(  # short description
+    'description': tr(  # short description
         'An ID attribute in the aggregation layer.'),
-    'description': tr(
+    'help_text': tr(
         'A unique identifier for each aggregation feature. If you provide '
         'this we will persist these identifiers in the output datasets so '
         'that you can do a table join back to the original aggregation layer '
@@ -301,9 +301,9 @@ analysis_id_field = {
     'length': default_field_length,
     'precision': 0,
     'absolute': False,
-    'help_text': tr(  # short description
+    'description': tr(  # short description
         'An ID attribute in the analysis layer.'),
-    'description': tr(
+    'help_text': tr(
         'A unique identifier for each analysis feature.'),
     'citations': [
         {

--- a/safe/gui/tools/help/definitions_help.py
+++ b/safe/gui/tools/help/definitions_help.py
@@ -109,6 +109,44 @@ def content():
     message.add(bullets)
 
     ##
+    # Basic concepts ...
+    ##
+    ##
+    # Help dialog contents ...
+    ##
+    _create_section_header(
+        message,
+        table_of_contents,
+        'glossary',
+        tr('Glossary of terms'))
+
+    last_group = None
+    table = None
+    for key, value in definitions.concepts.iteritems():
+        current_group = value['group']
+        if current_group != last_group:
+            if last_group is not None:
+                message.add(table)
+            header = m.Heading(current_group, **SUBSECTION_STYLE)
+            message.add(header)
+            table = _start_glossary_table(current_group)
+            last_group = current_group
+        row = m.Row()
+        term = value['key'].replace('_', ' ')
+        description = m.Message(value['description'])
+        for citation in value['citations']:
+            if citation['text'] in [None, '']:
+                continue
+            if citation['link'] in [None, '']:
+                description.add(m.Paragraph(citation['text']))
+            else:
+                description.add(m.Paragraph(
+                    m.Link(citation['link'], citation['text'])))
+        row.add(m.Cell(term))
+        row.add(m.Cell(description))
+        table.add(row)
+
+    ##
     # Help dialog contents ...
     ##
     _create_section_header(
@@ -468,6 +506,15 @@ def content():
     full_message.add(table_of_contents)
     full_message.add(message)
     return full_message
+
+
+def _start_glossary_table(group):
+    table = m.Table(style_class='table table-condensed table-striped')
+    row = m.Row()
+    row.add(m.Cell(tr('Term')), header_flag=True)
+    row.add(m.Cell(tr('Description')), header_flag=True)
+    table.add(row)
+    return table
 
 
 def _create_section_header(message, table_of_contents, id, text):

--- a/safe/gui/tools/help/definitions_help.py
+++ b/safe/gui/tools/help/definitions_help.py
@@ -145,6 +145,8 @@ def content():
         row.add(m.Cell(term))
         row.add(m.Cell(description))
         table.add(row)
+    # ensure the last group's table is added
+    message.add(table)
 
     ##
     # Help dialog contents ...

--- a/safe/gui/tools/help/definitions_help.py
+++ b/safe/gui/tools/help/definitions_help.py
@@ -132,7 +132,7 @@ def content():
             table = _start_glossary_table(current_group)
             last_group = current_group
         row = m.Row()
-        term = value['key'].replace('_', ' ')
+        term = value['key'].replace('_', ' ').title()
         description = m.Message(value['description'])
         for citation in value['citations']:
             if citation['text'] in [None, '']:

--- a/safe/gui/tools/help/definitions_help.py
+++ b/safe/gui/tools/help/definitions_help.py
@@ -503,7 +503,10 @@ def content():
 
     # Finally we add the table of contents at the top
     full_message = m.Message()
-    header = m.Heading(tr('Contents'), **SECTION_STYLE)
+    # Contents is not a link so reset style
+    style = SECTION_STYLE
+    style['element_id'] = ''
+    header = m.Heading(tr('Contents'), **style)
     full_message.add(header)
     full_message.add(table_of_contents)
     full_message.add(message)
@@ -520,6 +523,8 @@ def _start_glossary_table(group):
 
 
 def _create_section_header(message, table_of_contents, id, text):
+    # Warning a side effect here is that the SECTION_STYLE is updated
+    # when setting style as we don't have a deep copy
     style = SECTION_STYLE
     style['element_id'] = id
     header = m.Heading(text, **style)

--- a/safe/messaging/item/cell.py
+++ b/safe/messaging/item/cell.py
@@ -95,7 +95,7 @@ class Cell(MessageElement):
         # Special case for when we want to put a nested table in a cell
         # We don't use isinstance because of recursive imports with table
         class_name = args[0].__class__.__name__
-        if class_name in ['BulletedList', 'Table']:
+        if class_name in ['BulletedList', 'Table', 'Message']:
             self.content = args[0]
         else:
             self.content = Text(*args)
@@ -126,7 +126,7 @@ class Cell(MessageElement):
         # Special case for when we want to put a nested table in a cell
         # We don't use isinstance because of recursive imports with table
         class_name = self.content.__class__.__name__
-        if class_name in ['BulletedList', 'Table']:
+        if class_name in ['BulletedList', 'Table', 'Message']:
             html = self.content.to_html()
         else:
             html = self.content.to_html(wrap_slash=self.wrap_slash)

--- a/safe/report/test/test_impact_report.py
+++ b/safe/report/test/test_impact_report.py
@@ -218,43 +218,33 @@ class TestImpactReport(unittest.TestCase):
             notes_assumptions_component['key'])
         """:type: safe.report.report_metadata.Jinja2ComponentsMetadata"""
 
+        # TODO: this test is fragile and will break whenever we change
+        # definitions. TS. I reduced the test fragments to snippets which
+        # will hopefully make things a little less fragile.
         expected_context = {
-            'header': u'Notes and assumptions',
-            'items': [
-                u'The impacts on roads, people, buildings and other exposure '
-                u'elements may be underestimated if the exposure data are '
-                u'incomplete.',
-
-                u'Structures overlapping the analysis extent may be assigned '
-                u'a hazard status lower than that to which they are exposed '
-                u'outside the analysis area.',
-
-                u'Numbers reported for structures have been rounded to the '
-                u'nearest 10 if the total is less than 1,000; nearest 100 if '
-                u'more than 1,000and less than 100,000; and nearest 1000 if '
-                u'more than 100,000.',
-
-                u'Rounding is applied to all structure counts, which may '
-                u'cause discrepancies between subtotals and totals.',
-
-                u'The extent and severity of the mapped scenario or hazard '
-                u'zones may not be consistent with future events.',
-
-                u'The impacts on roads, people, buildings and '
-                u'other exposure elements may differ from the '
-                u'analysis results due to local conditions '
-                u'such as terrain and infrastructure type.',
-
-                u'The analysis extent is limited to the extent '
-                u'of the aggregation layer or analysis extent. '
-                u'Hazard and exposure data outside the '
-                u'analysis extent are not included in the '
-                u'impact layer, impact map or impact reports.'
-            ]
+            u'impacts on roads, people, buildings',
+            u'overlapping the analysis extent',
+            u'more than 1,000 and less than 100,000',
+            u'cause discrepancies',
+            u'zones may not be consistent with future events',
+            u'terrain and infrastructure type',
+            u'analysis extent is limited',
+            u'Hazard and exposure data outside'
         }
         actual_context = notes_assumptions.context
+        for expected_item in expected_context:
+            current_flag = False
+            # Iterate to see if expected_item is in at least one of the
+            # actual content items ...
+            for actual_item in actual_context['items']:
+                if expected_item in actual_item:
+                    current_flag = True
+            # It was not found in any item :-(
+            self.assertTrue(
+                current_flag,
+                '"%s" not found in %s' % (
+                    expected_item, actual_context['items']))
 
-        self.assertDictEqual(expected_context, actual_context)
         self.assertTrue(
             notes_assumptions.output, empty_component_output_message)
 


### PR DESCRIPTION
fix #3799 - clarify how roundings work in notes. fix #3916 - ensure that concepts are all shown nicely in definitions help. Improve reporting test to be less fragile. Funded by DFAT.

### What does it fix ?
* Ticket #3799 #3916
* Funded by :  DFAT
* Description : See screenshots below for key changes:

![screencapture](https://cloud.githubusercontent.com/assets/178003/23186272/2a976ce8-f88f-11e6-944f-692f49b8727e.gif)

Rounding explanation for #3799 (this is shown in IF report notes too)

![2017-02-21 23_43_25-inasafe help](https://cloud.githubusercontent.com/assets/178003/23186416/c00e4fa8-f88f-11e6-86f2-c1eb01f927a5.png)

