### PR TITLE
add notes for fatality rates

### DIFF
--- a/safe/definitions/reports/components.py
+++ b/safe/definitions/reports/components.py
@@ -272,7 +272,7 @@ notes_assumptions_component = {
             ]
         },
         'hazard_displacement_rates_note_format': tr(
-            '{name} - {displacement_rate:.2%}'),
+            '{name} - {displacement_rate:.0%}'),
         'fatality_rates_note_format': {
             'item_header': tr('fatality rates notes'),
             'item_list': [
@@ -281,7 +281,7 @@ notes_assumptions_component = {
             ]
         },
         'hazard_fatality_rates_note_format': tr(
-            '{name} - {fatality_rate:.6%}')
+            '{name} - {fatality_rate}%')
     }
 }
 

--- a/safe/definitions/reports/components.py
+++ b/safe/definitions/reports/components.py
@@ -272,7 +272,16 @@ notes_assumptions_component = {
             ]
         },
         'hazard_displacement_rates_note_format': tr(
-            '{name} - {displacement_rate:.2%}')
+            '{name} - {displacement_rate:.2%}'),
+        'fatality_rates_note_format': {
+            'item_header': tr('fatality rates notes'),
+            'item_list': [
+                tr('For this analysis, the following fatality rates were '
+                   'used: {rate_description}')
+            ]
+        },
+        'hazard_fatality_rates_note_format': tr(
+            '{name} - {fatality_rate:.6%}')
     }
 }
 

--- a/safe/gui/tools/help/definitions_help.py
+++ b/safe/gui/tools/help/definitions_help.py
@@ -37,7 +37,7 @@ from safe.gui.tools.help.shakemap_converter_help \
 from safe.messaging import styles
 from safe.utilities.i18n import tr
 from safe.utilities.resources import resource_url, resources_path
-from safe.utilities.utilities import html_scientific_notation_rate
+from safe.utilities.rounding import html_scientific_notation_rate
 
 LOGGER = logging.getLogger('InaSAFE')
 # For chapter sections

--- a/safe/gui/tools/help/definitions_help.py
+++ b/safe/gui/tools/help/definitions_help.py
@@ -37,6 +37,7 @@ from safe.gui.tools.help.shakemap_converter_help \
 from safe.messaging import styles
 from safe.utilities.i18n import tr
 from safe.utilities.resources import resource_url, resources_path
+from safe.utilities.utilities import html_scientific_notation_rate
 
 LOGGER = logging.getLogger('InaSAFE')
 # For chapter sections
@@ -1098,16 +1099,20 @@ def definition_to_message(
             else:
                 row.add(m.Cell(tr('unspecified')))
 
-            if inasafe_class.get('fatality_rate') >= 0:
-                rate = inasafe_class['fatality_rate'] * 100
-                rate = u'%s%%' % format(rate, 'f')
+            if inasafe_class.get('fatality_rate') > 0:
+                # we want to show the rate as a scientific notation
+                rate = html_scientific_notation_rate(
+                    inasafe_class['fatality_rate'])
+                rate = u'%s%%' % rate
                 row.add(m.Cell(rate))
+            elif inasafe_class.get('fatality_rate') == 0:
+                row.add(m.Cell('0%'))
             else:
                 row.add(m.Cell(tr('unspecified')))
 
             if 'displacement_rate' in inasafe_class:
                 rate = inasafe_class['displacement_rate'] * 100
-                rate = u'%s%%' % rate
+                rate = u'%.0f%%' % rate
                 row.add(m.Cell(rate))
             else:
                 row.add(m.Cell(tr('unspecified')))

--- a/safe/report/extractors/action_notes.py
+++ b/safe/report/extractors/action_notes.py
@@ -12,7 +12,7 @@ from safe.report.extractors.util import (
 from safe.utilities.resources import (
     resource_url,
     resources_path)
-from safe.utilities.utilities import html_scientific_notation_rate
+from safe.utilities.rounding import html_scientific_notation_rate
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"

--- a/safe/report/extractors/action_notes.py
+++ b/safe/report/extractors/action_notes.py
@@ -12,6 +12,7 @@ from safe.report.extractors.util import (
 from safe.utilities.resources import (
     resource_url,
     resources_path)
+from safe.utilities.utilities import html_scientific_notation_rate
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -148,15 +149,23 @@ def notes_assumptions_extractor(impact_report, component_metadata):
             extra_args, 'hazard_fatality_rates_note_format')
         fatality_rates_note = []
         for hazard_class in hazard_classification['classes']:
-            if not hazard_class['fatality_rate'] >= 0:
-                hazard_class['fatality_rate'] = 0
+            # we make a copy here because we don't want to
+            # change the real value.
+            copy_of_hazard_class = dict(hazard_class)
+            if not copy_of_hazard_class['fatality_rate'] > 0:
+                copy_of_hazard_class['fatality_rate'] = 0
+            else:
+                # we want to show the rate as a scientific notation
+                copy_of_hazard_class['fatality_rate'] = (
+                    html_scientific_notation_rate(
+                        copy_of_hazard_class['fatality_rate']))
+
             fatality_rates_note.append(
-                fatality_rates_note_format.format(**hazard_class))
+                fatality_rates_note_format.format(**copy_of_hazard_class))
 
         rate_description = ', '.join(fatality_rates_note)
 
-        for index, fatality_note in enumerate(
-                fatality_note_dict['item_list']):
+        for index, fatality_note in enumerate(fatality_note_dict['item_list']):
             fatality_note_dict['item_list'][index] = (
                 fatality_note.format(rate_description=rate_description)
             )

--- a/safe/report/extractors/action_notes.py
+++ b/safe/report/extractors/action_notes.py
@@ -3,7 +3,6 @@
 """
 from safe.common.utilities import safe_dir
 from safe.definitions.exposure import exposure_population
-from safe.definitions.hazard import earthquake_mmi_scale, hazard_earthquake
 from safe.report.extractors.composer import QGISComposerContext
 from safe.report.extractors.util import (
     resolve_from_dictionary,

--- a/safe/report/extractors/action_notes.py
+++ b/safe/report/extractors/action_notes.py
@@ -3,6 +3,7 @@
 """
 from safe.common.utilities import safe_dir
 from safe.definitions.exposure import exposure_population
+from safe.definitions.hazard import earthquake_mmi_scale, hazard_earthquake
 from safe.report.extractors.composer import QGISComposerContext
 from safe.report.extractors.util import (
     resolve_from_dictionary,
@@ -113,13 +114,14 @@ def notes_assumptions_extractor(impact_report, component_metadata):
             extra_args, 'displacement_rates_note_format')
 
         # generate rate description
-        hazard_note_format = resolve_from_dictionary(
+        displacement_rates_note_format = resolve_from_dictionary(
             extra_args, 'hazard_displacement_rates_note_format')
-        hazard_note = []
+        displacement_rates_note = []
         for hazard_class in hazard_classification['classes']:
-            hazard_note.append(hazard_note_format.format(**hazard_class))
+            displacement_rates_note.append(
+                displacement_rates_note_format.format(**hazard_class))
 
-        rate_description = ', '.join(hazard_note)
+        rate_description = ', '.join(displacement_rates_note)
 
         for index, displacement_note in enumerate(
                 displacement_note_dict['item_list']):
@@ -128,6 +130,39 @@ def notes_assumptions_extractor(impact_report, component_metadata):
             )
 
         context['items'].append(displacement_note_dict)
+
+    # Check hazard have displacement rate
+    for hazard_class in hazard_classification['classes']:
+        if hazard_class.get('fatality_rate', 0) > 0:
+            have_fatality_rate = True
+            break
+    else:
+        have_fatality_rate = False
+
+    if have_fatality_rate and exposure_type == exposure_population:
+        # add notes for fatality rate used
+        fatality_note_dict = resolve_from_dictionary(
+            extra_args, 'fatality_rates_note_format')
+
+        # generate rate description
+        fatality_rates_note_format = resolve_from_dictionary(
+            extra_args, 'hazard_fatality_rates_note_format')
+        fatality_rates_note = []
+        for hazard_class in hazard_classification['classes']:
+            if not hazard_class['fatality_rate'] >= 0:
+                hazard_class['fatality_rate'] = 0
+            fatality_rates_note.append(
+                fatality_rates_note_format.format(**hazard_class))
+
+        rate_description = ', '.join(fatality_rates_note)
+
+        for index, fatality_note in enumerate(
+                fatality_note_dict['item_list']):
+            fatality_note_dict['item_list'][index] = (
+                fatality_note.format(rate_description=rate_description)
+            )
+
+        context['items'].append(fatality_note_dict)
 
     return context
 

--- a/safe/report/test/test_impact_report.py
+++ b/safe/report/test/test_impact_report.py
@@ -970,7 +970,7 @@ class TestImpactReport(unittest.TestCase):
 
         expected_context = (
             'For this analysis, the following displacement rates were used: '
-            'Wet - 90.00%, Dry - 0.00%')
+            'Wet - 90%, Dry - 0%')
         actual_context = notes_assumptions.context['items'][-1]['item_list'][0]
         self.assertEqual(expected_context.strip(), actual_context.strip())
 

--- a/safe/utilities/rounding.py
+++ b/safe/utilities/rounding.py
@@ -266,10 +266,21 @@ def html_scientific_notation_rate(rate):
     :return: Rate value with html tag to show the exponent
     :rtype: str
     """
-    rate = '%.2E' % Decimal(rate)
-    html_rate = rate.split('E')
-    # we use html tag to show exponent
-    html_rate[1] = '10<sup>{exponent}</sup>'.format(
-        exponent=html_rate[1])
-    html_rate.insert(1, 'x')
-    return ''.join(html_rate)
+    precision = '%.3f'
+    if rate * 100 > 0:
+        decimal_rate = Decimal(precision % (rate * 100))
+        if decimal_rate == Decimal((precision % 0)):
+            decimal_rate = Decimal(str(rate * 100))
+    else:
+        decimal_rate = Decimal(str(rate * 100))
+    if decimal_rate.as_tuple().exponent >= -3:
+        rate_percentage = str(decimal_rate)
+    else:
+        rate = '%.2E' % decimal_rate
+        html_rate = rate.split('E')
+        # we use html tag to show exponent
+        html_rate[1] = '10<sup>{exponent}</sup>'.format(
+            exponent=html_rate[1])
+        html_rate.insert(1, 'x')
+        rate_percentage = ''.join(html_rate)
+    return rate_percentage

--- a/safe/utilities/rounding.py
+++ b/safe/utilities/rounding.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 """Rounding and number formatting."""
-
-
+from decimal import Decimal
 from math import ceil
 
 from safe.definitions.units import unit_mapping
@@ -253,3 +252,24 @@ def fatalities_range(number):
             return range_format.format(
                 min_range=add_separators(min_range),
                 max_range=add_separators(max_range))
+
+
+def html_scientific_notation_rate(rate):
+    """Helper for convert decimal rate using scientific notation.
+
+    For example we want to show the very detail value of fatality rate
+    because it might be a very small number.
+
+    :param rate: Rate value
+    :type rate: float
+
+    :return: Rate value with html tag to show the exponent
+    :rtype: str
+    """
+    rate = '%.2E' % Decimal(rate)
+    html_rate = rate.split('E')
+    # we use html tag to show exponent
+    html_rate[1] = '10<sup>{exponent}</sup>'.format(
+        exponent=html_rate[1])
+    html_rate.insert(1, 'x')
+    return ''.join(html_rate)

--- a/safe/utilities/utilities.py
+++ b/safe/utilities/utilities.py
@@ -13,6 +13,7 @@ import unicodedata
 import webbrowser
 
 from PyQt4.QtCore import QPyNullVariant
+from decimal import Decimal
 
 from safe.common.exceptions import NoKeywordsFoundError, MetadataReadError
 from safe.definitions.versions import (
@@ -411,3 +412,23 @@ def readable_os_version():
         return ' {version}'.format(version=platform.mac_ver()[0])
     elif platform.system() == 'Windows':
         return platform.platform()
+
+
+def html_scientific_notation_rate(rate):
+    """Helper for convert decimal rate to scientific notation. For example
+    we want to show the very detail value of fatality rate because it might be
+    a very small number.
+
+    :param rate: Rate value
+    :type rate: float
+
+    :return: Rate value with html tag to show the exponent
+    :rtype: str
+    """
+    rate = '%.2E' % Decimal(rate)
+    html_rate = rate.split('E')
+    # we use html tag to show exponent
+    html_rate[1] = '10<sup>{exponent}</sup>'.format(
+        exponent=html_rate[1])
+    html_rate.insert(1, 'x')
+    return ''.join(html_rate)

--- a/safe/utilities/utilities.py
+++ b/safe/utilities/utilities.py
@@ -13,7 +13,6 @@ import unicodedata
 import webbrowser
 
 from PyQt4.QtCore import QPyNullVariant
-from decimal import Decimal
 
 from safe.common.exceptions import NoKeywordsFoundError, MetadataReadError
 from safe.definitions.versions import (
@@ -412,23 +411,3 @@ def readable_os_version():
         return ' {version}'.format(version=platform.mac_ver()[0])
     elif platform.system() == 'Windows':
         return platform.platform()
-
-
-def html_scientific_notation_rate(rate):
-    """Helper for convert decimal rate to scientific notation. For example
-    we want to show the very detail value of fatality rate because it might be
-    a very small number.
-
-    :param rate: Rate value
-    :type rate: float
-
-    :return: Rate value with html tag to show the exponent
-    :rtype: str
-    """
-    rate = '%.2E' % Decimal(rate)
-    html_rate = rate.split('E')
-    # we use html tag to show exponent
-    html_rate[1] = '10<sup>{exponent}</sup>'.format(
-        exponent=html_rate[1])
-    html_rate.insert(1, 'x')
-    return ''.join(html_rate)


### PR DESCRIPTION
### What does it fix?
* Ticket: #4093 
* Funded by: DFAT
* Description: add fatality ratio to the note just like the displacement ratio. the rounding is the same as what displayed in the definition help.

![selection_084](https://cloud.githubusercontent.com/assets/11134669/26398271/3226a77e-40a3-11e7-98e1-2f53ba530cb0.png)
