### PR TITLE
display warning about conflicting plugin

### DIFF
--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -97,6 +97,8 @@ from safe.gui.widgets.message import (
     show_no_keywords_message,
     show_keyword_version_message,
     getting_started_message,
+    conflicting_plugin_message,
+    conflicting_plugin_string,
     no_overlap_message,
     ready_message,
     enable_messaging)
@@ -108,6 +110,7 @@ from safe.gui.analysis_utilities import (
     generate_infographic_report,
     add_layer_to_canvas,
     remove_layer_from_canvas)
+from safe.utilities.utilities import is_plugin_installed
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -148,6 +151,11 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             http://doc.qt.nokia.com/4.7-snapshot/designer-using-a-ui-file.html
         """
         QtGui.QDockWidget.__init__(self, None)
+
+        # Dirty hack to display a warning about this plugin.
+        self.conflicting_plugin_detected = is_plugin_installed(
+            'EmergencyMapper')
+
         self.setupUi(self)
         self.show_question_button.setVisible(False)
         self.progress_bar.hide()
@@ -621,7 +629,10 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
 
         # For issue #618
         if len(layers) == 0:
-            send_static_message(self, getting_started_message())
+            if self.conflicting_plugin_detected:
+                send_static_message(self, conflicting_plugin_message())
+            else:
+                send_static_message(self, getting_started_message())
             return
 
         self.get_layers_lock = True
@@ -841,7 +852,10 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
 
         # Do nothing if there is no active layer - see #1861
         if not self._has_active_layer():
-            send_static_message(self, getting_started_message())
+            if self.conflicting_plugin_detected:
+                send_static_message(self, conflicting_plugin_message())
+            else:
+                send_static_message(self, getting_started_message())
 
         # Now try to read the keywords and show them in the dock
         try:
@@ -905,7 +919,10 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             # Added this check in 3.2 for #1861
             active_layer = self.iface.activeLayer()
             if active_layer is None:
-                send_static_message(self, getting_started_message())
+                if self.conflicting_plugin_detected:
+                    send_static_message(self, conflicting_plugin_message())
+                else:
+                    send_static_message(self, getting_started_message())
             else:
                 show_no_keywords_message(self)
                 self.print_button.setEnabled(False)
@@ -1131,6 +1148,10 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         Please update the code in step_fc990_analysis.py in function
         setup_and_run_analysis(). It should follow approximately the same code.
         """
+        if self.conflicting_plugin_detected:
+            display_critical_message_bar(
+                tr('Conflicting plugin'), conflicting_plugin_string())
+
         # Start the analysis
         self.impact_function = self.validate_impact_function()
         if not isinstance(self.impact_function, ImpactFunction):
@@ -1405,7 +1426,10 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         hazard_index = self.hazard_layer_combo.currentIndex()
         exposure_index = self.exposure_layer_combo.currentIndex()
         if hazard_index == -1 or exposure_index == -1:
-            message = getting_started_message()
+            if self.conflicting_plugin_detected:
+                message = conflicting_plugin_message()
+            else:
+                message = getting_started_message()
             return False, message
         else:
             return True, None

--- a/safe/gui/widgets/message.py
+++ b/safe/gui/widgets/message.py
@@ -79,6 +79,36 @@ def missing_keyword_message(sender, missing_keyword_exception):
     send_static_message(sender, message)
 
 
