### PR TITLE
reduce logs

### DIFF
--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -2010,12 +2010,13 @@ class ImpactFunction(object):
                 if valid:
                     self.set_state_process('post_processor', name)
                     message = u'{name} : Running'.format(name=name)
+                    LOGGER.info(message)
 
             else:
-                message = u'{name} : Could not run : {reason}'.format(
-                    name=name, reason=message)
-
-            LOGGER.info(message)
+                # message = u'{name} : Could not run : {reason}'.format(
+                #     name=name, reason=message)
+                # LOGGER.info(message)
+                pass
 
         self.debug_layer(layer, add_to_datastore=False)
 


### PR DESCRIPTION
### What does it fix?
* Funded by: DFAT
* Description: 

Travis is not happy because of too many logs.
This line is for each postprocessor, for each impact function that we launch, so it's a lot!

I'm thinking about a function logging messages only if we are not on travis
