### PR TITLE
Do not report exposure type

### DIFF
--- a/safe/definitions/exposure_classifications.py
+++ b/safe/definitions/exposure_classifications.py
@@ -671,6 +671,20 @@ generic_landcover_classes = {
                     'link': None
                 }
             ]
+        },
+        {
+            'key': 'do_not_report',
+            'name': tr('Do Not Report'),
+            'description': tr(
+                'Land use types that will be excluded in the analysis.'),
+            'osm_downloader': [],
+            'string_defaults': [],
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
         }
     ]
 }

--- a/safe/definitions/exposure_classifications.py
+++ b/safe/definitions/exposure_classifications.py
@@ -3,6 +3,7 @@
 """Definitions relating to exposure classifications."""
 
 from safe.utilities.i18n import tr
+from safe.definitions.constants import DO_NOT_REPORT
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -28,6 +29,21 @@ exposure_classification_type = tr('Exposure Classification'),
 # The osm_downloader is not used in InaSAFE itself. It is used in OSM-Reporter
 # to generate the value_mapping. Please do not remove it.
 # See https://github.com/kartoza/osm-reporter/wiki how to use this key.
+
+do_not_report_class = {
+    'key': DO_NOT_REPORT,
+    'name': tr('Do Not Report'),
+    'description': tr(
+        'Land use types that will be excluded in the analysis.'),
+    'osm_downloader': [],
+    'string_defaults': [],
+    'citations': [
+        {
+            'text': None,
+            'link': None
+        }
+    ]
+}
 
 generic_structure_classes = {
     'key': 'generic_structure_classes',
@@ -658,6 +674,8 @@ generic_landcover_classes = {
                 }
             ]
         },
+        do_not_report_class,
+        # Need to put other class in the end
         {
             'key': 'other',
             'name': tr('Other'),
@@ -665,20 +683,6 @@ generic_landcover_classes = {
                 'Any other land use type.'),
             'osm_downloader': [],
             'string_defaults': ['other'],
-            'citations': [
-                {
-                    'text': None,
-                    'link': None
-                }
-            ]
-        },
-        {
-            'key': 'do_not_report',
-            'name': tr('Do Not Report'),
-            'description': tr(
-                'Land use types that will be excluded in the analysis.'),
-            'osm_downloader': [],
-            'string_defaults': [],
             'citations': [
                 {
                     'text': None,
@@ -781,6 +785,8 @@ badan_geologi_landcover_classes = {
                 }
             ]
         },
+        do_not_report_class,
+        # Need to put other class in the end
         {
             'key': 'other',
             'name': tr('Other'),
@@ -788,20 +794,6 @@ badan_geologi_landcover_classes = {
                 'Any other land use type.'),
             'osm_downloader': [],
             'string_defaults': ['other'],
-            'citations': [
-                {
-                    'text': None,
-                    'link': None
-                }
-            ]
-        },
-        {
-            'key': 'do_not_report',
-            'name': tr('Do Not Report'),
-            'description': tr(
-                'Land use types that will be excluded in the analysis.'),
-            'osm_downloader': [],
-            'string_defaults': [],
             'citations': [
                 {
                     'text': None,

--- a/safe/definitions/exposure_classifications.py
+++ b/safe/definitions/exposure_classifications.py
@@ -794,6 +794,20 @@ badan_geologi_landcover_classes = {
                     'link': None
                 }
             ]
+        },
+        {
+            'key': 'do_not_report',
+            'name': tr('Do Not Report'),
+            'description': tr(
+                'Land use types that will be excluded in the analysis.'),
+            'osm_downloader': [],
+            'string_defaults': [],
+            'citations': [
+                {
+                    'text': None,
+                    'link': None
+                }
+            ]
         }
     ]
 }

--- a/safe/gis/vector/prepare_vector_layer.py
+++ b/safe/gis/vector/prepare_vector_layer.py
@@ -24,6 +24,7 @@ from safe.gis.vector.tools import (
 )
 from safe.gis.sanity_check import check_layer
 from safe.definitions.processing_steps import prepare_vector_steps
+from safe.definitions.constants import DO_NOT_REPORT
 from safe.definitions.fields import (
     exposure_id_field,
     hazard_id_field,
@@ -360,11 +361,11 @@ def _remove_features(layer):
 
             # If there is exposure that mapped to do not report class
             if layer_purpose == layer_purpose_exposure['key']:
-                is_do_not_report = layer.keywords.get('value_map', {}).get(
-                    'do_not_report')
+                is_do_not_report = layer.keywords.get(
+                    'value_map', {}).get(DO_NOT_REPORT)
                 if is_do_not_report:
                     if feature[field_name] in layer.keywords['value_map'][
-                            'do_not_report']:
+                            DO_NOT_REPORT]:
                         layer.deleteFeature(feature.id())
                         i += 1
 

--- a/safe/gis/vector/prepare_vector_layer.py
+++ b/safe/gis/vector/prepare_vector_layer.py
@@ -360,11 +360,11 @@ def _remove_features(layer):
 
             # If there is exposure that mapped to do not report class
             if layer_purpose == layer_purpose_exposure['key']:
-                is_do_not_report = layer.keywords['value_map'].get(
+                is_do_not_report = layer.keywords.get('value_map', {}).get(
                     'do_not_report')
                 if is_do_not_report:
                     if feature[field_name] in layer.keywords['value_map'][
-                        'do_not_report']:
+                            'do_not_report']:
                         layer.deleteFeature(feature.id())
                         i += 1
 

--- a/safe/gis/vector/test/test_prepare_vector_layer.py
+++ b/safe/gis/vector/test/test_prepare_vector_layer.py
@@ -74,9 +74,14 @@ class TestPrepareLayer(unittest.TestCase):
         'GDAL 2.1 is required to edit GeoJSON.')
     def test_remove_rows(self):
         """Test we can remove rows."""
-
         layer = load_test_vector_layer(
             'gisv4', 'hazard', 'classified_vector.geojson', clone=True)
+        feature_count = layer.featureCount()
+        _remove_features(layer)
+        self.assertEqual(layer.featureCount(), feature_count - 1)
+
+        layer = load_test_vector_layer(
+            'exposure', 'landcover.geojson', clone=True)
         feature_count = layer.featureCount()
         _remove_features(layer)
         self.assertEqual(layer.featureCount(), feature_count - 1)
@@ -201,6 +206,7 @@ class TestPrepareLayer(unittest.TestCase):
         self.assertNotEqual(unique_values_automatic, unique_values_before)
         self.assertEqual(unique_values_automatic, range(layer.featureCount()))
 
