### PR TITLE
remove some str() functions

### DIFF
--- a/safe/common/test/test_utilities.py
+++ b/safe/common/test/test_utilities.py
@@ -93,8 +93,7 @@ class TestUtilities(unittest.TestCase):
                              ('1', '5,754'),
                              ('5,754', '11,507')]
         # print_class(my_array, my_result_class, my_expected_class)
-        my_msg = 'got: ' + str(my_result_class)
-        my_msg += ' expect: ' + str(my_expected_class)
+        my_msg = 'got: %s expect: %s' % (my_result_class, my_expected_class)
         assert my_result_class == my_expected_class, my_msg
 
     def test_humanize_class3(self):
@@ -107,8 +106,7 @@ class TestUtilities(unittest.TestCase):
         my_expected_class = [('0', '0.1'),
                              ('0.1', '0.5'),
                              ('0.5', '0.9')]
-        my_msg = 'got: ' + str(my_result_class)
-        my_msg += ' expect: ' + str(my_expected_class)
+        my_msg = 'got: %s expect: %s' % (my_result_class, my_expected_class)
         # print_class(my_array, my_result_class, my_expected_class)
         assert my_result_class == my_expected_class, my_msg
 
@@ -122,8 +120,7 @@ class TestUtilities(unittest.TestCase):
         my_expected_class = [('0', '7.1'),
                              ('7.1', '7.5'),
                              ('7.5', '7.9')]
-        my_msg = 'got: ' + str(my_result_class)
-        my_msg += ' expect: ' + str(my_expected_class)
+        my_msg = 'got: %s expect: %s' % (my_result_class, my_expected_class)
         # print_class(my_array, my_result_class, my_expected_class)
         assert my_result_class == my_expected_class, my_msg
 
@@ -140,8 +137,7 @@ class TestUtilities(unittest.TestCase):
                              ('8', '9'),
                              ('9', '11')]
         # print_class(my_array, my_result_class, my_expected_class)
-        my_msg = 'got: ' + str(my_result_class)
-        my_msg += ' expect: ' + str(my_expected_class)
+        my_msg = 'got: %s expect: %s' % (my_result_class, my_expected_class)
         assert my_result_class == my_expected_class, my_msg
 
     def test_humanize_class6(self):
@@ -157,8 +153,7 @@ class TestUtilities(unittest.TestCase):
                              ('8', '9'),
                              ('9', '11')]
         # print_class(my_array, my_result_class, my_expected_class)
-        my_msg = 'got: ' + str(my_result_class)
-        my_msg += ' expect: ' + str(my_expected_class)
+        my_msg = 'got: %s expect: %s' % (my_result_class, my_expected_class)
         assert my_result_class == my_expected_class, my_msg
 
     def test_get_significant_decimal(self):

--- a/safe/common/version.py
+++ b/safe/common/version.py
@@ -83,13 +83,11 @@ def get_version(version=None):
         version = tuple(version_list + [status] + ['0'])
 
     if len(version) != 5:
-        msg = ('Version must be a tuple of length 5. '
-               'I got %s' % str(version))
+        msg = 'Version must be a tuple of length 5. I got %s' % (version,)
         raise RuntimeError(msg)
 
     if version[3] not in ('alpha', 'beta', 'rc', 'final'):
-        msg = ('Version tuple not as expected. '
-               'I got %s' % str(version))
+        msg = 'Version tuple not as expected. I got %s' % (version,)
         raise RuntimeError(msg)
 
     # Now build the two parts of the version number:

--- a/safe/gui/tools/batch/batch_dialog.py
+++ b/safe/gui/tools/batch/batch_dialog.py
@@ -231,19 +231,17 @@ class BatchDialog(QDialog, FORM_CLASS):
         # NOTE(gigih): need this line to remove existing rows
         self.table.setRowCount(0)
 
-        path = str(scenario_directory)
-
-        if not os.path.exists(path):
+        if not os.path.exists(scenario_directory):
             # LOGGER.info('Scenario directory does not exist: %s' % path)
             return
 
         # only support .py and .txt files
-        for current_path in os.listdir(path):
+        for current_path in os.listdir(scenario_directory):
             extension = os.path.splitext(current_path)[1]
-            absolute_path = os.path.join(path, current_path)
+            absolute_path = os.path.join(scenario_directory, current_path)
 
             if extension == '.py':
