### PR TITLE
Only set profiling to provenance if not in debug mode.

### DIFF
--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -1676,11 +1676,12 @@ class ImpactFunction(object):
 
         # Put profiling file path to the provenance
         # FIXME(IS): Very hacky
-        profiling_path = join(dirname(
-            self._analysis_impacted.publicSource()),
-            layer_purpose_profiling['name'] + '.csv')
-        output_layer_provenance[
-            provenance_layer_profiling['provenance_key']] = profiling_path
+        if not self.debug_mode:
+            profiling_path = join(dirname(
+                self._analysis_impacted.publicSource()),
+                layer_purpose_profiling['name'] + '.csv')
+            output_layer_provenance[
+                provenance_layer_profiling['provenance_key']] = profiling_path
 
         # Update provenance data with output layers URI
         self._provenance.update(output_layer_provenance)


### PR DESCRIPTION
### What does it fix?
* Ticket: No ticket
* Funded by: DFAT
* Description: 
  Since I hacked the way to put profiling in the output layer and the hack only works on non debug mode, I use the hack only in non debug mode.

### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR
