### PR TITLE
add classification unit to hazard classification definition for general report title

### DIFF
--- a/safe/definitions/hazard_classifications.py
+++ b/safe/definitions/hazard_classifications.py
@@ -136,7 +136,8 @@ generic_hazard_classes = {
         exposure_population,
         exposure_road,
         exposure_structure
-    ]
+    ],
+    'classification_unit': tr('hazard zone')
 }
 
 earthquake_mmi_scale = {
@@ -386,7 +387,8 @@ earthquake_mmi_scale = {
         exposure_population,
         exposure_road,
         exposure_structure
-    ]
+    ],
+    'classification_unit': tr('MMI intensity')
 }
 
 volcano_hazard_classes = {
@@ -464,7 +466,8 @@ volcano_hazard_classes = {
         exposure_population,
         exposure_road,
         exposure_structure
-    ]
+    ],
+    'classification_unit': tr('hazard zone')
 }
 
 flood_hazard_classes = {
@@ -526,7 +529,8 @@ flood_hazard_classes = {
         exposure_population,
         exposure_road,
         exposure_structure
-    ]
+    ],
+    'classification_unit': tr('hazard zone')
 }
 
 flood_petabencana_hazard_classes = {
@@ -630,7 +634,8 @@ flood_petabencana_hazard_classes = {
                 }
             ]
         }
-    ]
+    ],
+    'classification_unit': tr('hazard zone')
 }
 
 ash_hazard_classes = {
@@ -764,7 +769,8 @@ ash_hazard_classes = {
         exposure_population,
         exposure_road,
         exposure_structure
-    ]
+    ],
+    'classification_unit': tr('hazard zone')
 }
 
 # Original tsunami hazard classes with displacement rates added
@@ -891,7 +897,8 @@ tsunami_hazard_classes = {
         exposure_place,
         exposure_road,
         exposure_structure
-    ]
+    ],
+    'classification_unit': tr('hazard zone')
 }
 
 # Duplicate classes for tsunami hazard; modified for population exposure
@@ -998,7 +1005,8 @@ tsunami_hazard_population_classes = {
     ],
     'exposures': [
         exposure_population
-    ]
+    ],
+    'classification_unit': tr('hazard zone')
 }
 # duplicate classes for tsunami hazard based on advice from Pak Hamza
 tsunami_hazard_classes_ITB = {
@@ -1141,7 +1149,8 @@ tsunami_hazard_classes_ITB = {
         exposure_place,
         exposure_road,
         exposure_structure
-    ]
+    ],
+    'classification_unit': tr('hazard zone')
 }
 
 # duplicate classes for tsunami hazard based on advice from Pak Hamza and
@@ -1266,7 +1275,8 @@ tsunami_hazard_population_classes_ITB = {
     ],
     'exposures': [
         exposure_population
-    ]
+    ],
+    'classification_unit': tr('hazard zone')
 }
 
 cyclone_au_bom_hazard_classes = {
@@ -1518,7 +1528,8 @@ cyclone_au_bom_hazard_classes = {
         exposure_population,
         exposure_road,
         exposure_structure
-    ]
+    ],
+    'classification_unit': tr('cyclone category')
 }
 
 cyclone_sshws_hazard_classes = {
@@ -1764,7 +1775,8 @@ cyclone_sshws_hazard_classes = {
         exposure_population,
         exposure_road,
         exposure_structure
-    ]
+    ],
+    'classification_unit': tr('cyclone category')
 }
 
 hazard_classification = {

--- a/safe/definitions/reports/components.py
+++ b/safe/definitions/reports/components.py
@@ -114,7 +114,7 @@ general_report_component = {
                 'general-report.html',
     'extra_args': {
         'header': tr('General Report'),
-        'table_header_format': tr('Estimated {title}'),
+        'table_header_format': tr('Estimated {title} affected per {unit}'),
         'hazard_header': tr('Hazard Zone'),
         # Used to customize header.
         # See issue inasafe#3688: remove all 'total' words

--- a/safe/report/extractors/general_report.py
+++ b/safe/report/extractors/general_report.py
@@ -164,7 +164,8 @@ def general_report_extractor(impact_report, component_metadata):
     table_header_format = resolve_from_dictionary(
         extra_args, 'table_header_format')
     table_header = table_header_format.format(
-        title=provenance['map_legend_title'])
+        title=provenance['map_legend_title'],
+        unit=hazard_classification['classification_unit'])
 
     context['header'] = header
     context['summary'] = summary

--- a/safe/report/test/test_earthquake_report.py
+++ b/safe/report/test/test_earthquake_report.py
@@ -105,7 +105,8 @@ class TestEarthquakeReport(unittest.TestCase):
         """:type: safe.report.report_metadata.Jinja2ComponentsMetadata"""
 
         expected_context = {
-            'table_header': u'Estimated Number of people',
+            'table_header': (
+                u'Estimated Number of people affected per MMI intensity'),
             'header': u'General Report',
             'summary': [
                 {

--- a/safe/report/test/test_impact_report.py
+++ b/safe/report/test/test_impact_report.py
@@ -176,7 +176,8 @@ class TestImpactReport(unittest.TestCase):
 
         expected_context = {
             'header': u'General Report',
-            'table_header': u'Estimated Number of buildings',
+            'table_header': (
+                u'Estimated Number of buildings affected per hazard zone'),
             'summary': [
                 {
                     'header_label': u'Hazard Zone',


### PR DESCRIPTION
### What does it fix ?
* Ticket #3957 
* Funded by : DFAT
* Description : 

classification unit added per hazard classification:
- generic_hazard_classes = 'hazard zone'
- earthquake_mmi_scale = 'MMI intensity'
- volcano_hazard_classes = 'hazard_zone'
- flood_hazard_classes = 'hazard_zone'
- flood_petabencana_hazard_classes = 'hazard_zone'
- ash_hazard_classes = 'hazard_zone'
- tsunami_hazard_classes = 'hazard_zone'
- tsunami_hazard_population_classes = 'hazard_zone'
- tsunami_hazard_classes_ITB = 'hazard_zone'
- tsunami_hazard_poopulation_classes_ITB = 'hazard_zone'
- cyclone_au_bom_hazard_classes = 'cyclone_category'
- cyclone_sshws_hazard_classes = 'cyclone_category'

![selection_043](https://cloud.githubusercontent.com/assets/11134669/24184051/8a7225ce-0efe-11e7-9d29-3004beff8070.png)

