### PR TITLE
add option to launch keyword wizard on shakemap importer

### DIFF
--- a/safe/gui/tools/shake_grid/shakemap_converter_dialog.py
+++ b/safe/gui/tools/shake_grid/shakemap_converter_dialog.py
@@ -202,10 +202,12 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
         base_name = file_info.baseName()
         self.output_layer = QgsRasterLayer(file_name, base_name)
         self.output_layer.keywords = KeywordIO.read_keywords(self.output_layer)
-        self.output_layer.keywords['classification'] = earthquake_mmi_scale['key']
+        self.output_layer.keywords['classification'] = (
+            earthquake_mmi_scale['key'])
         keywords = self.output_layer.keywords
         if self.output_layer.isValid():
-            self.output_layer = reclassify(self.output_layer, overwrite_input=True)
+            self.output_layer = reclassify(
+                self.output_layer, overwrite_input=True)
             KeywordIO.write_keywords(self.output_layer, keywords)
         else:
             LOGGER.debug("Failed to load")
@@ -220,7 +222,8 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
                 LOGGER.debug("Failed to load")
             else:
                 # noinspection PyArgumentList
-                QgsMapLayerRegistry.instance().addMapLayers([self.output_layer])
+                QgsMapLayerRegistry.instance().addMapLayers(
+                    [self.output_layer])
                 iface.zoomToActiveLayer()
 
         if (self.keyword_wizard_checkbox.isChecked() and

--- a/safe/gui/tools/shake_grid/shakemap_converter_dialog.py
+++ b/safe/gui/tools/shake_grid/shakemap_converter_dialog.py
@@ -86,7 +86,7 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
         self.input_path.textChanged.connect(self.on_input_path_textChanged)
         # noinspection PyUnresolvedReferences
         self.output_path.textChanged.connect(self.on_output_path_textChanged)
-        self.load_result.clicked.connect(self.on_load_result_toggled)
+        self.load_result.clicked.connect(self.load_result_toggled)
 
         # Set up things for context help
         self.help_button = self.button_box.button(QtGui.QDialogButtonBox.Help)
@@ -222,8 +222,7 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
                 LOGGER.debug("Failed to load")
             else:
                 # noinspection PyArgumentList
-                QgsMapLayerRegistry.instance().addMapLayers(
-                    [self.output_layer])
+                QgsMapLayerRegistry.instance().addMapLayer(self.output_layer)
                 iface.zoomToActiveLayer()
 
         if (self.keyword_wizard_checkbox.isChecked() and
@@ -252,11 +251,9 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
             self.tr('Raster file (*.tif)'))
         self.output_path.setText(filename)
 
-    @pyqtSignature('')  # prevents actions being handled twice
-    def on_load_result_toggled(self):
-        """Autoconnect slot activated when load_result checkbox is clicked.
+    def load_result_toggled(self):
+        """Function that perform action when load_result checkbox is clicked.
         """
-        # noinspection PyCallByClass,PyTypeChecker
         if self.load_result.isChecked():
             self.keyword_wizard_checkbox.setEnabled(True)
         else:

--- a/safe/gui/tools/shake_grid/shakemap_converter_dialog.py
+++ b/safe/gui/tools/shake_grid/shakemap_converter_dialog.py
@@ -36,6 +36,7 @@ from safe.messaging import styles
 from safe.utilities.styling import mmi_ramp_roman
 from safe.utilities.resources import html_footer, html_header, get_ui_class
 from safe.gui.tools.shake_grid.shake_grid import convert_mmi_data
+from safe.gui.tools.wizard.wizard_dialog import WizardDialog
 from safe.gui.tools.help.shakemap_converter_help import shakemap_converter_help
 from safe.gis.raster.reclassify import reclassify
 from safe.utilities.keyword_io import KeywordIO
@@ -49,7 +50,7 @@ FORM_CLASS = get_ui_class('shakemap_importer_dialog_base.ui')
 
 class ShakemapConverterDialog(QDialog, FORM_CLASS):
     """Importer for shakemap grid.xml files."""
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, iface=None, dock_widget=None):
         """Constructor for the dialog.
 
         Show the grid converter dialog.
@@ -57,9 +58,17 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
         :param parent: parent - widget to use as parent.
         :type parent: QWidget
 
+        :param iface: QGIS QGisAppInterface instance.
+        :type iface: QGisAppInterface
+
+        :param dock_widget: Dock widget instance.
+        :type dock_widget: Dock
+
         """
         QDialog.__init__(self, parent)
         self.parent = parent
+        self.iface = iface
+        self.dock_widget = dock_widget
         self.setupUi(self)
         self.setWindowTitle(
             self.tr('InaSAFE %s Shakemap Converter' % get_version()))
@@ -67,6 +76,7 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
         self.on_input_path_textChanged()
         self.on_output_path_textChanged()
         self.update_warning()
+        self.output_layer = None
 
         # Event register
         # noinspection PyUnresolvedReferences
@@ -76,6 +86,7 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
         self.input_path.textChanged.connect(self.on_input_path_textChanged)
         # noinspection PyUnresolvedReferences
         self.output_path.textChanged.connect(self.on_output_path_textChanged)
+        self.load_result.clicked.connect(self.on_load_result_toggled)
 
         # Set up things for context help
         self.help_button = self.button_box.button(QtGui.QDialogButtonBox.Help)
@@ -189,13 +200,13 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
         # reclassify raster
         file_info = QFileInfo(file_name)
         base_name = file_info.baseName()
-        layer = QgsRasterLayer(file_name, base_name)
-        layer.keywords = KeywordIO.read_keywords(layer)
-        layer.keywords['classification'] = earthquake_mmi_scale['key']
-        keywords = layer.keywords
-        if layer.isValid():
-            layer = reclassify(layer, overwrite_input=True)
-            KeywordIO.write_keywords(layer, keywords)
+        self.output_layer = QgsRasterLayer(file_name, base_name)
+        self.output_layer.keywords = KeywordIO.read_keywords(self.output_layer)
+        self.output_layer.keywords['classification'] = earthquake_mmi_scale['key']
+        keywords = self.output_layer.keywords
+        if self.output_layer.isValid():
+            self.output_layer = reclassify(self.output_layer, overwrite_input=True)
+            KeywordIO.write_keywords(self.output_layer, keywords)
         else:
             LOGGER.debug("Failed to load")
 
@@ -203,14 +214,19 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
 
         if self.load_result.isChecked():
             # noinspection PyTypeChecker
-            mmi_ramp_roman(layer)
-            layer.saveDefaultStyle()
-            if not layer.isValid():
+            mmi_ramp_roman(self.output_layer)
+            self.output_layer.saveDefaultStyle()
+            if not self.output_layer.isValid():
                 LOGGER.debug("Failed to load")
             else:
                 # noinspection PyArgumentList
-                QgsMapLayerRegistry.instance().addMapLayers([layer])
+                QgsMapLayerRegistry.instance().addMapLayers([self.output_layer])
                 iface.zoomToActiveLayer()
+
+        if (self.keyword_wizard_checkbox.isChecked() and
+                self.keyword_wizard_checkbox.isEnabled()):
+            self.launch_keyword_wizard()
+
         self.done(self.Accepted)
 
     @pyqtSignature('')  # prevents actions being handled twice
@@ -232,6 +248,16 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
             self, self.tr('Output file'), 'grid.tif',
             self.tr('Raster file (*.tif)'))
         self.output_path.setText(filename)
+
+    @pyqtSignature('')  # prevents actions being handled twice
+    def on_load_result_toggled(self):
+        """Autoconnect slot activated when load_result checkbox is clicked.
+        """
+        # noinspection PyCallByClass,PyTypeChecker
+        if self.load_result.isChecked():
+            self.keyword_wizard_checkbox.setEnabled(True)
+        else:
+            self.keyword_wizard_checkbox.setEnabled(False)
 
     @pyqtSlot()
     @pyqtSignature('bool')  # prevents actions being handled twice
@@ -272,3 +298,17 @@ class ShakemapConverterDialog(QDialog, FORM_CLASS):
         string += footer
 
         self.help_web_view.setHtml(string)
+
+    def launch_keyword_wizard(self):
+        """Launch keyword creation wizard."""
+        # make sure selected layer is the output layer
+        if self.iface.activeLayer() != self.output_layer:
+            return
+
+        # launch wizard dialog
+        self.keyword_wizard = WizardDialog(
+            self.iface.mainWindow(),
+            self.iface,
+            self.dock_widget)
+        self.keyword_wizard.set_keywords_creation_mode(self.output_layer)
+        self.keyword_wizard.exec_()  # modal

--- a/safe/gui/tools/shake_grid/test/test_shakemap_converter_dialog.py
+++ b/safe/gui/tools/shake_grid/test/test_shakemap_converter_dialog.py
@@ -40,14 +40,14 @@ class ShakemapImporterTest(unittest.TestCase):
 
     def test_init_dialog(self):
         """Test for showing table in the first."""
-        shakemap_converter_dialog = ShakemapConverterDialog(PARENT)
+        shakemap_converter_dialog = ShakemapConverterDialog(PARENT, IFACE)
         msg = 'Dialog is failed to create'
         self.assertIsNotNone(shakemap_converter_dialog, msg)
 
     def test_behaviour(self):
         """Test behaviour of elements in the dialog
         """
-        shakemap_importer_dialog = ShakemapConverterDialog(PARENT)
+        shakemap_importer_dialog = ShakemapConverterDialog(PARENT, IFACE)
         shakemap_importer_dialog.use_output_default.setEnabled(True)
         my_grid_path = os.path.join(TESTDATA, 'grid.xml')
         shakemap_importer_dialog.input_path.setText(my_grid_path)
@@ -63,7 +63,7 @@ class ShakemapImporterTest(unittest.TestCase):
 
     def test_converting(self):
         """Test converting grif file to tiff."""
-        dialog = ShakemapConverterDialog(PARENT)
+        dialog = ShakemapConverterDialog(PARENT, IFACE)
         dialog.use_output_default.setEnabled(False)
         grid_path = standard_data_path(
             'hazard',

--- a/safe/gui/ui/shakemap_importer_dialog_base.ui
+++ b/safe/gui/ui/shakemap_importer_dialog_base.ui
@@ -14,7 +14,7 @@
    <string>InaSAFE - Shakemap Importer</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -31,21 +31,12 @@
      </property>
      <widget class="QWidget" name="page">
       <layout class="QGridLayout" name="gridLayout_5">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
        <item row="0" column="0">
-        <widget class="QWebView" name="help_web_view">
-         <property name="url">
+        <widget class="QWebView" name="help_web_view" native="true">
+         <property name="url" stdset="0">
           <url>
            <string>about:blank</string>
           </url>
@@ -56,21 +47,12 @@
      </widget>
      <widget class="QWidget" name="page_1">
       <layout class="QGridLayout" name="gridLayout_6">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
        <item row="0" column="0">
-        <widget class="QWebView" name="info_web_view">
-         <property name="url">
+        <widget class="QWebView" name="info_web_view" native="true">
+         <property name="url" stdset="0">
           <url>
            <string>about:blank</string>
           </url>
@@ -193,6 +175,13 @@
             </property>
             <property name="checked">
              <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QCheckBox" name="keyword_wizard_checkbox">
+            <property name="text">
+             <string>Launch keywords wizard</string>
             </property>
            </widget>
           </item>

--- a/safe/plugin.py
+++ b/safe/plugin.py
@@ -787,7 +787,8 @@ class Plugin(object):
         from safe.gui.tools.shake_grid.shakemap_converter_dialog import (
             ShakemapConverterDialog)
 
-        dialog = ShakemapConverterDialog(self.iface.mainWindow())
+        dialog = ShakemapConverterDialog(
+            self.iface.mainWindow(), self.iface, self.dock_widget)
         dialog.exec_()  # modal
 
     def show_multi_buffer(self):


### PR DESCRIPTION
### What does it fix ?
* Ticket #4040 
* Funded by : DFAT
* Description : By launching the keyword wizard, the layer from shakemap importer would be version 4.0 ready keywords.
![shakemap-kw](https://cloud.githubusercontent.com/assets/11134669/24110444/01a3234e-0dc6-11e7-80be-b70958c3da82.gif)