+def conflicting_plugin_string():
+    """Return the error message when a plugin is conflicting with InaSAFE.
+
+    :return: The error string.
+    :rtype: basestring
+    """
+    message = tr(
+        'The plugin EmergencyMapper is conflicting with InaSAFE. You may have '
+        'some issues by running InaSAFE. You should remove the other plugin, '
+        'not only disable it. Check that the folder doesn\'t exist '
+        'anymore on your system.')
+    return message
+
+
+def conflicting_plugin_message():
+    """Unfortunately, one plugin is conflicting with InaSAFE.
+
+    We are displaying a message about this conflict.
+
+    :returns: Information for the user on how to get started.
+    :rtype: safe.messaging.Message
+    """
+    message = m.Message()
+    message.add(LOGO_ELEMENT)
+    message.add(m.Heading(tr('Conflicting plugin detected'), **WARNING_STYLE))
+    notes = m.Paragraph(conflicting_plugin_string())
+    message.add(notes)
+    return message
+
+
 def getting_started_message():
     """Generate a message for initial application state.
 

--- a/safe/utilities/test/test_utilities.py
+++ b/safe/utilities/test/test_utilities.py
@@ -17,14 +17,15 @@ from safe.utilities.utilities import (
     humanise_seconds,
     impact_attribution,
     replace_accentuated_characters,
+    is_plugin_installed,
     is_keyword_version_supported
 )
 from safe.utilities.gis import qgis_version
 
 
 class UtilitiesTest(unittest.TestCase):
-    """Tests for reading and writing of raster and vector data
-    """
+
+    """Tests for reading and writing of raster and vector data."""
 
     def setUp(self):
         """Test setup."""
@@ -37,8 +38,8 @@ class UtilitiesTest(unittest.TestCase):
     def test_get_qgis_version(self):
         """Test we can get the version of QGIS"""
         version = qgis_version()
-        message = 'Got version %s of QGIS, but at least 107000 is needed'
-        assert version > 10700, message
+        message = 'Got version %s of QGIS, but at least 214000 is needed'
+        self.assertTrue(version > 21400, message)
 
     def test_humanize_seconds(self):
         """Test that humanise seconds works."""
@@ -98,6 +99,15 @@ class UtilitiesTest(unittest.TestCase):
         self.assertTrue(is_keyword_version_supported('3.2.1-alpha', '3.2'))
         self.assertTrue(is_keyword_version_supported('3.2.1', '3.3'))
         self.assertFalse(is_keyword_version_supported('3.02.1', '3.2'))
+
+    @unittest.skipIf(
+        os.environ.get('ON_TRAVIS', False),
+        'The plugin is not installed under the same directory in Travis.')
+    def test_if_plugin_is_installed(self):
+        """Test if we can know if a plugin is installed."""
+        self.assertTrue(is_plugin_installed('inasafe'))
+        self.assertFalse(is_plugin_installed('inasafeZ'))
+
 
 if __name__ == '__main__':
     suite = unittest.makeSuite(UtilitiesTest)

--- a/safe/utilities/utilities.py
+++ b/safe/utilities/utilities.py
@@ -13,6 +13,8 @@ import unicodedata
 import webbrowser
 
 from PyQt4.QtCore import QPyNullVariant
+from qgis.core import QgsApplication
+from os.path import join, isdir
 
 from safe.common.exceptions import NoKeywordsFoundError, MetadataReadError
 from safe.definitions.versions import (
@@ -412,3 +414,16 @@ def readable_os_version():
         return ' {version}'.format(version=platform.mac_ver()[0])
     elif platform.system() == 'Windows':
         return platform.platform()
+
+
+def is_plugin_installed(name):
+    """Check if a plugin is installed, even if it's not enabled.
+
+    :param name: Name of the plugin to check.
+    :type name: string
+
+    :return: If the plugin is installed.
+    :rtype: bool
+    """
+    directory = QgsApplication.qgisSettingsDirPath()
+    return isdir(join(directory, 'python', 'plugins', name))


### PR DESCRIPTION
### What does it fix?
* Ticket: None
* Funded by: DFAT
* Description: 
<img width="433" alt="screen shot 2017-09-27 at 10 43 44" src="https://user-images.githubusercontent.com/1609292/30894898-d392e124-a370-11e7-9d52-119e3d54dc90.png">

I could it better, but it's not my priority ;-)

The problem is if the plugin is enabled, it will even raise an exception in InaSAFE and FloodMapper will be loaded itself, so users think that the problem comes from InaSAFE:

<img width="1667" alt="screen shot 2017-09-27 at 10 46 05" src="https://user-images.githubusercontent.com/1609292/30894945-1c8453fe-a371-11e7-85cd-b4ba2e6fd98e.png">

No more InaSAFE toolbar, exception from InaSAFE, and FloodMapper is loaded.

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
