### PR TITLE
fix issue #3974: add an affected note for affecting hazard class

### DIFF
--- a/safe/definitions/reports/components.py
+++ b/safe/definitions/reports/components.py
@@ -244,6 +244,10 @@ notes_assumptions_component = {
                 'bullet-list-section.html',
     'extra_args': {
         'header': tr('Notes and assumptions'),
+        'affected_note_format': tr(
+            'Exposures in this following hazard classes are considered '
+            'affected: {hazard_classes}'
+        ),
         'displacement_rates_note_format': tr(
             'For this analysis, the following displacement rates were used: '
             '{rate_description}'),

--- a/safe/report/extractors/action_notes.py
+++ b/safe/report/extractors/action_notes.py
@@ -70,6 +70,25 @@ def notes_assumptions_extractor(impact_report, component_metadata):
             hazard_classification = classification
             break
 
+    # Check hazard affected class
+    affected_classes = []
+    for hazard_class in hazard_classification['classes']:
+        if hazard_class.get('affected', False):
+            affected_classes.append(hazard_class)
+
+    if affected_classes:
+        affected_note_format = resolve_from_dictionary(
+            extra_args, 'affected_note_format')
+
+        # generate hazard classes
+        hazard_classes = ', '.join([
+            c['name'] for c in affected_classes
+        ])
+
+        context['items'].append(
+            affected_note_format.format(hazard_classes=hazard_classes)
+        )
+
     # Check hazard have displacement rate
     for hazard_class in hazard_classification['classes']:
         if hazard_class.get('displacement_rate', 0) > 0:


### PR DESCRIPTION
### What does it fix ?
* Ticket #3974 
* Funded by : DFAT
* Description : add an affected note for affecting hazard class

<img width="346" alt="screen shot 2017-03-03 at 02 49 25" src="https://cloud.githubusercontent.com/assets/831865/23524268/7380b0fc-ffbc-11e6-87b9-c1c493d89187.png">
<img width="337" alt="screen shot 2017-03-03 at 02 49 58" src="https://cloud.githubusercontent.com/assets/831865/23524270/74c22432-ffbc-11e6-940a-895456c33bdd.png">

