### PR TITLE
Fix bug step fc function

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -18,7 +18,7 @@ about=Developed for the Indonesian Government - BNPB, Australian Government - AI
 # If you change version and status here, please also change in safe/definitions/versions.py
 version=4.3.0
 # alpha, beta, rc or final
-status=final
+status=alpha
 
 
 # end of mandatory metadata

--- a/safe/definitions/versions.py
+++ b/safe/definitions/versions.py
@@ -10,7 +10,7 @@ __revision__ = '$Format:%H$'
 # InaSAFE version (please synchronize with metadata.txt)
 inasafe_version = '4.3.0'
 # alpha, beta, rc or final
-inasafe_release_status = 'final'
+inasafe_release_status = 'alpha'
 
 # InaSAFE Keyword Version compatibility.
 inasafe_keyword_version = '4.3'

--- a/safe/gui/tools/wizard/step_kw65_summary.py
+++ b/safe/gui/tools/wizard/step_kw65_summary.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 """InaSAFE Wizard Step Keyword Summary."""
 
-import os
 import re
 
 from safe import messaging as m
@@ -14,6 +13,7 @@ from safe.definitions.versions import inasafe_keyword_version
 from safe.gui.tools.wizard.wizard_step import WizardStep
 from safe.gui.tools.wizard.wizard_step import get_wizard_step_ui_class
 from safe.utilities.resources import resources_path
+from safe.gui.tools.wizard.utilities import layers_intersect
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -55,12 +55,21 @@ class StepKwSummary(WizardStep, FORM_CLASS):
                 elif parent_step in [self.parent.step_fc_explayer_from_canvas,
                                      self.parent.
                                      step_fc_explayer_from_browser]:
-                    new_step = self.parent.step_fc_disjoint_layers
+                    if layers_intersect(
+                            self.parent.hazard_layer,
+                            self.parent.exposure_layer):
+                        new_step = self.parent.step_fc_agglayer_origin
+                    else:
+                        new_step = self.parent.step_fc_disjoint_layers
 
                 elif parent_step in [self.parent.step_fc_agglayer_from_canvas,
                                      self.parent.
                                      step_fc_agglayer_from_browser]:
-                    new_step = self.parent.step_fc_agglayer_disjoint
+                    if layers_intersect(self.parent.exposure_layer,
+                                        self.parent.aggregation_layer):
+                        new_step = self.parent.step_fc_summary
+                    else:
+                        new_step = self.parent.step_fc_agglayer_disjoint
                 else:
                     raise Exception('No such step')
             else:

--- a/safe/gui/tools/wizard/step_kw65_summary.py
+++ b/safe/gui/tools/wizard/step_kw65_summary.py
@@ -121,7 +121,6 @@ class StepKwSummary(WizardStep, FORM_CLASS):
         if self.parent.parent_step:
             # It's the KW mode embedded in IFCW mode,
             # so check if the layer is compatible
-            im_func = self.parent.step_fc_function.selected_function()
             if not self.parent.is_layer_compatible(
                     self.parent.layer, None, current_keywords):
                 msg = self.tr(

--- a/safe/gui/tools/wizard/wizard_dialog.py
+++ b/safe/gui/tools/wizard/wizard_dialog.py
@@ -254,8 +254,8 @@ class WizardDialog(QDialog, FORM_CLASS):
                 layer_name=self.layer.name())
         else:
             mode_name = tr(
-                'Keywords creation wizard for layer <b>%s</b>').format(
-                layer_name=self.layer.name())
+                'Keywords creation wizard for layer <b>{layer_name}</b>'
+            ).format(layer_name=self.layer.name())
         self.lblSubtitle.setText(mode_name)
 
     def set_mode_label_to_ifcw(self):


### PR DESCRIPTION
### What does it fix?
* Ticket: No Ticket
* Funded by: WB
* Description: 
Fixing this bug:
```
AttributeError: 'WizardDialog' object has no attribute 'step_fc_function'
Traceback (most recent call last):
  File "C:/Users/aless/.qgis2/python/plugins\inasafe\safe\gui\tools\wizard\wizard_dialog.py", line 678, in on_pbnNext_released
    new_step.set_widgets()
  File "C:/Users/aless/.qgis2/python/plugins\inasafe\safe\gui\tools\wizard\step_kw65_summary.py", line 130, in set_widgets
    im_func = self.parent.step_fc_function.selected_function()
AttributeError: 'WizardDialog' object has no attribute 'step_fc_function'
```

To replicate, assign keyword in a layer when working on IFCW.

The fix is just merely removing old code that's not longer relevant. Previously we need to set the IF that we want to use, but now, all IF is possible (no need to choose IF anymore).


### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR
