### PR TITLE
add many logs in the IF

### DIFF
--- a/safe/gis/vector/default_values.py
+++ b/safe/gis/vector/default_values.py
@@ -61,9 +61,9 @@ def add_default_values(layer, callback=None):
 
     if not defaults:
         # Case 1 and 2.
-        LOGGER.debug(
-            tr('inasafe_default_value is not present, we can not fill default '
-               'values.'))
+        LOGGER.info(
+            'inasafe_default_value is not present, we can not fill default '
+            'ratios for this layer.')
         return layer
 
     for default in defaults.keys():
@@ -74,11 +74,13 @@ def add_default_values(layer, callback=None):
 
         if not field:
             # Case 3
-            LOGGER.debug(
-                '{field} key is not present but the layer has {value} as a '
-                'default for {field}. We create the new field.'.format(
-                    **{'field': target_field['key'],
-                       'value': defaults[default]}))
+            LOGGER.info(
+                '{field} is not present but the layer has {value} as a '
+                'default for {field}. We create the new field '
+                '{new_field} with this value.'.format(
+                    field=target_field['key'],
+                    value=defaults[default],
+                    new_field=target_field['field_name']))
 
             new_field = create_field_from_definition(target_field)
 
@@ -95,11 +97,10 @@ def add_default_values(layer, callback=None):
 
         else:
             # Case 4
-            LOGGER.debug(
-                '{field} key is present and the layer has {value} as a '
-                'default for {field}, we should fill null values.'.format(
-                    **{'field': target_field['key'],
-                       'value': defaults[default]}))
+            LOGGER.info(
+                '{field} is present and the layer has {value} as a '
+                'default for {field}, we MUST do nothing.'.format(
+                    field=target_field['key'], value=defaults[default]))
 
             index = layer.fieldNameIndex(field)
 

--- a/safe/gis/vector/from_counts_to_ratios.py
+++ b/safe/gis/vector/from_counts_to_ratios.py
@@ -2,6 +2,7 @@
 
 """From counts to ratio."""
 
+import logging
 from safe.definitions.utilities import definition
 from safe.definitions.fields import size_field, count_ratio_mapping
 from safe.definitions.processing_steps import (
@@ -10,6 +11,7 @@ from safe.utilities.profiling import profile
 from safe.gis.vector.tools import create_field_from_definition
 from safe.gis.sanity_check import check_layer
 
+LOGGER = logging.getLogger('InaSAFE')
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -54,6 +56,17 @@ def from_counts_to_ratios(layer, callback=None):
             name = ratio_field['field_name']
             layer.keywords['inasafe_fields'][ratio_field['key']] = name
             mapping[count_field['field_name']] = layer.fieldNameIndex(name)
+            LOGGER.info(
+                'Count field {count_field} detected in the exposure, we are '
+                'going to create a equivalent field {ratio_field} in the '
+                'exposure layer.'.format(
+                    count_field=count_field['key'],
+                    ratio_field=ratio_field['key']))
+        else:
+            LOGGER.info(
+                'Count field {count_field} not detected in the exposure. We '
+                'will not compute a ratio from this field.'.format(
+                    count_field=count_field['key']))
 
     if len(mapping) == 0:
         # There is not a count field. Let's skip this layer.

--- a/safe/gis/vector/prepare_vector_layer.py
+++ b/safe/gis/vector/prepare_vector_layer.py
@@ -112,6 +112,9 @@ def prepare_vector_layer(layer, callback=None):
     rename_remove_inasafe_fields(cleaned)
 
     if _size_is_needed(cleaned):
+        LOGGER.info(
+            'We noticed some counts in your exposure layer. Before to update '
+            'geometries, we compute the original size for each feature.')
         run_single_post_processor(cleaned, post_processor_size)
 
     if cleaned.keywords['layer_purpose'] == 'exposure':
@@ -231,10 +234,11 @@ def rename_remove_inasafe_fields(layer):
     # Houra, InaSAFE keywords match our concepts !
     layer.keywords['inasafe_fields'].update(new_keywords)
 
-    # Remove useless fields
+    # Remove unnecessary fields
     for field in layer.fields().toList():
         if field.name() not in expected_fields.values():
-            to_remove.append(field.name())
+            if field.name() not in to_remove:
+                to_remove.append(field.name())
     remove_fields(layer, to_remove)
     LOGGER.debug(tr(
         'Fields which have been removed from %s : %s'
@@ -377,6 +381,8 @@ def _add_id_column(layer):
             break
 
     if not has_id_column:
+        LOGGER.info(
+            'We add an ID column in {purpose}'.format(purpose=layer_purpose))
 
         layer.startEditing()
 

--- a/safe/gis/vector/recompute_counts.py
+++ b/safe/gis/vector/recompute_counts.py
@@ -2,6 +2,8 @@
 
 """Recompute counts."""
 
+import logging
+
 from safe.common.exceptions import InvalidKeywordsForProcessingAlgorithm
 from safe.definitions.fields import (
     size_field,
@@ -14,6 +16,7 @@ from safe.utilities.profiling import profile
 from safe.gis.vector.tools import SizeCalculator
 from safe.gis.sanity_check import check_layer
 
+LOGGER = logging.getLogger('InaSAFE')
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -57,6 +60,10 @@ def recompute_counts(layer, callback=None):
     for field, field_name in fields.iteritems():
         if field in absolute_field_keys and field != size_field['key']:
             indexes.append(layer.fieldNameIndex(field_name))
+            LOGGER.info(
+                'We detected the count {field_name}, we will recompute the '
+                'count according to the new size.'.format(
+                    field_name=field_name))
 
     if not len(indexes):
         msg = 'Absolute field not found in the layer %s' % (


### PR DESCRIPTION
### What does it fix ?
* Ticket #3971 
* Funded by : DFAT
* Description : 

It adds many logs which are very useful to see what happen with ratios and counts : 
```
2017-03-01T17:34:11	0	aggregation: Aggregation layer already in exposure CRS
2017-03-01T17:34:11	0	female_ratio_field field detected in the aggregation layer AND the equivalent count has not been detected in the exposure layer. We will propagate this ratio to the exposure layer later when we combine these two layers.
2017-03-01T17:34:11	0	youth_ratio_field = 0.25 constant detected in the aggregation layer AND the equivalent count has not been detected in the exposure layer. We are adding this ratio to the exposure layer.
2017-03-01T17:34:11	0	adult_ratio_field is neither a constant nor a field AND the equivalent count has not been detected in the exposure layer. We will do nothing about it.
2017-03-01T17:34:11	0	elderly_ratio_field = 0.2 constant detected in the aggregation layer AND the equivalent count has not been detected in the exposure layer. We are adding this ratio to the exposure layer.
2017-03-01T17:34:11	0	aggregation: Convert the aggregation layer to the analysis layer
```