### PR TITLE
do not refresh the IF we are using an aggregation layer

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -26,6 +26,7 @@ status=final
 
 changelog=
     Version 4.1.2
+    - Avoid recomputing analysis extent when we pan/zoom with an aggregation layer
     - Fix issue when using a continuous hazard dataset (#4289)
     - Fix for cases where a pie chart slice calculation has a divide by zero error (#4289)
     - Fix issue where Keywords Wizard is not enabled if old keywords exist (#4284)

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -169,6 +169,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         self.setup_button_connectors()
 
         self.iface.layerSavedAs.connect(self.save_auxiliary_files)
+        self.iface.mapCanvas().extentsChanged.connect(self.extents_changed)
 
         canvas = self.iface.mapCanvas()
 
@@ -406,9 +407,18 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         self.iface.mapCanvas().layersChanged.connect(self.get_layers)
         self.iface.currentLayerChanged.connect(self.layer_changed)
 
+    def extents_changed(self):
+        """Helper to know if we need to refresh the IF when we pan/zoom.
+
+        This function is always connected to the extentsChanged signal from
+        the map canvas. According to the aggregation layer, we refresh or not.
+
+        We got a problem by trying to connect/disconnect before every time.
+        """
         if not self._aggregation:
-            self.iface.mapCanvas().extentsChanged.connect(
-                self.validate_impact_function)
+            self.validate_impact_function()
+        else:
+            pass
 
     # pylint: disable=W0702
     def disconnect_layer_listener(self):
@@ -423,10 +433,6 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
 
         self.iface.mapCanvas().layersChanged.disconnect(self.get_layers)
         self.iface.currentLayerChanged.disconnect(self.layer_changed)
-
-        if not self._aggregation:
-            self.iface.mapCanvas().extentsChanged.disconnect(
-                self.validate_impact_function)
 
     @pyqtSlot(QgsMapLayer, str)
     def save_auxiliary_files(self, layer, destination):


### PR DESCRIPTION
### What does it fix?
* Funded by: WB
* Description: do not refresh the IF we are using an aggregation layer

It seems I got some problems by trying to connect/disconnect. I just found that I could use one function always connected to pan/zoom. It makes it much easier now.

![stop_refresh](https://user-images.githubusercontent.com/1609292/27709526-bb5db808-5d1c-11e7-9953-c7c42b4bcd0b.gif)
