### PR TITLE
Partial fix for #4151 - show help_text in field definitions

### DIFF
--- a/safe/gui/tools/help/definitions_help.py
+++ b/safe/gui/tools/help/definitions_help.py
@@ -1209,7 +1209,7 @@ def _add_field_to_table(field, table):
     table.add(row)
     # Description goes in its own row with spanning
     row = m.Row()
-    row.add(m.Cell(field['description'], span=6))
+    row.add(m.Cell(field['description'] + ' ' + field['help_text'], span=6))
     table.add(row)
 
 


### PR DESCRIPTION
### What does it fix ?
* Ticket : #4151
* Funded by : DFAT
* Description : Show help text in field descriptions.

![screen shot 2017-05-11 at 4 32 39 pm](https://cloud.githubusercontent.com/assets/178003/25954896/eb2ee650-3667-11e7-8772-efee8d379984.png)

