### PR TITLE
enable inasafe for QGIS 2.14, 2.16 and 2.18

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -10,8 +10,8 @@
 
 [general]
 name=InaSAFE
-qgisMinimumVersion=2.0
-qgisMaximumVersion=2.14
+qgisMinimumVersion=2.14
+qgisMaximumVersion=2.18
 description=InaSAFE is free software that allows disaster managers to study realistic natural hazard impact scenarios for better planning, preparedness and response activities.
 about=Developed for the Indonesian Government - BNPB, Australian Government - AIFDR and DMInnovation and, and World Bank - GFDRR
 


### PR DESCRIPTION
### What does it fix ?
* Funded by : DFAT
* Description : 
  * InaSAFE 3 was available on QGIS 2.18 so users will never see this update to 4.0 and they will stick to InaSAFE 3. I don't think it's something we want.
  * QGIS 2.18 will become the next LTR so we better fix it if we notice something wrong.
  * I'm using QGIS 2.18 and InaSAFE is now disabled by default when I launch QGIS.

 