### PR TITLE
Fix description option dialog

### DIFF
--- a/safe/gui/tools/options_dialog.py
+++ b/safe/gui/tools/options_dialog.py
@@ -533,7 +533,8 @@ class OptionsDialog(QtGui.QDialog, FORM_CLASS):
                 'min_value', 0)
             parameter.maximum_allowed_value = default_value.get(
                 'max_value', 100000000)
-            parameter.help_text = default_value.get('description')
+            parameter.help_text = default_value.get('help_text')
+            parameter.description = default_value.get('description')
 
             # Check if user ask to restore to the most default value.
             if self.is_restore_default:


### PR DESCRIPTION
### What does it fix ?
* Ticket : No ticket number
* Funded by : DFAT
* Description : 
   Previously it was like this (missing description)
   <img width="825" alt="screen shot 2017-03-08 at 12 16 59" src="https://cloud.githubusercontent.com/assets/1421861/23691136/4001acae-03f9-11e7-9294-672548fb0fe2.png">
   Now it has description back
   
   <img width="815" alt="screen shot 2017-03-08 at 12 18 07" src="https://cloud.githubusercontent.com/assets/1421861/23691149/502211fa-03f9-11e7-8402-1389949cf187.png">


