### PR TITLE
add notes based on concepts

### DIFF
--- a/resources/report-templates/standard-template/jinja2/aggregation-postprocessors.html
+++ b/resources/report-templates/standard-template/jinja2/aggregation-postprocessors.html
@@ -68,7 +68,14 @@
                 <div>
                     <ul>
                         {% for note in value.notes %}
-                        <li colspan="100%">{{ note }}</li>
+                            {% if ':' in note %}
+                                {% set concept = note.split(':')[0] %}
+                                {% set note = note.split(':')[1:] %}
+                                {% set note = ':'.join(note) %}
+                                <li colspan="100%"><b>{{ concept|capitalize }}</b>:{{ note }}</li>
+                            {% else %}
+                                <li colspan="100%">{{ note }}</li>
+                            {% endif %}
                         {% endfor %}
                     </ul>
                 </div>

--- a/safe/definitions/field_groups.py
+++ b/safe/definitions/field_groups.py
@@ -322,3 +322,4 @@ for field_group in all_field_groups:
         tr('{group_name} group: {note}'.format(
             group_name=field_group['name'],
             note=field_group['description'])))
+    del field_group  # to prevent duplicate definition

--- a/safe/definitions/field_groups.py
+++ b/safe/definitions/field_groups.py
@@ -111,18 +111,8 @@ age_displaced_count_group = {
         adult_displaced_count_field,
         elderly_displaced_count_field
     ],
-    'notes': [
-        tr('Infant: ' + concepts['infant']['description']),
-        tr('Child: ' + concepts['child']['description']),
-        tr('Youth: ' + concepts['youth']['description']),
-        tr('Adult: ' + concepts['adult']['description']),
-        tr('Elderly: ' + concepts['elderly']['description'])
-    ]
+    'notes': []
 }
-age_displaced_count_groups['notes'].insert(
-    0,
-    tr('Age group: ' + (
-        age_displaced_count_groups['description'])))
 
 gender_ratio_group = {
     'key': 'gender_ratio_group',
@@ -174,18 +164,8 @@ gender_displaced_count_group = {
         child_bearing_age_displaced_count_field,
         pregnant_lactating_displaced_count_field
     ],
-    'notes': [
-        tr('Female: ' + concepts['female']['description']),
-        tr('Child bearing age: ' + (
-            concepts['child_bearing_age']['description'])),
-        tr('Pregnant lactating: ' + (
-            concepts['pregnant_lactating']['description']))
-    ]
+    'notes': []
 }
-gender_displaced_count_group['notes'].insert(
-    0,
-    tr('Gender group: ' + (
-        gender_displaced_count_group['description'])))
 
 vulnerability_ratio_group = {
     'key': 'vulnerability_ratio_group',
@@ -255,16 +235,8 @@ vulnerability_displaced_count_group = {
         over_60_displaced_count_field,
         disabled_displaced_count_field
     ],
-    'notes': [
-        tr('Under 5: ' + concepts['under_5']['description']),
-        tr('Over 60: ' + concepts['over_60']['description']),
-        tr('Disabled: ' + concepts['disabled']['description'])
-    ]
+    'notes': []
 }
-vulnerability_displaced_count_group['notes'].insert(
-    0,
-    tr('Vulnerability group: ' + (
-        vulnerability_displaced_count_group['description'])))
 
 aggregation_field_groups = [
     age_ratio_group,
@@ -310,3 +282,40 @@ all_field_groups = [
     vulnerability_count_group,
     vulnerability_displaced_count_group
 ]
+
+# Update notes for each group
+age_group_notes = [
+        tr('Age group: ' + age_displaced_count_group['description']),
+        tr('Infant: ' + concepts['infant']['description']),
+        tr('Child: ' + concepts['child']['description']),
+        tr('Youth: ' + concepts['youth']['description']),
+        tr('Adult: ' + concepts['adult']['description']),
+        tr('Elderly: ' + concepts['elderly']['description'])
+    ]
+
+gender_group_notes = [
+        tr('Gender group: ' + gender_displaced_count_group['description']),
+        tr('Female: ' + concepts['female']['description']),
+        tr('Child bearing age: ' + (
+            concepts['child_bearing_age']['description'])),
+        tr('Pregnant lactating: ' + (
+            concepts['pregnant_lactating']['description']))
+    ]
+
+vulnerability_group_notes = [
+        tr('Vulnerability group: ' + (
+            vulnerability_displaced_count_group['description'])),
+        tr('Under 5: ' + concepts['under_5']['description']),
+        tr('Over 60: ' + concepts['over_60']['description']),
+        tr('Disabled: ' + concepts['disabled']['description'])
+    ]
+
+age_ratio_group['notes'] = age_group_notes
+age_count_group['notes'] = age_group_notes
+age_displaced_count_group['notes'] = age_group_notes
+gender_ratio_group['notes'] = gender_group_notes
+gender_count_group['notes'] = gender_group_notes
+gender_displaced_count_group['notes'] = gender_group_notes
+vulnerability_ratio_group['notes'] = vulnerability_group_notes
+vulnerability_count_group['notes'] = vulnerability_group_notes
+vulnerability_displaced_count_group['notes'] = vulnerability_group_notes

--- a/safe/definitions/field_groups.py
+++ b/safe/definitions/field_groups.py
@@ -3,6 +3,7 @@
 """Definitions relating to group of fields."""
 
 from safe.utilities.i18n import tr
+from safe.definitions.concepts import concepts
 
 from safe.definitions.fields import (
     infant_count_field,
@@ -110,8 +111,18 @@ age_displaced_count_group = {
         adult_displaced_count_field,
         elderly_displaced_count_field
     ],
-    'notes': []
+    'notes': [
+        tr('Infant: ' + concepts['infant']['description']),
+        tr('Child: ' + concepts['child']['description']),
+        tr('Youth: ' + concepts['youth']['description']),
+        tr('Adult: ' + concepts['adult']['description']),
+        tr('Elderly: ' + concepts['elderly']['description'])
+    ]
 }
+age_displaced_count_groups['notes'].insert(
+    0,
+    tr('Age group: ' + (
+        age_displaced_count_groups['description'])))
 
 gender_ratio_group = {
     'key': 'gender_ratio_group',
@@ -163,8 +174,18 @@ gender_displaced_count_group = {
         child_bearing_age_displaced_count_field,
         pregnant_lactating_displaced_count_field
     ],
-    'notes': []
+    'notes': [
+        tr('Female: ' + concepts['female']['description']),
+        tr('Child bearing age: ' + (
+            concepts['child_bearing_age']['description'])),
+        tr('Pregnant lactating: ' + (
+            concepts['pregnant_lactating']['description']))
+    ]
 }
+gender_displaced_count_group['notes'].insert(
+    0,
+    tr('Gender group: ' + (
+        gender_displaced_count_group['description'])))
 
 vulnerability_ratio_group = {
     'key': 'vulnerability_ratio_group',
@@ -234,8 +255,16 @@ vulnerability_displaced_count_group = {
         over_60_displaced_count_field,
         disabled_displaced_count_field
     ],
-    'notes': []
+    'notes': [
+        tr('Under 5: ' + concepts['under_5']['description']),
+        tr('Over 60: ' + concepts['over_60']['description']),
+        tr('Disabled: ' + concepts['disabled']['description'])
+    ]
 }
+vulnerability_displaced_count_group['notes'].insert(
+    0,
+    tr('Vulnerability group: ' + (
+        vulnerability_displaced_count_group['description'])))
 
 aggregation_field_groups = [
     age_ratio_group,

--- a/safe/definitions/field_groups.py
+++ b/safe/definitions/field_groups.py
@@ -285,25 +285,25 @@ all_field_groups = [
 
 # Update notes for each group
 age_group_notes = [
-        tr('Infant: ' + concepts['infant']['description']),
-        tr('Child: ' + concepts['child']['description']),
-        tr('Youth: ' + concepts['youth']['description']),
-        tr('Adult: ' + concepts['adult']['description']),
-        tr('Elderly: ' + concepts['elderly']['description'])
+        tr('Infant: {note}'.format(note=concepts['infant']['description'])),
+        tr('Child: {note}'.format(note=concepts['child']['description'])),
+        tr('Youth: {note}'.format(note=concepts['youth']['description'])),
+        tr('Adult: {note}'.format(note=concepts['adult']['description'])),
+        tr('Elderly: {note}'.format(note=concepts['elderly']['description']))
     ]
 
 gender_group_notes = [
-        tr('Female: ' + concepts['female']['description']),
-        tr('Child bearing age: ' + (
-            concepts['child_bearing_age']['description'])),
-        tr('Pregnant lactating: ' + (
-            concepts['pregnant_lactating']['description']))
+        tr('Female: {note}'.format(note=concepts['female']['description'])),
+        tr('Child bearing age: {note}'.format(
+            note=concepts['child_bearing_age']['description'])),
+        tr('Pregnant lactating: {note}'.format(
+            note=concepts['pregnant_lactating']['description']))
     ]
 
 vulnerability_group_notes = [
-        tr('Under 5: ' + concepts['under_5']['description']),
-        tr('Over 60: ' + concepts['over_60']['description']),
-        tr('Disabled: ' + concepts['disabled']['description'])
+        tr('Under 5: {note}'.format(note=concepts['under_5']['description'])),
+        tr('Over 60: {note}'.format(note=concepts['over_60']['description'])),
+        tr('Disabled: {note}'.format(note=concepts['disabled']['description']))
     ]
 
 age_ratio_group['notes'] += age_group_notes
@@ -318,4 +318,7 @@ vulnerability_displaced_count_group['notes'] += vulnerability_group_notes
 
 for field_group in all_field_groups:
     field_group['notes'].insert(
-        0, tr(field_group['name'] + ' group: ' + field_group['description']))
+        0,
+        tr('{group_name} group: {note}'.format(
+            group_name=field_group['name'],
+            note=field_group['description'])))

--- a/safe/definitions/field_groups.py
+++ b/safe/definitions/field_groups.py
@@ -285,7 +285,6 @@ all_field_groups = [
 
 # Update notes for each group
 age_group_notes = [
-        tr('Age group: ' + age_displaced_count_group['description']),
         tr('Infant: ' + concepts['infant']['description']),
         tr('Child: ' + concepts['child']['description']),
         tr('Youth: ' + concepts['youth']['description']),
@@ -294,7 +293,6 @@ age_group_notes = [
     ]
 
 gender_group_notes = [
-        tr('Gender group: ' + gender_displaced_count_group['description']),
         tr('Female: ' + concepts['female']['description']),
         tr('Child bearing age: ' + (
             concepts['child_bearing_age']['description'])),
@@ -303,19 +301,21 @@ gender_group_notes = [
     ]
 
 vulnerability_group_notes = [
-        tr('Vulnerability group: ' + (
-            vulnerability_displaced_count_group['description'])),
         tr('Under 5: ' + concepts['under_5']['description']),
         tr('Over 60: ' + concepts['over_60']['description']),
         tr('Disabled: ' + concepts['disabled']['description'])
     ]
 
-age_ratio_group['notes'] = age_group_notes
-age_count_group['notes'] = age_group_notes
-age_displaced_count_group['notes'] = age_group_notes
-gender_ratio_group['notes'] = gender_group_notes
-gender_count_group['notes'] = gender_group_notes
-gender_displaced_count_group['notes'] = gender_group_notes
-vulnerability_ratio_group['notes'] = vulnerability_group_notes
-vulnerability_count_group['notes'] = vulnerability_group_notes
-vulnerability_displaced_count_group['notes'] = vulnerability_group_notes
+age_ratio_group['notes'] += age_group_notes
+age_count_group['notes'] += age_group_notes
+age_displaced_count_group['notes'] += age_group_notes
+gender_ratio_group['notes'] += gender_group_notes
+gender_count_group['notes'] += gender_group_notes
+gender_displaced_count_group['notes'] += gender_group_notes
+vulnerability_ratio_group['notes'] += vulnerability_group_notes
+vulnerability_count_group['notes'] += vulnerability_group_notes
+vulnerability_displaced_count_group['notes'] += vulnerability_group_notes
+
+for field_group in all_field_groups:
+    field_group['notes'].insert(
+        0, tr(field_group['name'] + ' group: ' + field_group['description']))

--- a/safe/report/test/test_impact_report.py
+++ b/safe/report/test/test_impact_report.py
@@ -17,6 +17,10 @@ from safe.definitions.fields import (
     total_affected_field,
     total_not_exposed_field,
     total_field)
+from safe.definitions.field_groups import (
+    age_displaced_count_group,
+    gender_displaced_count_group,
+    vulnerability_displaced_count_group)
 from safe.definitions.hazard_classifications import flood_hazard_classes
 from safe.impact_function.impact_function import ImpactFunction
 from safe.report.report_metadata import ReportMetadata
@@ -873,12 +877,14 @@ class TestImpactReport(unittest.TestCase):
             aggregation_postprocessors_component['key'])
         """:type: safe.report.report_metadata.Jinja2ComponentsMetadata"""
 
+        actual_context = aggregation_postprocessors.context
         expected_context = {
             'sections': OrderedDict([
                 ('age', {
                     'header': u'Detailed Age Report',
                     'notes': [u'Columns and rows containing only 0 or "No '
-                              u'data" values are excluded from the tables.'],
+                              u'data" values are excluded from the '
+                              u'tables.'] + age_displaced_count_group['notes'],
                     'rows': [[u'B', '2,700', '660', '1,800', '240'],
                              [u'C', '6,500', '1,700', '4,300', '590'],
                              [u'F', '7,100', '1,800', '4,700', '640'],
@@ -909,7 +915,9 @@ class TestImpactReport(unittest.TestCase):
                 ('gender', {
                     'header': u'Detailed Gender Report',
                     'notes': [u'Columns and rows containing only 0 or "No '
-                              u'data" values are excluded from the tables.'],
+                              u'data" values are excluded from the '
+                              u'tables.'] + (
+                        gender_displaced_count_group['notes']),
                     'rows': [
                         [u'B', '2,700', '1,400'],
                         [u'C', '6,500', '3,300'],
@@ -990,7 +998,6 @@ class TestImpactReport(unittest.TestCase):
                         '1,300']})]),
             'use_aggregation': True
         }
-        actual_context = aggregation_postprocessors.context
 
         self.assertDictEqual(expected_context, actual_context)
         self.assertTrue(
@@ -1046,7 +1053,8 @@ class TestImpactReport(unittest.TestCase):
                 ('age', {
                     'header': u'Detailed Age Report',
                     'notes': [u'Columns and rows containing only 0 or "No '
-                              u'data" values are excluded from the tables.'],
+                              u'data" values are excluded from the '
+                              u'tables.'] + age_displaced_count_group['notes'],
                     'rows': [[u'B', '10', '0', '0', '0'],
                              [u'C', '10', '10', '10', '0'],
                              [u'F', '10', '0', '10', '0'],
@@ -1077,7 +1085,9 @@ class TestImpactReport(unittest.TestCase):
                 ('gender', {
                     'header': u'Detailed Gender Report',
                     'notes': [u'Columns and rows containing only 0 or "No '
-                              u'data" values are excluded from the tables.'],
+                              u'data" values are excluded from the '
+                              u'tables.'] + (
+                        gender_displaced_count_group['notes']),
                     'rows': [[u'B', '10', '0'],
                              [u'C', '10', '10'],
                              [u'F', '10', '10'],


### PR DESCRIPTION
### What does it fix ?
* Ticket : #4069 
* Funded by : DFAT
* Description : Add notes to the bottom of the demographic breakdown table. The notes came from description in concepts.py.

![selection_068](https://cloud.githubusercontent.com/assets/11134669/25827971/fddb4b3c-3477-11e7-8fed-90922f591a28.png)

