### PR TITLE
Fix 3633

### DIFF
--- a/safe/metadata/__init__.py
+++ b/safe/metadata/__init__.py
@@ -5,8 +5,8 @@
 # pylint: disable=unused-import
 from safe.metadata.base_metadata import BaseMetadata
 from safe.metadata.generic_layer_metadata import GenericLayerMetadata
-from safe.metadata.exposure_summary_layer_metadata import (
-    ExposureSummaryLayerMetadata)
+from safe.metadata.output_layer_metadata import (
+    OutputLayerMetadata)
 from safe.metadata.exposure_layer_metadata import ExposureLayerMetadata
 from safe.metadata.hazard_layer_metadata import HazardLayerMetadata
 from safe.metadata.aggregation_layer_metadata import AggregationLayerMetadata

--- a/safe/metadata/output_layer_metadata.py
+++ b/safe/metadata/output_layer_metadata.py
@@ -1,33 +1,22 @@
-# -*- coding: utf-8 -*-
-"""
-InaSAFE Disaster risk assessment tool developed by AusAid -
-**metadata module.**
-
-Contact : ole.moller.nielsen@gmail.com
-
-.. note:: This program is free software; you can redistribute it and/or modify
-     it under the terms of the GNU General Public License as published by
-     the Free Software Foundation; either version 2 of the License, or
-     (at your option) any later version.
-"""
-
-__author__ = 'marco@opengis.ch'
-__revision__ = '$Format:%H$'
-__date__ = '27/05/2015'
-__copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
-                 'Disaster Reduction')
+# coding=utf-8
+"""Metadata for Output Layer."""
 
 import json
 from xml.etree import ElementTree
 from safe.metadata import BaseMetadata
+
 from safe.metadata.provenance import Provenance
 from safe.metadata.utils import reading_ancillary_files, XML_NS, prettify_xml
 from safe.metadata.utils import merge_dictionaries
-
 from safe.metadata.encoder import MetadataEncoder
 
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
 
-class ExposureSummaryLayerMetadata(BaseMetadata):
+
+class OutputLayerMetadata(BaseMetadata):
     """
     Metadata class for exposure summary layers
 
@@ -114,7 +103,7 @@ class ExposureSummaryLayerMetadata(BaseMetadata):
 
         # initialize base class
         super(
-            ExposureSummaryLayerMetadata, self).__init__(
+            OutputLayerMetadata, self).__init__(
             layer_uri, xml_uri, json_uri)
 
     @property
@@ -125,7 +114,7 @@ class ExposureSummaryLayerMetadata(BaseMetadata):
         :return: dictionary representation of the metadata
         :rtype: dict
         """
-        metadata = super(ExposureSummaryLayerMetadata, self).dict
+        metadata = super(OutputLayerMetadata, self).dict
 
         metadata['provenance'] = self.provenance
         metadata['summary_data'] = self.summary_data
@@ -158,7 +147,7 @@ class ExposureSummaryLayerMetadata(BaseMetadata):
         :rtype: dict
         """
         with reading_ancillary_files(self):
-            metadata = super(ExposureSummaryLayerMetadata, self).read_json()
+            metadata = super(OutputLayerMetadata, self).read_json()
             if 'provenance' in metadata:
                 for provenance_step in metadata['provenance']:
                     try:
@@ -194,7 +183,7 @@ class ExposureSummaryLayerMetadata(BaseMetadata):
         :rtype: ElementTree.Element
         """
 
-        root = super(ExposureSummaryLayerMetadata, self).xml
+        root = super(OutputLayerMetadata, self).xml
         provenance_path = self._special_properties['provenance']
         provenance_element = root.find(provenance_path, XML_NS)
 
@@ -222,7 +211,7 @@ class ExposureSummaryLayerMetadata(BaseMetadata):
         """
 
         with reading_ancillary_files(self):
-            root = super(ExposureSummaryLayerMetadata, self).read_xml()
+            root = super(OutputLayerMetadata, self).read_xml()
             if root is not None:
                 self._read_provenance_from_xml(root)
         return root
@@ -313,7 +302,7 @@ class ExposureSummaryLayerMetadata(BaseMetadata):
         :param keywords:
         :return:
         """
-        super(ExposureSummaryLayerMetadata, self).update_from_dict(keywords)
+        super(OutputLayerMetadata, self).update_from_dict(keywords)
 
         if 'if_provenance' in keywords.keys():
             if_provenance = keywords['if_provenance']

