### PR TITLE
Fix annoying behaviour when resizing Field Mapping Tool.

### DIFF
--- a/safe/gui/tools/field_mapping_dialog.py
+++ b/safe/gui/tools/field_mapping_dialog.py
@@ -103,6 +103,7 @@ class FieldMappingDialog(QDialog, FORM_CLASS):
         self.layer_input_layout.addWidget(self.layer_combo_box)
 
         self.header_label = QLabel()
+        self.header_label.setWordWrap(True)
         self.main_layout.addWidget(self.header_label)
         self.main_layout.addLayout(self.layer_input_layout)
 

--- a/safe/gui/ui/field_mapping_dialog_base.ui
+++ b/safe/gui/ui/field_mapping_dialog_base.ui
@@ -6,9 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>969</width>
-    <height>513</height>
+    <width>1000</width>
+    <height>500</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>1000</width>
+    <height>500</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>

--- a/safe/gui/widgets/field_mapping_tab.py
+++ b/safe/gui/widgets/field_mapping_tab.py
@@ -96,6 +96,7 @@ class FieldMappingTab(QWidget, object):
 
         # Footer
         self.footer_label = QLabel()
+        self.footer_label.setWordWrap(True)
 
         # Parameters
         self.extra_parameters = [


### PR DESCRIPTION
### What does it fix?
* Ticket: No ticket
* Funded by: DFAT
* Description: 
From:

![annoying_resize](https://user-images.githubusercontent.com/1421861/31210219-be81aa90-a9ba-11e7-9992-57a607c89019.gif)

To:
![not_annoying_resize](https://user-images.githubusercontent.com/1421861/31210221-c2aad74a-a9ba-11e7-9605-557001e268ac.gif)

I was trying to make the fix for the height, but still no luck.
### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR
