### PR TITLE
make the tables in general report in different row

### DIFF
--- a/resources/report-templates/standard-template/jinja2/general-report.html
+++ b/resources/report-templates/standard-template/jinja2/general-report.html
@@ -7,30 +7,30 @@
             {{ table_header|capitalize }}
         </h5>
     </div>
-    <div class="row">
-        {% for section in summary %}
-        <div class="col-sm-6">
-            <table class="table table-striped condensed">
-                <thead>
-                    <tr>
-                        <th colspan="1">{{ section.header_label }}</th>
-                        <th class="text-right" colspan="1">{{ section.value_label }}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for item in section.rows %}
-                    <tr>
-                        {% if item.as_header %}
-                            <th colspan="1">{{ item.name }}</th>
-                        {% else %}
-                            <td colspan="1">{{ item.name }}</td>
-                        {% endif %}
-                        <td class="text-right" colspan=1>{{ item.value }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+    {% for section in summary %}
+        <div class="row">
+            <div class="col-sm-12">
+                <table class="table table-striped condensed">
+                    <thead>
+                        <tr>
+                            <th colspan="1">{{ section.header_label }}</th>
+                            <th class="text-right" colspan="1">{{ section.value_label }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for item in section.rows %}
+                        <tr>
+                            {% if item.as_header %}
+                                <th colspan="1">{{ item.name }}</th>
+                            {% else %}
+                                <td colspan="1">{{ item.name }}</td>
+                            {% endif %}
+                            <td class="text-right" colspan=1>{{ item.value }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </div>
-        {% endfor %}
-    </div>
+    {% endfor %}
 </div>


### PR DESCRIPTION
### What does it fix?
* Ticket: #
* Funded by: DFAT
* Description: Put the table in general report in different row to avoid table that randomly floats to right in mac and windows

![selection_087](https://cloud.githubusercontent.com/assets/11134669/26490141/5b1fce52-4234-11e7-930b-291515a9f6d9.png)
![selection_088](https://cloud.githubusercontent.com/assets/11134669/26490143/5c1775a8-4234-11e7-9da1-a092f1733a58.png)

