### PR TITLE
fix composer in QGIS 2.18

### DIFF
--- a/safe/report/processors/default.py
+++ b/safe/report/processors/default.py
@@ -4,7 +4,6 @@ Module for basic renderer we support. Currently we have:
 
 - Jinja2 Templating renderer
 - QGIS Composition templating renderer
-
 """
 import io
 import logging
@@ -16,7 +15,6 @@ from PyQt4.QtCore import QUrl
 from PyQt4.QtGui import QImage, QPainter
 from PyQt4.QtSvg import QSvgRenderer
 from jinja2.environment import Environment
-from jinja2.exceptions import TemplateNotFound
 from jinja2.loaders import FileSystemLoader
 from qgis.core import (
     QgsMapLayer,
@@ -25,7 +23,10 @@ from qgis.core import (
     QgsComposerHtml,
     QgsRectangle,
     QgsLegendRenderer,
-    QgsComposerLegendStyle)
+    QgsComposerLegendStyle,
+    QgsComposerMap,
+    QgsComposerLegend,
+)
 
 from safe.common.exceptions import TemplateLoadingError
 from safe.common.utilities import temp_dir
@@ -399,7 +400,7 @@ def qgis_composer_renderer(impact_report, component):
         map_extent_option = map_el.get('extent')
         composer_map = composition.getComposerItemById(item_id)
         """:type: qgis.core.QgsComposerMap"""
-        if composer_map:
+        if isinstance(composer_map, QgsComposerMap):
             composer_map.setKeepLayerSet(True)
             layer_set = [l.id() for l in layers if isinstance(l, QgsMapLayer)]
             composer_map.setLayerSet(layer_set)
@@ -452,7 +453,7 @@ def qgis_composer_renderer(impact_report, component):
 
         legend = composition.getComposerItemById(item_id)
         """:type: qgis.core.QgsComposerLegend"""
-        if legend:
+        if isinstance(legend, QgsComposerLegend):
             # set column count
             if column_count:
                 legend.setColumnCount(column_count)


### PR DESCRIPTION
### What does it fix?
* Ticket: backport of #4280

This doesn't fix the problem. But at least, we don't have a python exception.
QGIS 2.18 is not officially supported by InaSAFE yet. Only in 3 months