### PR TITLE
Fix 4303 output layer metadata

### DIFF
--- a/safe/datastore/datastore.py
+++ b/safe/datastore/datastore.py
@@ -232,7 +232,7 @@ class DataStore(object):
         """Add a raster layer to the database.
 
         :param raster_layer: The layer to add.
-        :type raster_layer: QgsVectorLayer
+        :type raster_layer: QgsRasterLayer
 
         :param layer_name: The name of the layer in the datastore.
         :type layer_name: str

--- a/safe/definitions/provenance.py
+++ b/safe/definitions/provenance.py
@@ -1,6 +1,15 @@
 # coding=utf-8
 """Provenance Keys."""
 
+from safe.definitions.layer_purposes import (
+    layer_purpose_exposure_summary,
+    layer_purpose_aggregate_hazard_impacted,
+    layer_purpose_aggregation_summary,
+    layer_purpose_analysis_impacted,
+    layer_purpose_exposure_summary_table,
+    layer_purpose_profiling
+)
+
 from safe.utilities.i18n import tr
 
 provenance_action_checklist = {
@@ -153,6 +162,39 @@ provenance_user = {
     'name': tr('User'),
     'provenance_key': 'user'
 }
+
+# Output layer path
+provenance_layer_exposure_summary = {
+    'key': 'provenance_layer_exposure_summary',
+    'name': layer_purpose_exposure_summary['name'],
+    'provenance_key': layer_purpose_exposure_summary['key']
+}
+provenance_layer_aggregate_hazard_impacted = {
+    'key': 'provenance_layer_aggregate_hazard_impacted',
+    'name': layer_purpose_aggregate_hazard_impacted['name'],
+    'provenance_key': layer_purpose_aggregate_hazard_impacted['key']
+}
+provenance_layer_aggregation_summary = {
+    'key': 'provenance_layer_aggregation_summary',
+    'name': layer_purpose_aggregation_summary['name'],
+    'provenance_key': layer_purpose_aggregation_summary['key']
+}
+provenance_layer_analysis_impacted = {
+    'key': 'provenance_layer_analysis_impacted',
+    'name': layer_purpose_analysis_impacted['name'],
+    'provenance_key': layer_purpose_analysis_impacted['key']
+}
+provenance_layer_exposure_summary_table = {
+    'key': 'provenance_layer_exposure_summary_table',
+    'name': layer_purpose_exposure_summary_table['name'],
+    'provenance_key': layer_purpose_exposure_summary_table['key']
+}
+provenance_layer_profiling = {
+    'key': 'provenance_layer_profiling',
+    'name': layer_purpose_profiling['name'],
+    'provenance_key': layer_purpose_profiling['key']
+}
+
 provenance_list = [
     provenance_action_checklist,
     provenance_aggregation_keywords,
@@ -184,4 +226,11 @@ provenance_list = [
     provenance_requested_extent,
     provenance_start_datetime,
     provenance_user,
+    # Output layer path
+    provenance_layer_exposure_summary,
+    provenance_layer_aggregate_hazard_impacted,
+    provenance_layer_aggregation_summary,
+    provenance_layer_analysis_impacted,
+    provenance_layer_exposure_summary_table,
+    provenance_layer_profiling
 ]

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -899,7 +899,6 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             ]
 
             provenances = keywords.get('provenance_data', {})
-            LOGGER.debug('Set Keywords')
             self.set_provenance_to_project_variables(provenances)
 
             show_keywords = True
@@ -915,7 +914,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             if show_keywords:
                 if inasafe_keyword_version_key not in keywords.keys():
                     show_keyword_version_message(
-                        self, 'No Version', self.inasafe_version)
+                        self, tr('No Version'), self.inasafe_version)
                     self.print_button.setEnabled(False)
                 else:
                     keyword_version = str(keywords.get(

--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -117,8 +117,7 @@ from safe.definitions.provenance import (
     provenance_layer_aggregate_hazard_impacted,
     provenance_layer_aggregation_summary,
     provenance_layer_analysis_impacted,
-    provenance_layer_exposure_summary_table,
-    provenance_layer_profiling
+    provenance_layer_exposure_summary_table
 )
 from safe.impact_function.provenance_utilities import (
     get_map_title, get_analysis_question)

--- a/safe/impact_function/test/test_impact_function.py
+++ b/safe/impact_function/test/test_impact_function.py
@@ -4,7 +4,6 @@
 
 from copy import deepcopy
 import getpass
-import platform
 from socket import gethostname
 
 import unittest
@@ -24,6 +23,43 @@ from safe.definitions.fields import (
     female_displaced_count_field,
     youth_displaced_count_field,
     displaced_field,
+)
+from safe.definitions.provenance import (
+    provenance_action_checklist,
+    provenance_aggregation_keywords,
+    provenance_aggregation_layer,
+    provenance_aggregation_layer_id,
+    provenance_analysis_extent,
+    provenance_analysis_question,
+    provenance_data_store_uri,
+    provenance_duration,
+    provenance_end_datetime,
+    provenance_exposure_keywords,
+    provenance_exposure_layer,
+    provenance_exposure_layer_id,
+    provenance_gdal_version,
+    provenance_hazard_keywords,
+    provenance_hazard_layer,
+    provenance_hazard_layer_id,
+    provenance_host_name,
+    provenance_impact_function_name,
+    provenance_impact_function_title,
+    provenance_inasafe_version,
+    provenance_map_legend_title,
+    provenance_map_title,
+    provenance_notes,
+    provenance_os,
+    provenance_pyqt_version,
+    provenance_qgis_version,
+    provenance_qt_version,
+    provenance_requested_extent,
+    provenance_start_datetime,
+    provenance_user,
+    provenance_layer_exposure_summary,
+    provenance_layer_aggregate_hazard_impacted,
+    provenance_layer_aggregation_summary,
+    provenance_layer_analysis_impacted,
+    provenance_layer_exposure_summary_table
 )
 from safe.definitions.default_values import female_ratio_default_value
 from safe.definitions.layer_purposes import (
@@ -759,26 +795,36 @@ class TestImpactFunction(unittest.TestCase):
         hazard_category = definition(hazard_layer.keywords['hazard_category'])
 
         expected_provenance = {
-            'gdal_version': gdal.__version__,
-            'host_name': gethostname(),
-            'map_title': get_map_title(hazard, exposure, hazard_category),
-            'map_legend_title': exposure['layer_legend_title'],
-            'user': getpass.getuser(),
-            'os': readable_os_version(),
-            'pyqt_version': PYQT_VERSION_STR,
-            'qgis_version': QGis.QGIS_VERSION,
-            'qt_version': QT_VERSION_STR,
-            'inasafe_version': get_version(),
-            'aggregation_layer': aggregation_layer.source(),
-            'aggregation_layer_id': aggregation_layer.id(),
-            'exposure_layer': exposure_layer.source(),
-            'exposure_layer_id': exposure_layer.id(),
-            'hazard_layer': hazard_layer.source(),
-            'hazard_layer_id': hazard_layer.id(),
-            'analysis_question': get_analysis_question(hazard, exposure),
-            'aggregation_keywords': deepcopy(aggregation_layer.keywords),
-            'exposure_keywords': deepcopy(exposure_layer.keywords),
-            'hazard_keywords': deepcopy(hazard_layer.keywords),
+            provenance_gdal_version['provenance_key']: gdal.__version__,
+            provenance_host_name['provenance_key']: gethostname(),
+            provenance_map_title['provenance_key']: get_map_title(
+                hazard, exposure, hazard_category),
+            provenance_map_legend_title['provenance_key']: exposure[
+                'layer_legend_title'],
+            provenance_user['provenance_key']: getpass.getuser(),
+            provenance_os['provenance_key']: readable_os_version(),
+            provenance_pyqt_version['provenance_key']: PYQT_VERSION_STR,
+            provenance_qgis_version['provenance_key']: QGis.QGIS_VERSION,
+            provenance_qt_version['provenance_key']: QT_VERSION_STR,
+            provenance_inasafe_version['provenance_key']: get_version(),
+            provenance_aggregation_layer['provenance_key']:
+                aggregation_layer.source(),
+            provenance_aggregation_layer_id['provenance_key']:
+                aggregation_layer.id(),
+            provenance_exposure_layer['provenance_key']:
+                exposure_layer.source(),
+            provenance_exposure_layer_id['provenance_key']:
+                exposure_layer.id(),
+            provenance_hazard_layer['provenance_key']: hazard_layer.source(),
+            provenance_hazard_layer_id['provenance_key']: hazard_layer.id(),
+            provenance_analysis_question['provenance_key']:
+                get_analysis_question(hazard, exposure),
+            provenance_aggregation_keywords['provenance_key']: deepcopy(
+                aggregation_layer.keywords),
+            provenance_exposure_keywords['provenance_key']:
+                deepcopy(exposure_layer.keywords),
+            provenance_hazard_keywords['provenance_key']: deepcopy(
+                hazard_layer.keywords),
         }
 
         # Set up impact function
@@ -796,19 +842,39 @@ class TestImpactFunction(unittest.TestCase):
         self.maxDiff = None
 
         expected_provenance.update({
-            'action_checklist': impact_function.action_checklist(),
-            'analysis_extent': impact_function.analysis_extent.exportToWkt(),
-            'impact_function_name': impact_function.name,
-            'impact_function_title': impact_function.title,
-            'notes': impact_function.notes(),
-            'requested_extent': impact_function.requested_extent,
-            'data_store_uri': impact_function.datastore.uri_path,
-            'start_datetime': impact_function.start_datetime,
-            'end_datetime': impact_function.end_datetime,
-            'duration': impact_function.duration
+            provenance_action_checklist['provenance_key']:
+                impact_function.action_checklist(),
+            provenance_analysis_extent['provenance_key']:
+                impact_function.analysis_extent.exportToWkt(),
+            provenance_impact_function_name['provenance_key']:
+                impact_function.name,
+            provenance_impact_function_title['provenance_key']:
+                impact_function.title,
+            provenance_notes['provenance_key']: impact_function.notes(),
+            provenance_requested_extent['provenance_key']: impact_function.
+                requested_extent,
+            provenance_data_store_uri['provenance_key']: impact_function.
+                datastore.uri_path,
+            provenance_start_datetime['provenance_key']: impact_function.
+                start_datetime,
+            provenance_end_datetime['provenance_key']:
+                impact_function.end_datetime,
+            provenance_duration['provenance_key']: impact_function.duration
         })
 
-        self.assertDictEqual(expected_provenance, impact_function.provenance)
+        self.assertDictContainsSubset(
+            expected_provenance, impact_function.provenance)
+
+        output_layer_provenance_keys = [
+            provenance_layer_exposure_summary['provenance_key'],
+            provenance_layer_aggregate_hazard_impacted['provenance_key'],
+            provenance_layer_aggregation_summary['provenance_key'],
+            provenance_layer_analysis_impacted['provenance_key'],
+            provenance_layer_exposure_summary_table['provenance_key']
+        ]
+
+        for key in output_layer_provenance_keys:
+            self.assertIn(key, impact_function.provenance.keys())
 
         # Future reference: I comment out these lines since the keywords
         # properties are used in the report generation. Removing it will make
@@ -840,26 +906,33 @@ class TestImpactFunction(unittest.TestCase):
         hazard_category = definition(hazard_layer.keywords['hazard_category'])
 
         expected_provenance = {
-            'gdal_version': gdal.__version__,
-            'host_name': gethostname(),
-            'map_title': get_map_title(hazard, exposure, hazard_category),
-            'map_legend_title': exposure['layer_legend_title'],
-            'inasafe_version': get_version(),
-            'pyqt_version': PYQT_VERSION_STR,
-            'qgis_version': QGis.QGIS_VERSION,
-            'qt_version': QT_VERSION_STR,
-            'user': getpass.getuser(),
-            'os': readable_os_version(),
-            'aggregation_layer': None,
-            'aggregation_layer_id': None,
-            'exposure_layer': exposure_layer.source(),
-            'exposure_layer_id': exposure_layer.id(),
-            'hazard_layer': hazard_layer.source(),
-            'hazard_layer_id': hazard_layer.id(),
-            'analysis_question': get_analysis_question(hazard, exposure),
-            'aggregation_keywords': None,
-            'exposure_keywords': deepcopy(exposure_layer.keywords),
-            'hazard_keywords': deepcopy(hazard_layer.keywords),
+            provenance_gdal_version['provenance_key']: gdal.__version__,
+            provenance_host_name['provenance_key']: gethostname(),
+            provenance_map_title['provenance_key']: get_map_title(
+                hazard, exposure, hazard_category),
+            provenance_map_legend_title['provenance_key']: exposure[
+                'layer_legend_title'],
+            provenance_user['provenance_key']: getpass.getuser(),
+            provenance_os['provenance_key']: readable_os_version(),
+            provenance_pyqt_version['provenance_key']: PYQT_VERSION_STR,
+            provenance_qgis_version['provenance_key']: QGis.QGIS_VERSION,
+            provenance_qt_version['provenance_key']: QT_VERSION_STR,
+            provenance_inasafe_version['provenance_key']: get_version(),
+            provenance_aggregation_layer['provenance_key']: None,
+            provenance_aggregation_layer_id['provenance_key']: None,
+            provenance_exposure_layer['provenance_key']:
+                exposure_layer.source(),
+            provenance_exposure_layer_id['provenance_key']:
+                exposure_layer.id(),
+            provenance_hazard_layer['provenance_key']: hazard_layer.source(),
+            provenance_hazard_layer_id['provenance_key']: hazard_layer.id(),
+            provenance_analysis_question['provenance_key']:
+                get_analysis_question(hazard, exposure),
+            provenance_aggregation_keywords['provenance_key']: None,
+            provenance_exposure_keywords['provenance_key']:
+                deepcopy(exposure_layer.keywords),
+            provenance_hazard_keywords['provenance_key']: deepcopy(
+                hazard_layer.keywords),
         }
 
         # Set up impact function
@@ -874,19 +947,39 @@ class TestImpactFunction(unittest.TestCase):
         self.maxDiff = None
 
         expected_provenance.update({
-            'action_checklist': impact_function.action_checklist(),
-            'analysis_extent': impact_function.analysis_extent.exportToWkt(),
-            'impact_function_name': impact_function.name,
-            'impact_function_title': impact_function.title,
-            'notes': impact_function.notes(),
-            'requested_extent': impact_function.requested_extent,
-            'data_store_uri': impact_function.datastore.uri_path,
-            'start_datetime': impact_function.start_datetime,
-            'end_datetime': impact_function.end_datetime,
-            'duration': impact_function.duration
+            provenance_action_checklist['provenance_key']:
+                impact_function.action_checklist(),
+            provenance_analysis_extent['provenance_key']:
+                impact_function.analysis_extent.exportToWkt(),
+            provenance_impact_function_name['provenance_key']:
+                impact_function.name,
+            provenance_impact_function_title['provenance_key']:
+                impact_function.title,
+            provenance_notes['provenance_key']: impact_function.notes(),
+            provenance_requested_extent['provenance_key']: impact_function.
+                requested_extent,
+            provenance_data_store_uri['provenance_key']: impact_function.
+                datastore.uri_path,
+            provenance_start_datetime['provenance_key']: impact_function.
+                start_datetime,
+            provenance_end_datetime['provenance_key']:
+                impact_function.end_datetime,
+            provenance_duration['provenance_key']: impact_function.duration
         })
 
-        self.assertDictEqual(expected_provenance, impact_function.provenance)
+        self.assertDictContainsSubset(
+            expected_provenance, impact_function.provenance)
+
+        output_layer_provenance_keys = [
+            provenance_layer_exposure_summary['provenance_key'],
+            provenance_layer_aggregate_hazard_impacted['provenance_key'],
+            provenance_layer_aggregation_summary['provenance_key'],
+            provenance_layer_analysis_impacted['provenance_key'],
+            provenance_layer_exposure_summary_table['provenance_key']
+        ]
+
+        for key in output_layer_provenance_keys:
+            self.assertIn(key, impact_function.provenance.keys())
 
     def test_vector_post_minimum_needs_value_generation(self):
         """Test minimum needs postprocessors on vector exposure.

--- a/safe/utilities/keyword_io.py
+++ b/safe/utilities/keyword_io.py
@@ -126,7 +126,7 @@ class KeywordIO(QObject):
         :type show_header: bool
 
         :returns: A safe message object containing a table.
-        :rtype: safe.messaging.message
+        :rtype: safe.messaging.Message
         """
         if keywords is None and self.layer is not None:
             keywords = self.read_keywords(self.layer)


### PR DESCRIPTION
### What does it fix?
* Ticket: #4303 
* Funded by: DFAT
* Description: 
   - Adding output layer URI in the output layer metadata (e.g. aggregate_hazard_impacted in the image below)
<img width="1433" alt="screen shot 2017-07-26 at 22 35 12" src="https://user-images.githubusercontent.com/1421861/28629838-bc8ec0dc-7252-11e7-9627-d0f09dd4ef85.png">

