### PR TITLE
display warning about conflicting plugin

### DIFF
--- a/safe/gui/widgets/message.py
+++ b/safe/gui/widgets/message.py
@@ -78,6 +78,36 @@ def missing_keyword_message(sender, missing_keyword_exception):
     send_static_message(sender, message)
 
 
+def conflicting_plugin_string():
+    """Return the error message when a plugin is conflicting with InaSAFE.
+
+    :return: The error string.
+    :rtype: basestring
+    """
+    message = tr(
+        'The plugin EmergencyMapper is conflicting with InaSAFE. You may have '
+        'some issues by running InaSAFE. You should remove the other plugin, '
+        'not only disable it. Check that the folder doesn\'t exist '
+        'anymore on your system.')
+    return message
+
+
+def conflicting_plugin_message():
+    """Unfortunately, one plugin is conflicting with InaSAFE.
+
+    We are displaying a message about this conflict.
+
+    :returns: Information for the user on how to get started.
+    :rtype: safe.messaging.Message
+    """
+    message = m.Message()
+    message.add(LOGO_ELEMENT)
+    message.add(m.Heading(tr('Conflicting plugin detected'), **WARNING_STYLE))
+    notes = m.Paragraph(conflicting_plugin_string())
+    message.add(notes)
+    return message
+
+
 def getting_started_message():
     """Generate a message for initial application state.
 

--- a/safe/utilities/test/test_utilities.py
+++ b/safe/utilities/test/test_utilities.py
@@ -17,14 +17,15 @@ from safe.utilities.utilities import (
     humanise_seconds,
     impact_attribution,
     replace_accentuated_characters,
+    is_plugin_installed,
     is_keyword_version_supported
 )
 from safe.utilities.gis import qgis_version
 
 
 class UtilitiesTest(unittest.TestCase):
-    """Tests for reading and writing of raster and vector data
-    """
+
+    """Tests for reading and writing of raster and vector data."""
 
     def setUp(self):
         """Test setup."""
@@ -37,8 +38,8 @@ class UtilitiesTest(unittest.TestCase):
     def test_get_qgis_version(self):
         """Test we can get the version of QGIS"""
         version = qgis_version()
-        message = 'Got version %s of QGIS, but at least 107000 is needed'
-        assert version > 10700, message
+        message = 'Got version %s of QGIS, but at least 214000 is needed'
+        self.assertTrue(version > 21400, message)
 
     def test_humanize_seconds(self):
         """Test that humanise seconds works."""
@@ -98,6 +99,15 @@ class UtilitiesTest(unittest.TestCase):
         self.assertTrue(is_keyword_version_supported('3.2.1-alpha', '3.2'))
         self.assertTrue(is_keyword_version_supported('3.2.1', '3.3'))
         self.assertFalse(is_keyword_version_supported('3.02.1', '3.2'))
+
+    @unittest.skipIf(
+        os.environ.get('ON_TRAVIS', False),
+        'The plugin is not installed under the same directory in Travis.')
+    def test_if_plugin_is_installed(self):
+        """Test if we can know if a plugin is installed."""
+        self.assertTrue(is_plugin_installed('inasafe'))
+        self.assertFalse(is_plugin_installed('inasafeZ'))
+
 
 if __name__ == '__main__':
     suite = unittest.makeSuite(UtilitiesTest)

--- a/safe/utilities/utilities.py
+++ b/safe/utilities/utilities.py
@@ -13,6 +13,8 @@ import unicodedata
 import webbrowser
 
 from PyQt4.QtCore import QPyNullVariant
+from qgis.core import QgsApplication
+from os.path import join, isdir
 
 from safe.common.exceptions import NoKeywordsFoundError, MetadataReadError
 from safe.definitions.versions import (
@@ -440,3 +442,16 @@ def readable_os_version():
         return ' {version}'.format(version=platform.mac_ver()[0])
     elif platform.system() == 'Windows':
         return platform.platform()
+
+
+def is_plugin_installed(name):
+    """Check if a plugin is installed, even if it's not enabled.
+
+    :param name: Name of the plugin to check.
+    :type name: string
+
+    :return: If the plugin is installed.
+    :rtype: bool
+    """
+    directory = QgsApplication.qgisSettingsDirPath()
+    return isdir(join(directory, 'python', 'plugins', name))


### PR DESCRIPTION
### What does it fix?
* Ticket: #
* Funded by: DFAT
* Description: Backport from develop. We have a problem with Emergency Mapper plugin.

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
