### PR TITLE
Fix #4130 Earthquake help text - set default options

### DIFF
--- a/safe/gui/tools/options_dialog.py
+++ b/safe/gui/tools/options_dialog.py
@@ -335,6 +335,29 @@ class OptionsDialog(QDialog, FORM_CLASS):
         self.close()
 
     # noinspection PyPep8Naming
+    @pyqtSignature('int')  # prevents actions being handled twice
+    def on_earthquake_function_currentIndexChanged(self, current_index):
+        """Auto-connect slot activated when earthquake model is changed.
+        """
+        model = EARTHQUAKE_FUNCTIONS[current_index]
+        notes = ''
+        for note in model['notes']:
+            notes += note + '\n\n'
+
+        citations = ''
+        for citation in model['citations']:
+            citations += citation['text'] + '\n\n'
+
+        text = tr('Description:\n\n%s\n\n'
+            'Notes:\n\n%s\n\n'
+            'Citations:\n\n%s') % (
+            model['description'],
+            notes,
+            citations)
+
+        self.earthquake_fatality_model_notes.setText(text)
+
+    # noinspection PyPep8Naming
     @pyqtSignature('')  # prevents actions being handled twice
     def on_toolKeywordCachePath_clicked(self):
         """Auto-connect slot activated when cache file tool button is clicked.

--- a/safe/gui/ui/options_dialog_base.ui
+++ b/safe/gui/ui/options_dialog_base.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>712</width>
-    <height>685</height>
+    <width>864</width>
+    <height>629</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,21 +25,12 @@
      </property>
      <widget class="QWidget" name="page">
       <layout class="QGridLayout" name="gridLayout">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
        <item row="0" column="0">
-        <widget class="QWebView" name="help_web_view" native="true">
-         <property name="url" stdset="0">
+        <widget class="QWebView" name="help_web_view">
+         <property name="url">
           <url>
            <string>about:blank</string>
           </url>
@@ -50,38 +41,20 @@
      </widget>
      <widget class="QWidget" name="page_1">
       <layout class="QGridLayout" name="gridLayout_5">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
        <item row="0" column="0">
         <widget class="QTabWidget" name="tabWidget">
          <property name="currentIndex">
-          <number>3</number>
+          <number>1</number>
          </property>
          <widget class="QWidget" name="tab_basic">
           <attribute name="title">
            <string>Basic Options</string>
           </attribute>
           <layout class="QGridLayout" name="gridLayout_4">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>0</number>
            </property>
            <item row="0" column="0">
@@ -100,8 +73,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>682</width>
-                <height>592</height>
+                <width>834</width>
+                <height>536</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -195,40 +168,6 @@
                 </layout>
                </item>
                <item>
-                <widget class="QLabel" name="label">
-                 <property name="text">
-                  <string>Default Earthquake Fatality Model</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout">
-                 <item>
-                  <widget class="QComboBox" name="earthquake_function">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item>
                 <widget class="QGroupBox" name="grpNotImplemented">
                  <property name="title">
                   <string>Not yet implemented</string>
@@ -315,6 +254,40 @@
               </layout>
              </widget>
             </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="earthquake_tab">
+          <attribute name="title">
+           <string>Earthquake</string>
+          </attribute>
+          <layout class="QGridLayout" name="gridLayout_7">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Default earthquake fatality model</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QComboBox" name="earthquake_function">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>Selected model notes</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QTextBrowser" name="earthquake_fatality_model_notes"/>
            </item>
           </layout>
          </widget>
@@ -540,7 +513,7 @@
          </widget>
          <widget class="QWidget" name="tab_default_values">
           <attribute name="title">
-           <string>Demographic Default</string>
+           <string>Demographic Defaults</string>
           </attribute>
           <layout class="QVBoxLayout" name="verticalLayout_5">
            <item>
@@ -672,7 +645,7 @@ p, li { white-space: pre-wrap; }
   <customwidget>
    <class>QWebView</class>
    <extends>QWidget</extends>
-   <header>PyQt4.QtWebKit</header>
+   <header>QtWebKit/QWebView</header>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
Added separate tab for earthquake in options and show definitions relating to earthquake for the selected model.

Signed-off-by: Tim Sutton <tim@kartoza.com>

### What does it fix ?
* Ticket : #4130
* Funded by : DFAT
* Description :  Added eq tab in options

![licecap](https://cloud.githubusercontent.com/assets/178003/25940671/2be56a38-3637-11e7-87ec-431ca25c9c7d.gif)

