### PR TITLE
Add safe/version.txt

### DIFF
--- a/safe/common/version.py
+++ b/safe/common/version.py
@@ -37,16 +37,16 @@ def current_git_hash():
 
 
 def release_status():
-    """Returns the release status from plugin metadata file.
+    """Returns the release status from safe/version.txt file.
 
     :returns: The status of release - it could be alpha, beta, rc, or final.
     :rtype: basestring
     """
     status = ''
     # Get location of application wide version info
-    root_dir = os.path.abspath(os.path.join(
-        os.path.dirname(__file__), '..', '..'))
-    fid = open(os.path.join(root_dir, 'metadata.txt'))
+    safe_root_dir = os.path.abspath(os.path.join(
+        os.path.dirname(__file__), '..'))
+    fid = open(os.path.join(safe_root_dir, 'version.txt'))
     for line in fid.readlines():
         if line.startswith('status'):
             status = line.strip().split('=')[1]
@@ -67,9 +67,9 @@ def get_version(version=None):
     """
     if version is None:
         # Get location of application wide version info
-        root_dir = os.path.abspath(os.path.join(
-            os.path.dirname(__file__), '..', '..'))
-        fid = open(os.path.join(root_dir, 'metadata.txt'))
+        safe_root_dir = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), '..'))
+        fid = open(os.path.join(safe_root_dir, 'version.txt'))
         version_list = []
         status = ''
         for line in fid.readlines():

--- a/safe/version.txt
+++ b/safe/version.txt
@@ -15,7 +15,6 @@ qgisMaximumVersion=2.18.99
 description=InaSAFE is free software that allows disaster managers to study realistic natural hazard impact scenarios for better planning, preparedness and response activities.
 about=Developed for the Indonesian Government - BNPB, Australian Government - AIFDR and DMInnovation and, and World Bank - GFDRR
 
-# If you change version and status here, please also change in safe/version.txt
 version=4.2.0
 # alpha, beta, rc or final
 status=beta


### PR DESCRIPTION
As per discussion with @timlinux 

SAFE package needs to know version number (e.g to write provenance in metadata), but the metadata.txt is out of the safe package. The simplest solution is to mirror this metadata.txt file (which is needed in the root for QGIS dir) into safe/version.txt.

### What does it fix?
* Ticket: -
* Funded by: WB
* Description: Adding safe/version.txt file.
