### PR TITLE
Fix 4240 reporting styling

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -17,7 +17,7 @@ about=Developed for the Indonesian Government - BNPB, Australian Government - AI
 
 version=4.2.0
 # alpha, beta, rc or final
-status=final
+status=beta
 
 
 # end of mandatory metadata

--- a/safe/definitions/test/test_utilities.py
+++ b/safe/definitions/test/test_utilities.py
@@ -2,6 +2,10 @@
 """Test for utilities module."""
 import unittest
 from copy import deepcopy
+from tempfile import mkdtemp
+from os.path import join, exists, splitext, split
+import shutil
+
 from safe import definitions
 
 from safe.definitions import (
@@ -40,6 +44,7 @@ from safe.definitions import (
     population_field_groups,
     aggregation_field_groups
 )
+from safe.definitions.reports.components import report_a4_blue
 
 from safe.definitions.utilities import (
     definition,
@@ -58,8 +63,11 @@ from safe.definitions.utilities import (
     default_classification_thresholds,
     default_classification_value_maps,
     fields_in_field_groups,
-    get_field_groups
+    get_field_groups,
+    map_report_component
 )
+
+from safe.common.utilities import safe_dir
 
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
@@ -71,6 +79,8 @@ __revision__ = '$Format:%H$'
 class TestDefinitionsUtilities(unittest.TestCase):
 
     """Test Utilities Class for Definitions."""
+
+    maxDiff = None
 
     def test_definition(self):
         """Test we can get definitions for keywords.
@@ -410,6 +420,26 @@ class TestDefinitionsUtilities(unittest.TestCase):
         field_groups = get_field_groups(layer_purpose_hazard['key'])
         expected = []
         self.assertListEqual(field_groups, expected)
+
+    def test_map_report_component(self):
+        """Test for map report component."""
+        # Default qpt
+        component = map_report_component(report_a4_blue, '.')
+        self.assertDictEqual(component, report_a4_blue)
+
+        # Custom qpt
+        target_directory = mkdtemp()
+        default_qpt = join(
+            safe_dir('..'),
+            'resources',
+            'qgis-composer-templates',
+            'a4-portrait-blue.qpt')
+        if exists(default_qpt):
+            target_path = join(target_directory, split(default_qpt)[1])
+            shutil.copy2(default_qpt, target_path)
+
+        component = map_report_component(report_a4_blue, target_directory)
+        self.assertTrue(component != report_a4_blue)
 
 
 if __name__ == '__main__':

--- a/safe/definitions/test/test_utilities.py
+++ b/safe/definitions/test/test_utilities.py
@@ -3,7 +3,7 @@
 import unittest
 from copy import deepcopy
 from tempfile import mkdtemp
-from os.path import join, exists, splitext, split
+from os.path import join, exists, split
 import shutil
 
 from safe import definitions

--- a/safe/definitions/utilities.py
+++ b/safe/definitions/utilities.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 """Utilities module for helping definitions retrieval."""
 
+from os.path import join, exists
+from qgis.core import QgsApplication
 from copy import deepcopy
 
 from safe import definitions
@@ -426,3 +428,29 @@ def get_field_groups(layer_purpose, layer_subcategory=None):
             subcategory = definition(layer_subcategory)
             field_groups += deepcopy(subcategory['field_groups'])
     return field_groups
+
+
+def map_report_component(component, custom_template_dir=None):
+    """Get a map report component based on custom qpt if exists
+
+    :param component: Component as dictionary.
+    :type component: dict
+
+    :param custom_template_dir: The directory where the custom template stored.
+    :type custom_template_dir: basestring
+
+    :returns: Map report component.
+    :rtype: dict
+    """
+    copy_component = deepcopy(component)
+    if not custom_template_dir:
+        custom_template_dir = join(
+            QgsApplication.qgisSettingsDirPath(), 'inasafe')
+
+    for component in copy_component['components']:
+        qpt_file_name = component['template'].split('/')[-1]
+        custom_qpt_path = join(custom_template_dir, qpt_file_name)
+        if exists(custom_qpt_path):
+            component['template'] = custom_qpt_path
+
+    return copy_component

--- a/safe/gui/analysis_utilities.py
+++ b/safe/gui/analysis_utilities.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from PyQt4.QtCore import QDir, Qt
 from qgis.core import QgsMapLayerRegistry, QgsProject, QgsMapLayer, QGis
 
-from safe.definitions.utilities import definition
+from safe.definitions.utilities import definition, map_report_component
 from safe.definitions.fields import hazard_class_field
 from safe.definitions.reports.components import (
     standard_impact_report_metadata_pdf,
@@ -69,7 +69,7 @@ def generate_impact_map_report(impact_function, iface):
     """
     # create impact report instance
     report_metadata = ReportMetadata(
-        metadata_dict=report_a4_blue)
+        metadata_dict=map_report_component(report_a4_blue))
     impact_report = ImpactReport(
         iface,
         report_metadata,

--- a/safe/gui/tools/batch/batch_dialog.py
+++ b/safe/gui/tools/batch/batch_dialog.py
@@ -53,6 +53,7 @@ from safe.definitions.layer_purposes import (
     layer_purpose_hazard,
     layer_purpose_exposure,
     layer_purpose_aggregation)
+from safe.definitions.utilities import map_report_component
 from safe.definitions.reports.components import (
     standard_impact_report_metadata_pdf,
     report_a4_blue)
@@ -702,7 +703,7 @@ class BatchDialog(QDialog, FORM_CLASS):
 
         # create impact map report instance
         map_report_metadata = ReportMetadata(
-            metadata_dict=report_a4_blue)
+            metadata_dict=map_report_component(report_a4_blue))
         impact_map_report = ImpactReport(
             iface,
             map_report_metadata,

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -37,6 +37,7 @@ from safe.definitions.constants import (
     PREPARE_FAILED_BAD_LAYER,
     PREPARE_SUCCESS,
 )
+from safe.definitions.utilities import map_report_component
 from safe.defaults import supporters_logo_path
 from safe.definitions.reports import (
     final_product_tag,
@@ -999,7 +1000,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         standard_impact_report_metadata = ReportMetadata(
             metadata_dict=standard_impact_report_metadata_pdf)
         standard_map_report_metadata = ReportMetadata(
-            metadata_dict=report_a4_blue)
+            metadata_dict=map_report_component(report_a4_blue))
 
         standard_report_metadata = [
             standard_impact_report_metadata,

--- a/safe/report/test/test_impact_report.py
+++ b/safe/report/test/test_impact_report.py
@@ -48,6 +48,7 @@ from safe.definitions.reports.components import (
     population_infographic_component,
     analysis_provenance_details_component,
     analysis_provenance_details_simplified_component)
+from safe.definitions.utilities import map_report_component
 from safe.report.impact_report import ImpactReport
 
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
@@ -1790,7 +1791,7 @@ class TestImpactReport(unittest.TestCase):
 
         # Create impact report
         report_metadata = ReportMetadata(
-            metadata_dict=report_a4_blue)
+            metadata_dict=map_report_component(report_a4_blue))
 
         impact_report = ImpactReport(
             IFACE,


### PR DESCRIPTION
### What does it fix?
* Ticket: #4240 
* Funded by: DFAT
* Description: 
    - Scan `{QGIS Setting dir}/inasafe` first for custom map template

cc @timlinux 

Tested in my local:
I use custom template for the portrait one (change the color from blue to green):
<img width="1425" alt="screen shot 2017-07-04 at 10 00 39" src="https://user-images.githubusercontent.com/1421861/27813380-c155a30c-609f-11e7-9807-4fee2db36ebb.png">