--- a/safe/metadata/test/scripts.py
+++ b/safe/metadata/test/scripts.py
@@ -4,8 +4,8 @@
 from safe.metadata.exposure_layer_metadata import ExposureLayerMetadata
 from safe.metadata.hazard_layer_metadata import HazardLayerMetadata
 from safe.metadata.aggregation_layer_metadata import AggregationLayerMetadata
-from safe.metadata.exposure_summary_layer_metadata import \
-    ExposureSummaryLayerMetadata
+from safe.metadata.output_layer_metadata import \
+    OutputLayerMetadata
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -19,7 +19,7 @@ def print_properties():
         ExposureLayerMetadata,
         HazardLayerMetadata,
         AggregationLayerMetadata,
-        ExposureSummaryLayerMetadata
+        OutputLayerMetadata
     ]
 
     for the_metadata in metadata:

--- a/safe/metadata/test/test_exposure_impacted_metadata.py
+++ b/safe/metadata/test/test_exposure_impacted_metadata.py
@@ -32,7 +32,7 @@ from PyQt4.QtCore import QDate, QUrl
 from safe.common.exceptions import MetadataReadError
 from safe.common.utilities import unique_filename
 
-from safe.metadata import ExposureSummaryLayerMetadata
+from safe.metadata import OutputLayerMetadata
 from safe.metadata.provenance import Provenance
 from safe.metadata.test import (
     TEMP_DIR,
@@ -52,7 +52,7 @@ class TestImpactMetadata(TestCase):
         self.assertEqual(metadata.provenance.last.title, 'IF Provenance')
 
     def test_metadata_date(self):
-        metadata = ExposureSummaryLayerMetadata('random_layer_id')
+        metadata = OutputLayerMetadata('random_layer_id')
         path = TEST_XML_BASEPATH + 'gco:Date'
 
         # using QDate
@@ -76,7 +76,7 @@ class TestImpactMetadata(TestCase):
             metadata.update('ISO19115_TEST', test_value)
 
     def test_metadata_url(self):
-        metadata = ExposureSummaryLayerMetadata('random_layer_id')
+        metadata = OutputLayerMetadata('random_layer_id')
         path = TEST_XML_BASEPATH + 'gmd:URL'
 
         # using QUrl
@@ -95,7 +95,7 @@ class TestImpactMetadata(TestCase):
             metadata.set('ISO19115_TEST', test_value, path)
 
     def test_metadata_str(self):
-        metadata = ExposureSummaryLayerMetadata('random_layer_id')
+        metadata = OutputLayerMetadata('random_layer_id')
         path = TEST_XML_BASEPATH + 'gco:CharacterString'
 
         # using str
@@ -132,7 +132,7 @@ class TestImpactMetadata(TestCase):
         self.assertEquals(expected_json, written_json)
 
     def test_json_read(self):
-        metadata = ExposureSummaryLayerMetadata(EXISTING_IMPACT_FILE)
+        metadata = OutputLayerMetadata(EXISTING_IMPACT_FILE)
         with open(EXISTING_IMPACT_JSON) as f:
             expected_metadata = f.read()
 
@@ -140,24 +140,24 @@ class TestImpactMetadata(TestCase):
 
     def test_invalid_json_read(self):
         with self.assertRaises(MetadataReadError):
-            ExposureSummaryLayerMetadata(
+            OutputLayerMetadata(
                 EXISTING_IMPACT_FILE,
                 json_uri=INVALID_IMPACT_JSON)
 
     def test_incomplete_json_read(self):
-        ExposureSummaryLayerMetadata(
+        OutputLayerMetadata(
             EXISTING_IMPACT_FILE,
             json_uri=INCOMPLETE_IMPACT_JSON)
 
     def test_xml_read(self):
-        generated_metadata = ExposureSummaryLayerMetadata(
+        generated_metadata = OutputLayerMetadata(
             EXISTING_IMPACT_FILE, xml_uri=EXISTING_IMPACT_XML)
 
         # TODO (MB): add more checks
         self.assertEquals(generated_metadata.get_xml_value('license'), 'GPLv2')
 
     def test_xml_to_json_to_xml(self):
-        generated_metadata = ExposureSummaryLayerMetadata(
+        generated_metadata = OutputLayerMetadata(
             EXISTING_IMPACT_FILE, xml_uri=EXISTING_IMPACT_XML
         )
         with open(EXISTING_IMPACT_XML) as f:
@@ -165,7 +165,7 @@ class TestImpactMetadata(TestCase):
 
         json_tmp_file = unique_filename(suffix='.json', dir=TEMP_DIR)
         generated_metadata.write_to_file(json_tmp_file)
-        read_tmp_metadata = ExposureSummaryLayerMetadata(
+        read_tmp_metadata = OutputLayerMetadata(
             EXISTING_IMPACT_FILE, json_uri=json_tmp_file
         )
         self.assertEquals(expected_metadata, read_tmp_metadata.xml)
@@ -196,7 +196,7 @@ class TestImpactMetadata(TestCase):
             'requested_extent_crs': 'EPSG: 4326',
             'parameter': {},
         }
-        metadata = ExposureSummaryLayerMetadata('random_layer_id')
+        metadata = OutputLayerMetadata('random_layer_id')
         path = TEST_XML_BASEPATH + 'gco:CharacterString'
         # using str
         test_value = 'Random string'
@@ -254,7 +254,7 @@ class TestImpactMetadata(TestCase):
             'parameter': {},
         }
 
-        metadata = ExposureSummaryLayerMetadata('random_layer_id')
+        metadata = OutputLayerMetadata('random_layer_id')
         provenance = Provenance()
         provenance.append_step(
             'Title 1', 'Description of step 1', '2015-06-25T13:14:24.508974')

--- a/safe/metadata/test/test_metadata.py
+++ b/safe/metadata/test/test_metadata.py
@@ -24,7 +24,7 @@ __copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
 
 from xml.etree import ElementTree
 from safe.metadata import BaseMetadata
-from safe.metadata import ExposureSummaryLayerMetadata
+from safe.metadata import OutputLayerMetadata
 from unittest import TestCase
 
 
@@ -39,7 +39,7 @@ class TestMetadata(TestCase):
 
     def test_metadata(self):
         """Check we can't instantiate with unsupported xml types"""
-        metadata = ExposureSummaryLayerMetadata('random_layer_id')
+        metadata = OutputLayerMetadata('random_layer_id')
         path = 'gmd:MD_Metadata/gmd:dateStamp/gco:RandomString'
 
         # using unsupported xml types

--- a/safe/utilities/metadata.py
+++ b/safe/utilities/metadata.py
@@ -15,7 +15,10 @@ from safe.definitions.layer_purposes import (
     layer_purpose_hazard,
     layer_purpose_exposure,
     layer_purpose_aggregation,
-    layer_purpose_exposure_summary
+    layer_purpose_exposure_summary,
+    layer_purpose_aggregate_hazard_impacted,
+    layer_purpose_analysis_impacted,
+    layer_purpose_exposure_summary_table
 )
 from safe.definitions.layer_modes import layer_mode_continuous
 from safe.definitions.versions import inasafe_keyword_version
@@ -23,7 +26,7 @@ from safe.metadata import (
     ExposureLayerMetadata,
     HazardLayerMetadata,
     AggregationLayerMetadata,
-    ExposureSummaryLayerMetadata,
+    OutputLayerMetadata,
     GenericLayerMetadata)
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
@@ -37,7 +40,10 @@ METADATA_CLASSES = {
     layer_purpose_exposure['key']: ExposureLayerMetadata,
     layer_purpose_hazard['key']: HazardLayerMetadata,
     layer_purpose_aggregation['key']: AggregationLayerMetadata,
-    layer_purpose_exposure_summary['key']: ExposureSummaryLayerMetadata
+    layer_purpose_exposure_summary['key']: OutputLayerMetadata,
+    layer_purpose_exposure_summary_table['key']: OutputLayerMetadata,
+    layer_purpose_analysis_impacted['key']: OutputLayerMetadata,
+    layer_purpose_aggregate_hazard_impacted['key']: OutputLayerMetadata
 }
 
 
@@ -122,7 +128,7 @@ def read_iso19115_metadata(layer_uri, keyword=None):
             message += 'Layer path: %s' % layer_uri
             raise KeywordNotFoundError(message)
 
-    if isinstance(metadata, ExposureSummaryLayerMetadata):
+    if isinstance(metadata, OutputLayerMetadata):
         keywords['if_provenance'] = metadata.provenance
     return keywords
 


### PR DESCRIPTION
### What does it fix?
* Ticket: #3633
* Funded by: DFAT
* Description: 
  - Use explicit mapping between layer purpose and metadata class
  - Rename output layer metadata
  - Currently, we don't have special output layer metadata, so all output layer has the same mapping. If in the future we have a special one, we just need to inherit from `OutputLayerMetadata` class, and update the mapping.