-                append_row(self.table, str(current_path), absolute_path)
+                append_row(self.table, current_path, absolute_path)
             elif extension == '.txt':
                 # insert scenarios from file into table widget
                 try:
@@ -387,7 +385,7 @@ class BatchDialog(QDialog, FORM_CLASS):
         :return: QGIS layer.
         :rtype: QgsMapLayer
         """
-        scenario_dir = str(self.source_directory.text())
+        scenario_dir = self.source_directory.text()
         joined_path = os.path.join(scenario_dir, layer_path)
         full_path = os.path.normpath(joined_path)
         file_name = os.path.split(layer_path)[-1]
@@ -606,15 +604,15 @@ class BatchDialog(QDialog, FORM_CLASS):
                 result = self.run_task(item, status_item, index=index)
                 if result:
                     # P for passed
-                    report.append('P: %s\n' % str(name_item))
+                    report.append('P: %s\n' % name_item)
                     pass_count += 1
                 else:
-                    report.append('F: %s\n' % str(name_item))
+                    report.append('F: %s\n' % name_item)
                     fail_count += 1
             except Exception, e:  # pylint: disable=W0703
                 LOGGER.exception('Batch execution failed. The exception: ' +
                                  str(e))
-                report.append('F: %s\n' % str(name_item))
+                report.append('F: %s\n' % name_item)
                 fail_count += 1
                 self.disable_busy_cursor()
 
@@ -652,7 +650,7 @@ class BatchDialog(QDialog, FORM_CLASS):
         current_time = datetime.now().strftime('%Y%m%d%H%M%S')
         report_path = 'batch-report-' + current_time + '.txt'
         output_path = self.output_directory.text()
-        path = os.path.join(str(output_path), report_path)
+        path = os.path.join(output_path, report_path)
 
         try:
             report_file = file(path, 'w')

--- a/safe/gui/tools/minimum_needs/needs_profile.py
+++ b/safe/gui/tools/minimum_needs/needs_profile.py
@@ -122,10 +122,7 @@ class NeedsProfile(MinimumNeeds):
         :type profile: basestring, str
         """
         profile_path = os.path.join(
-            str(self.root_directory),
-            'minimum_needs',
-            profile + '.json'
-        )
+            self.root_directory, 'minimum_needs', profile + '.json')
         self.read_from_file(profile_path)
 
     def save_profile(self, profile):
@@ -136,7 +133,7 @@ class NeedsProfile(MinimumNeeds):
         """
         profile = profile.replace('.json', '')
         profile_path = os.path.join(
-            str(self.root_directory),
+            self.root_directory,
             'minimum_needs',
             profile + '.json'
         )
@@ -195,7 +192,7 @@ class NeedsProfile(MinimumNeeds):
 
         else:
             locale_minimum_needs_dir = os.path.join(
-                str(self.root_directory), 'minimum_needs')
+                self.root_directory, 'minimum_needs')
             path_name = resources_path('minimum_needs')
             if not os.path.exists(locale_minimum_needs_dir):
                 os.makedirs(locale_minimum_needs_dir)
@@ -342,7 +339,7 @@ class NeedsProfile(MinimumNeeds):
         """
         self.remove_file(
             os.path.join(
-                str(self.root_directory), 'minimum_needs', profile + '.json')
+                self.root_directory, 'minimum_needs', profile + '.json')
         )
 
     def move_old_profile(self, locale_minimum_needs_dir):

--- a/safe/gui/tools/test/test_save_scenario.py
+++ b/safe/gui/tools/test/test_save_scenario.py
@@ -146,8 +146,8 @@ class SaveScenarioTest(unittest.TestCase):
         fake_dir = standard_data_path()
         scenario_file = unique_filename(
             prefix='scenarioTest', suffix='.txt', dir=fake_dir)
-        exposure_layer = str(self.DOCK.get_exposure_layer().publicSource())
-        hazard_layer = str(self.DOCK.get_hazard_layer().publicSource())
+        exposure_layer = self.DOCK.get_exposure_layer().publicSource()
+        hazard_layer = self.DOCK.get_hazard_layer().publicSource()
 
         relative_exposure = self.save_scenario_dialog.relative_path(
             scenario_file, exposure_layer)


### PR DESCRIPTION
### What does it fix?
* Ticket: Partially fixing #4306
* Funded by: DFAT
* Description: Remove some `str()` functions. I think these should be safe. QT is already giving us some unicode. No need to convert to str.
We should make `str` deprecated I think. Using the format `%s` is redundant.

Comments are welcome.
