### PR TITLE
override bootstrap 4 style (font-size and table padding)

### DIFF
--- a/resources/css/InaSAFE.css
+++ b/resources/css/InaSAFE.css
@@ -1,8 +1,12 @@
 body {
   font-family: 'Ubuntu', 'Lucida Grande', 'Segoe UI', 'Arial', sans-serif;
+  font-size: 14px;
 }
 th {text-align: left;}
 table {font-size: 12px ;!important;}
+.table th, .table td {
+  padding: 8px;
+}
 th.button-cell{
   padding: 4px 10px 4px;
   margin-bottom: 0;
@@ -42,6 +46,9 @@ h1, h2, h3, h4, h5, h6 {
   padding-left: 20px;
   padding-bottom: 0px;
   padding-top: 0px;
+}
+h5, .h5 {
+  font-size: 14px;
 }
 .warning {
   color: #fff;

--- a/resources/report-templates/standard-template/jinja2/general-report.html
+++ b/resources/report-templates/standard-template/jinja2/general-report.html
@@ -9,7 +9,7 @@
     </div>
     <div class="row">
         {% for section in summary %}
-        <div class="col-md-6 col-xs-12 col-sm-6">
+        <div class="col-sm-6">
             <table class="table table-striped condensed">
                 <thead>
                     <tr>

--- a/safe/gui/widgets/message_viewer.py
+++ b/safe/gui/widgets/message_viewer.py
@@ -374,7 +374,18 @@ class MessageViewer(QtWebKit.QWebView):
         printer.setOutputFormat(QtGui.QPrinter.PdfFormat)
         report_path = unique_filename(suffix='.pdf')
         printer.setOutputFileName(report_path)
-        self.print_(printer)
+
+        # We implement this to make sure the layout is just as good as
+        # in the browser.
+        html_content = html_header()
+        html_content += self.page_to_html()
+        html_content += html_footer()
+        # temporary QWebView
+        printer_web_view = QtWebKit.QWebView()
+        printer_web_view.setHtml(html_content)
+        printer_web_view.adjustSize()
+        printer_web_view.print_(printer)
+
         url = QtCore.QUrl.fromLocalFile(report_path)
         # noinspection PyTypeChecker,PyCallByClass,PyArgumentList
         QtGui.QDesktopServices.openUrl(url)


### PR DESCRIPTION
### What does it fix?
* Ticket: #
* Funded by: DFAT
* Description: Still cannot replicate table floats to right on the dock.

on save as pdf action:

BEFORE
![img_20170518_110337](https://cloud.githubusercontent.com/assets/11134669/26186190/f64ae500-3bb9-11e7-97a8-859296519838.jpg)

AFTER
![selection_079](https://cloud.githubusercontent.com/assets/11134669/26186213/1dc1368e-3bba-11e7-953e-1a536760507b.png)