+    # noinspection PyPep8Naming
     def test_sum_fields(self):
         """Test sum_fields method."""
         layer = load_test_vector_layer(

--- a/safe/test/data/exposure/landcover.xml
+++ b/safe/test/data/exposure/landcover.xml
@@ -175,54 +175,42 @@
           <classification>
             <gco:CharacterString>generic_landcover_classes</gco:CharacterString>
           </classification>
-          <inasafe_fields>
-            <gco:Dictionary>{&quot;productivity_cost_rate_field&quot;: &quot;productivity_cost_rate&quot;, &quot;exposure_id_field&quot;: &quot;id&quot;, &quot;productivity_rate_field&quot;: &quot;productivity_rate&quot;, &quot;exposure_type_field&quot;: &quot;FCODE&quot;, &quot;productivity_value_rate_field&quot;: &quot;productivity_value_rate&quot;}</gco:Dictionary>
-          </inasafe_fields>
-          <inasafe_default_values>
-            <gco:Dictionary/>
-          </inasafe_default_values>
           <scale>
             <gco:CharacterString/>
           </scale>
-          <multipart_polygon>
-            <gco:Boolean/>
-          </multipart_polygon>
-          <source>
-            <gco:CharacterString>My data</gco:CharacterString>
-          </source>
-          <value_map>
-            <gco:Dictionary>{&quot;farm&quot;: [&quot;Meadow&quot;], &quot;residential&quot;: [&quot;Population&quot;], &quot;wood&quot;: [&quot;Forest&quot;, &quot;Water&quot;]}</gco:Dictionary>
-          </value_map>
-          <layer_geometry>
-            <gco:CharacterString>polygon</gco:CharacterString>
-          </layer_geometry>
-          <exposure>
-            <gco:CharacterString>land_cover</gco:CharacterString>
-          </exposure>
-          <report>
-            <gco:CharacterString/>
-          </report>
           <exposure_unit>
             <gco:CharacterString/>
           </exposure_unit>
           <keyword_version>
             <gco:CharacterString>4.1</gco:CharacterString>
           </keyword_version>
-          <datatype>
-            <gco:CharacterString/>
-          </datatype>
-          <allow_resampling>
-            <gco:CharacterString/>
-          </allow_resampling>
+          <source>
+            <gco:CharacterString>My data</gco:CharacterString>
+          </source>
+          <value_map>
+            <gco:Dictionary>{&quot;farm&quot;: [&quot;Meadow&quot;], &quot;wood&quot;: [&quot;Forest&quot;, &quot;Water&quot;], &quot;do_not_report&quot;: [&quot;Population&quot;]}</gco:Dictionary>
+          </value_map>
+          <inasafe_fields>
+            <gco:Dictionary>{&quot;productivity_cost_rate_field&quot;: &quot;productivity_cost_rate&quot;, &quot;exposure_id_field&quot;: &quot;id&quot;, &quot;productivity_rate_field&quot;: &quot;productivity_rate&quot;, &quot;exposure_type_field&quot;: &quot;FCODE&quot;, &quot;productivity_value_rate_field&quot;: &quot;productivity_value_rate&quot;}</gco:Dictionary>
+          </inasafe_fields>
+          <layer_geometry>
+            <gco:CharacterString>polygon</gco:CharacterString>
+          </layer_geometry>
           <layer_purpose>
             <gco:CharacterString>exposure</gco:CharacterString>
           </layer_purpose>
-          <resolution>
-            <gco:FloatTuple/>
-          </resolution>
+          <inasafe_default_values>
+            <gco:Dictionary/>
+          </inasafe_default_values>
+          <active_band>
+            <gco:Integer/>
+          </active_band>
           <layer_mode>
             <gco:CharacterString>classified</gco:CharacterString>
           </layer_mode>
+          <exposure>
+            <gco:CharacterString>land_cover</gco:CharacterString>
+          </exposure>
         </inasafe>
       </gmd:supplementalInformation>
     </gmd:MD_DataIdentification>

--- a/safe/utilities/keyword_io.py
+++ b/safe/utilities/keyword_io.py
@@ -466,7 +466,7 @@ class KeywordIO(QObject):
             if definition(key):
                 name = definition(key)['name']
             else:
-                name = tr(key.capitalize())
+                name = tr(key.capitalize().replace('_', ' '))
             row.add(m.Cell(m.ImportantText(name)))
             # Then the value. If it contains more than one element we
             # present it as a bullet list, otherwise just as simple text


### PR DESCRIPTION
### What does it fix?
* Ticket: #3626 
* Funded by: DFAT
* Description: 
  - Add new class for `Do Not Report` that won't be included in the calculation. You can assign it on keyword wizard.

<img width="1427" alt="screen shot 2017-07-27 at 11 53 56" src="https://user-images.githubusercontent.com/1421861/28654935-521464c6-72c2-11e7-818e-37135143aa17.png">

<img width="419" alt="screen shot 2017-07-27 at 10 25 50" src="https://user-images.githubusercontent.com/1421861/28653214-8c7f4dd0-72b6-11e7-911a-8380cb8def22.png">
<img width="422" alt="screen shot 2017-07-27 at 10 26 02" src="https://user-images.githubusercontent.com/1421861/28653215-8cc7e2de-72b6-11e7-910b-ae27b5c12a43.png">

The number above is not added up because of the rounding.

cc @fredychandra 