### PR TITLE
add help from docstrings for expressions

### DIFF
--- a/safe/gis/expressions.py
+++ b/safe/gis/expressions.py
@@ -8,13 +8,17 @@ from qgis.core import (
 import datetime
 
 from safe.definitions.provenance import provenance_layer_analysis_impacted_id
-from safe.definitions.reports.infographic import no_data_replacement
 from safe.utilities.rounding import denomination, round_affected_number
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
 __email__ = "info@inasafe.org"
 __revision__ = '$Format:%H$'
+
+##
+# Docstrings for these expressions are used in the QGIS GUI in the Expression
+# dialog and also in the InaSAFE Help dialog.
+##
 
 
 @qgsfunction(

--- a/safe/plugin.py
+++ b/safe/plugin.py
@@ -4,7 +4,7 @@
 import sys
 import os
 import logging
-from inspect import getmembers, isfunction
+from inspect import getmembers
 
 # noinspection PyUnresolvedReferences
 import qgis  # pylint: disable=unused-import
@@ -630,13 +630,14 @@ class Plugin(object):
         self.iface.currentLayerChanged.disconnect(self.layer_changed)
 
         # Unload QGIS expressions loaded by the plugin.
-        qgis_expressions = [
-            fct[0] for fct in getmembers(expressions) if isfunction(fct[1])]
-        qgis_expressions += [
-            fct[0] for fct in getmembers(infographic) if isfunction(fct[1])]
-        for qgis_expression in qgis_expressions:
-            if qgis_expression != 'qgsfunction':
-                QgsExpression.unregisterFunction(qgis_expression)
+        qgis_expressions = {
+            fct[0]: fct[1] for fct in getmembers(expressions)
+            if fct[1].__class__.__name__ == 'QgsExpressionFunction'}
+        qgis_expressions.update({
+            fct[0]: fct[1] for fct in getmembers(infographic)
+            if fct[1].__class__.__name__ == 'QgsExpressionFunction'})
+        for qgis_expression in qgis_expressions.keys():
+            QgsExpression.unregisterFunction(qgis_expression)
 
     def toggle_inasafe_action(self, checked):
         """Check or un-check the toggle inaSAFE toolbar button.

--- a/safe/report/expressions/infographic.py
+++ b/safe/report/expressions/infographic.py
@@ -28,13 +28,16 @@ __revision__ = '$Format:%H$'
 
 group = tr('InaSAFE - Infographic Elements')
 
+##
+# Docstrings for these expressions are used in the QGIS GUI in the Expression
+# dialog and also in the InaSAFE Help dialog.
+##
+
 
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def inasafe_logo_white_path(feature, parent):
-    """Retrieve the full path of inasafe-logo-white.svg
-
-    """
+    """Retrieve the full path of inasafe-logo-white.svg."""
     _ = feature, parent  # NOQA
     return inasafe_logo_white['path']
 
@@ -42,9 +45,7 @@ def inasafe_logo_white_path(feature, parent):
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def inasafe_field_header(field, feature, parent):
-    """Retrieve a header name of the field name from definitions.
-
-    """
+    """Retrieve a header name of the field name from definitions."""
     _ = feature, parent  # NOQA
     age_fields = [under_5_displaced_count_field, over_60_displaced_count_field]
     symbol_mapping = {
@@ -78,9 +79,7 @@ def inasafe_field_header(field, feature, parent):
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def minimum_needs_unit(field, feature, parent):
-    """Retrieve units of the given minimum needs field name.
-
-    """
+    """Retrieve units of the given minimum needs field name."""
     _ = feature, parent  # NOQA
     field_definition = definition(field, 'field_name')
     if field_definition:
@@ -120,7 +119,6 @@ def minimum_needs_unit(field, feature, parent):
 def infographic_header_element(impact_function_name, feature, parent):
     """Given an impact function name, it will format it to an
     infographic header sentence.
-
     """
     _ = feature, parent  # NOQA
     string_format = infographic_header['string_format']
@@ -134,9 +132,7 @@ def infographic_header_element(impact_function_name, feature, parent):
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def map_overview_header_element(feature, parent):
-    """Retrieve map overview header string from definitions.
-
-    """
+    """Retrieve map overview header string from definitions."""
     _ = feature, parent  # NOQA
     header = map_overview_header['string_format']
     return header.capitalize()
@@ -145,9 +141,7 @@ def map_overview_header_element(feature, parent):
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def population_chart_header_element(feature, parent):
-    """Retrieve population chart header string from definitions.
-
-    """
+    """Retrieve population chart header string from definitions."""
     _ = feature, parent  # NOQA
     header = population_chart_header['string_format']
     return header.capitalize()
@@ -156,9 +150,7 @@ def population_chart_header_element(feature, parent):
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def people_section_header_element(feature, parent):
-    """Retrieve people section header string from definitions.
-
-    """
+    """Retrieve people section header string from definitions."""
     _ = feature, parent  # NOQA
     header = people_section_header['string_format']
     return header.capitalize()
@@ -167,9 +159,7 @@ def people_section_header_element(feature, parent):
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def age_gender_section_header_element(feature, parent):
-    """Retrieve age gender section header string from definitions.
-
-    """
+    """Retrieve age gender section header string from definitions."""
     _ = feature, parent  # NOQA
     header = age_gender_section_header['string_format']
     return header.capitalize()
@@ -178,9 +168,7 @@ def age_gender_section_header_element(feature, parent):
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def age_gender_section_notes_element(feature, parent):
-    """Retrieve age gender section notes string from definitions.
-
-    """
+    """Retrieve age gender section notes string from definitions."""
     _ = feature, parent  # NOQA
     notes = age_gender_section_notes['string_format']
     return notes.capitalize()
@@ -189,9 +177,7 @@ def age_gender_section_notes_element(feature, parent):
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def vulnerability_section_header_element(feature, parent):
-    """Retrieve vulnerability section header string from definitions.
-
-    """
+    """Retrieve vulnerability section header string from definitions."""
     _ = feature, parent  # NOQA
     header = vulnerability_section_header['string_format']
     return header.capitalize()
@@ -200,9 +186,7 @@ def vulnerability_section_header_element(feature, parent):
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def female_vulnerability_section_header_element(feature, parent):
-    """Retrieve female vulnerability section header string from definitions.
-
-    """
+    """Retrieve female vulnerability section header string from definitions."""
     _ = feature, parent  # NOQA
     header = female_vulnerability_section_header['string_format']
     return header.capitalize()
@@ -211,9 +195,7 @@ def female_vulnerability_section_header_element(feature, parent):
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def minimum_needs_section_header_element(feature, parent):
-    """Retrieve minimum needs section header string from definitions.
-
-    """
+    """Retrieve minimum needs section header string from definitions."""
     _ = feature, parent  # NOQA
     header = minimum_needs_section_header['string_format']
     return header.capitalize()
@@ -224,7 +206,6 @@ def minimum_needs_section_header_element(feature, parent):
 def additional_minimum_needs_section_header_element(feature, parent):
     """Retrieve additional minimum needs section header string
     from definitions.
-
     """
     _ = feature, parent  # NOQA
     header = additional_minimum_needs_section_header['string_format']
@@ -234,9 +215,7 @@ def additional_minimum_needs_section_header_element(feature, parent):
 @qgsfunction(
     args='auto', group=group, usesGeometry=False, referencedColumns=[])
 def minimum_needs_section_notes_element(feature, parent):
-    """Retrieve minimum needs section notes string from definitions.
-
-    """
+    """Retrieve minimum needs section notes string from definitions."""
     _ = feature, parent  # NOQA
     notes = minimum_needs_section_notes['string_format']
     return notes.capitalize()


### PR DESCRIPTION
### What does it fix?
* Ticket: #4252 
* Funded by: DFAT
* Description: This PR brings expressions docstrings into the InaSAFE help dialog.

One limitation, on this, we can't have translations. I'm looking for a patch in QGIS 3 where we can provide our custom translated strings.

<img width="1186" alt="screen shot 2017-08-22 at 18 28 53" src="https://user-images.githubusercontent.com/1609292/29576629-d3b32bd8-8768-11e7-803b-b646f06ce545.png">

@timlinux I think we should add a 15.2 for `Element-ID` from https://github.com/inasafe/inasafe/wiki/Map-Composer-Templating, there is no help for these, except on line in this wiki. `Element Tokens` will be removed according to #4252 @myarjunar?