### PR TITLE
allow only the same geometry type in the output layer

### DIFF
--- a/safe/gis/vector/clip.py
+++ b/safe/gis/vector/clip.py
@@ -149,7 +149,8 @@ def clip(layer_to_clip, mask_layer, callback=None):
                 out_feat = QgsFeature()
                 out_feat.setGeometry(new_geom)
                 out_feat.setAttributes(in_feat.attributes())
-                writer.addFeature(out_feat)
+                if new_geom.type() == layer_to_clip.geometryType():
+                    writer.addFeature(out_feat)
             except:
                 LOGGER.debug(
                     tr('Feature geometry error: One or more output features '


### PR DESCRIPTION
### What does it fix?
* Ticket: #4116 
* Funded by: DFAT
* Description: I think these two lines will fix this ticket. But I have more to do about invalid geometries.
