### PR TITLE
Avoid uninitialized variable.

### DIFF
--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -651,10 +651,10 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
                     (layer not in canvas_layers)):
                 continue
 
-            #    store uuid in user property of list widget for layers
-
+            # store uuid in user property of list widget for layers
             layer_id = layer.id()
-
+            # Avoid uninitialized variable
+            title = None
             # See if there is a title for this layer, if not,
             # fallback to the layer's filename
             # noinspection PyBroadException


### PR DESCRIPTION
### What does it fix?
* Ticket: No ticket
* Funded by: DFAT
* Description: 
Fixing this error:
```
2017-09-28T16:01:15    1    Traceback (most recent call last):
              File "C:/Users/chandf.DMINNOVATION/.qgis2/python/plugins\inasafe\safe\plugin.py", line 939, in layer_changed
                keywords = KeywordIO().read_keywords(layer)
              File "C:/Users/chandf.DMINNOVATION/.qgis2/python/plugins\inasafe\safe\utilities\keyword_io.py", line 80, in read_keywords
                return read_iso19115_metadata(source, keyword)
              File "C:/Users/chandf.DMINNOVATION/.qgis2/python/plugins\inasafe\safe\utilities\metadata.py", line 100, in read_iso19115_metadata
                metadata = GenericLayerMetadata(layer_uri, xml_uri)
              File "C:/Users/chandf.DMINNOVATION/.qgis2/python/plugins\inasafe\safe\metadata\generic_layer_metadata.py", line 63, in __init__
                layer_uri, xml_uri, json_uri)
              File "C:/Users/chandf.DMINNOVATION/.qgis2/python/plugins\inasafe\safe\metadata\base_metadata.py", line 247, in __init__
                self.read_from_ancillary_file(xml_uri)
              File "C:/Users/chandf.DMINNOVATION/.qgis2/python/plugins\inasafe\safe\metadata\base_metadata.py", line 659, in read_from_ancillary_file
                if not self.read_json():
              File "C:/Users/chandf.DMINNOVATION/.qgis2/python/plugins\inasafe\safe\metadata\generic_layer_metadata.py", line 104, in read_json
                metadata = super(GenericLayerMetadata, self).read_json()
              File "C:/Users/chandf.DMINNOVATION/.qgis2/python/plugins\inasafe\safe\metadata\base_metadata.py", line 318, in read_json
                metadata = self._read_json_db()
              File "C:/Users/chandf.DMINNOVATION/.qgis2/python/plugins\inasafe\safe\metadata\base_metadata.py", line 360, in _read_json_db
                metadata = json.loads(metadata_str)
              File "C:\PROGRA~1\QGIS2~1.14\apps\Python27\lib\json\__init__.py", line 338, in loads
                return _default_decoder.decode(s)
              File "C:\PROGRA~1\QGIS2~1.14\apps\Python27\lib\json\decoder.py", line 365, in decode
                obj, end = self.raw_decode(s, idx=_w(s, 0).end())
            TypeError: expected string or buffer

2017-09-28T16:01:15    1    Traceback (most recent call last):
              File "C:/Users/chandf.DMINNOVATION/.qgis2/python/plugins\inasafe\safe\gui\widgets\dock.py", line 673, in get_layers
                if title and self.set_layer_from_title_flag:
            UnboundLocalError: local variable 'title' referenced before assignment
```

### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR