### PR TITLE
change layer order - aggregation layer below impact layer

### DIFF
--- a/safe/report/extractors/composer.py
+++ b/safe/report/extractors/composer.py
@@ -252,7 +252,7 @@ def qgis_composer_extractor(impact_report, component_metadata):
         if aggregation_layer_id:
             aggregation_layer = layer_registry.mapLayers().get(
                 aggregation_layer_id, None)
-            layers.insert(0, aggregation_layer)
+            layers.append(aggregation_layer)
 
         layers.append(hazard_layer)
 


### PR DESCRIPTION
### What does it fix?
* Ticket: #4477 
* Funded by: DFAT
* Description: So there is a problem if we use a not transparent aggregation layer, the map report will put the aggregation layer on the top of impact layer. Now we want to put the aggregation layer anywhere below the impact layer.

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
