### PR TITLE
enable different projections in the zonal stats algorithm

### DIFF
--- a/safe/gis/raster/test/test_zonal_statistics.py
+++ b/safe/gis/raster/test/test_zonal_statistics.py
@@ -8,7 +8,8 @@ from safe.test.utilities import (
 )
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 
-from qgis.core import QGis
+from qgis.core import QGis, QgsCoordinateReferenceSystem
+from safe.gis.vector.reproject import reproject
 from safe.gis.raster.zonal_statistics import zonal_stats
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
@@ -27,6 +28,7 @@ class TestReclassifyRaster(unittest.TestCase):
 
     def test_zonal_statistics_raster(self):
         """Test we can do zonal statistics."""
+        # Same projection
         raster = load_test_raster_layer(
             'exposure', 'pop_binary_raster_20_20.asc')
         raster.keywords['inasafe_default_values'] = {}
@@ -41,3 +43,25 @@ class TestReclassifyRaster(unittest.TestCase):
 
         self.assertEqual(vector.fields().count(), number_fields + 1)
         self.assertEqual(vector.geometryType(), QGis.Polygon)
+
+        # With different projections
+        raster = load_test_raster_layer(
+            'exposure', 'pop_binary_raster_20_20.asc')
+        raster.keywords['inasafe_default_values'] = {}
+        vector_b = load_test_vector_layer(
+            'aggregation', 'grid_jakarta_4326.geojson')
+
+        vector_b.keywords['hazard_keywords'] = {}
+        vector_b.keywords['aggregation_keywords'] = {}
+
+        number_fields = vector_b.fields().count()
+        vector_b = reproject(vector, QgsCoordinateReferenceSystem(3857))
+        vector_b = zonal_stats(raster, vector_b)
+
+        self.assertEqual(vector_b.fields().count(), number_fields + 1)
+        self.assertEqual(vector_b.geometryType(), QGis.Polygon)
+
+        # We compare the results between these 2 zonal stats.
+        for feature_a, feature_b in zip(
+                vector.getFeatures(), vector_b.getFeatures()):
+            self.assertEqual(feature_a.attributes(), feature_b.attributes())

--- a/safe/gis/raster/zonal_statistics.py
+++ b/safe/gis/raster/zonal_statistics.py
@@ -7,8 +7,10 @@ from qgis.analysis import QgsZonalStatistics
 from qgis.core import QgsFeatureRequest
 
 from safe.gis.sanity_check import check_layer
-from safe.gis.vector.tools import copy_layer, create_memory_layer
+from safe.gis.vector.tools import (
+    copy_layer, create_memory_layer, create_field_from_definition)
 from safe.gis.vector.prepare_vector_layer import copy_fields, remove_fields
+from safe.gis.vector.reproject import reproject
 from safe.definitions.fields import exposure_count_field, total_field
 from safe.definitions.processing_steps import zonal_stats_steps
 from safe.definitions.layer_purposes import (
@@ -30,6 +32,10 @@ def zonal_stats(raster, vector, callback=None):
 
     Issue https://github.com/inasafe/inasafe/issues/3190
 
+    The algorithm will take care about projections.
+    We don't want to reproject the raster layer.
+    So if CRS are different, we reproject the vector layer and then we do a
+    lookup from the reprojected layer to the original vector layer.
 
     :param raster: The raster layer.
     :type raster: QgsRasterLayer
@@ -50,14 +56,26 @@ def zonal_stats(raster, vector, callback=None):
     output_layer_name = zonal_stats_steps['output_layer_name']
     processing_step = zonal_stats_steps['step_name']
 
-    layer = create_memory_layer(
-        output_layer_name,
-        vector.geometryType(),
-        vector.crs(),
-        vector.fields()
-    )
+    exposure = raster.keywords['exposure']
+    if raster.crs().authid() != vector.crs().authid():
+        layer = reproject(vector, raster.crs())
 
-    copy_layer(vector, layer)
+        # We prepare the copy
+        output_layer = create_memory_layer(
+            output_layer_name,
+            vector.geometryType(),
+            vector.crs(),
+            vector.fields()
+        )
+        copy_layer(vector, output_layer)
+    else:
+        layer = create_memory_layer(
+            output_layer_name,
+            vector.geometryType(),
+            vector.crs(),
+            vector.fields()
+        )
+        copy_layer(vector, layer)
 
     input_band = layer.keywords.get('active_band', 1)
     analysis = QgsZonalStatistics(
@@ -69,16 +87,28 @@ def zonal_stats(raster, vector, callback=None):
     result = analysis.calculateStatistics(None)
     LOGGER.debug(tr('Zonal stats on %s : %s' % (raster.source(), result)))
 
-    layer.startEditing()
-    exposure = raster.keywords['exposure']
     output_field = exposure_count_field['field_name'] % exposure
-    fields_to_rename = {
-        'exposure_sum': output_field
-    }
-    copy_fields(layer, fields_to_rename)
-    remove_fields(layer, fields_to_rename.keys())
+    if raster.crs().authid() != vector.crs().authid():
+        output_layer.startEditing()
+        field = create_field_from_definition(
+            exposure_count_field, exposure)
 
-    layer.commitChanges()
+        output_layer.addAttribute(field)
+        new_index = output_layer.fieldNameIndex(field.name())
+        old_index = layer.fieldNameIndex('exposure_sum')
+        for feature_input, feature_output in zip(
+                layer.getFeatures(), output_layer.getFeatures()):
+            output_layer.changeAttributeValue(
+                feature_input.id(), new_index, feature_input[old_index])
+        output_layer.commitChanges()
+        layer = output_layer
+    else:
+        fields_to_rename = {
+            'exposure_sum': output_field
+        }
+        copy_fields(layer, fields_to_rename)
+        remove_fields(layer, fields_to_rename.keys())
+        layer.commitChanges()
 
     # The zonal stats is producing some None values. We need to fill these
     # with 0. See issue : #3778


### PR DESCRIPTION
### What does it fix?
* Ticket: #4437
* Funded by: DFAT
* Description: This will allow us to use a different projection in the zonal stats alg, without reprojecting the raster layer.

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
