### PR TITLE
fix size calculator with a multi geometry

### DIFF
--- a/safe/datastore/datastore.py
+++ b/safe/datastore/datastore.py
@@ -126,8 +126,13 @@ class DataStore(object):
 
         try:
             layer.keywords
-            KeywordIO().write_keywords(
-                self.layer(result[1]), layer.keywords)
+            real_layer = self.layer(result[1])
+            if isinstance(real_layer, bool):
+                message = ('{name} was not found in the datastore or the '
+                           'layer was not valid.'.format(name=result[1]))
+                LOGGER.debug(message)
+                return False, message
+            KeywordIO().write_keywords(real_layer, layer.keywords)
         except AttributeError:
             pass
 

--- a/safe/gis/vector/summary_3_analysis.py
+++ b/safe/gis/vector/summary_3_analysis.py
@@ -2,6 +2,7 @@
 
 """Aggregate the aggregate hazard to the analysis layer."""
 
+from math import isnan
 from PyQt4.QtCore import QPyNullVariant
 from qgis.core import QGis, QgsFeatureRequest
 
@@ -107,7 +108,8 @@ def analysis_summary(aggregate_hazard, analysis, callback=None):
     for area in aggregate_hazard.getFeatures():
         hazard_value = area[hazard_class_index]
         value = area[total]
-        if not value or isinstance(value, QPyNullVariant):
+        if not value or isinstance(value, QPyNullVariant) or isnan(value):
+            # For isnan, see ticket #3812
             value = 0
         if not hazard_value or isinstance(hazard_value, QPyNullVariant):
             hazard_value = 'NULL'


### PR DESCRIPTION
### What does it fix ?
* Ticket #3812 
* Funded by : DFAT
* Description : Some layers become a multilinestring during the process. The size calculator can't handle this kind of geometry. It's better to compute the size part per part.
