### PR TITLE
rename test_earthquake_report to test_impact_report_earthquake

### DIFF
--- a/safe/report/test/test_impact_report_earthquake.py
+++ b/safe/report/test/test_impact_report_earthquake.py
@@ -30,6 +30,10 @@ __email__ = "info@inasafe.org"
 __revision__ = '$Format:%H$'
 
 
+# TODO: find out why this test makes test_minimum_needs_outputs failing
+# if this test runs in travis before test_minimum_needs_outputs. We change
+# the filename at the moment so it will run after test_minimum_needs_outputs.
+
 class TestEarthquakeReport(unittest.TestCase):
 
     """Test Earthquake Report.


### PR DESCRIPTION
### What does it fix?
* Ticket: 
* Funded by: DFAT 
* Description: we change the filename so this test will run after test_impact_report because if not, this eq report test will break test_minimum_needs_ouputs. we can find the better way to fix this later.
