### PR TITLE
enable landcover analysis for cyclones

### DIFF
--- a/safe/definitions/hazard.py
+++ b/safe/definitions/hazard.py
@@ -305,7 +305,6 @@ hazard_cyclone = {
     'layer_modes': [layer_mode_classified, layer_mode_continuous],
     'disabled_exposures': [
         exposure_place,
-        exposure_land_cover,
         exposure_road,
         exposure_population
     ]

--- a/safe/definitions/hazard.py
+++ b/safe/definitions/hazard.py
@@ -304,9 +304,7 @@ hazard_cyclone = {
     'field_groups': [],
     'layer_modes': [layer_mode_classified, layer_mode_continuous],
     'disabled_exposures': [
-        exposure_place,
-        exposure_road,
-        exposure_population
+        exposure_road
     ]
 }
 

--- a/safe/gui/tools/wizard/test/test_keyword_wizard.py
+++ b/safe/gui/tools/wizard/test/test_keyword_wizard.py
@@ -2918,7 +2918,7 @@ class TestKeywordWizard(unittest.TestCase):
             'layer_purpose': layer_purpose_hazard['key'],
             'layer_mode': layer_mode_continuous['key'],
             'thresholds': {
-                exposure_structure['key']: {
+                exposure_land_cover['key']: {
                     cyclone_au_bom_hazard_classes['key']: {
                         'active': True,
                         'classes': default_classification_thresholds(


### PR DESCRIPTION
this PR allows land cover analysis for cyclons hazards.

@timlinux, @Charlotte-Morgan why are exposure_place, exposure_road, exposure_population also disabled?
