### PR TITLE
add make command to run tests in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,34 +344,23 @@ build-nightlies:
 #
 ##########################################################
 
-docker-run-tests:
-    # The image is hosted in docker hub at
-    # https://registry.hub.docker.com/u/inasafe/inasafe-test-runner/
-	docker pull inasafe/inasafe-test-runner
-	#docker rm inasafe-test-runner
-	docker run -i -t --rm --name="inasafe-tests" \
-		-v /Users/timlinux/dev/python/inasafe_data/:/inasafe_data \
-		-v /Users/timlinux/dev/python/inasafe:/inasafe \
-		inasafe/inasafe-test-runner \
-		/bin/bash
-
-
-docker-test: testdata clean
+docker-start-test-container:
 	@echo
 	@echo "----------------------------------"
-	@echo "Regression Test Suite for running in docker"
-	@echo " against QGIS 2.x"
+	@echo "Start docker container for testing with QGIS 2.14"
+	@echo "Image: kartoza/qgis-testing:boundlessgeo-2.14.7"
+	@echo "You can use 'make docker-test' after that"
 	@echo "----------------------------------"
-	@PYTHONPATH=`pwd`:$(PYTHONPATH) xvfb-run \
-		--server-args="-screen 0, 1024x768x24" \
-		nosetests \
-		-v \
-		--with-id \
-		--with-xcoverage \
-		--with-xunit \
-		--verbose \
-		--cover-package=safe safe
+	@./start-docker-test.sh
 
+docker-test:
+	@echo
+	@echo "----------------------------------"
+	@echo "Run tests in docker"
+	@echo "You must run 'make docker-start-test-container' before."
+	@echo "You can change the tested package in 'test_suite.py' in the 'test_package' function."
+	@echo "----------------------------------"
+	@./run-docker-test.sh
 
 docker-update-translation-strings:
 	@echo "Update translation using docker"

--- a/run-docker-test.sh
+++ b/run-docker-test.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker exec -it qgis-testing-environment sh -c "qgis_testrunner.sh test_suite.test_package"

--- a/start-docker-test.sh
+++ b/start-docker-test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker run -d --name qgis-testing-environment -v ${PWD}:/tests_directory -e ON_TRAVIS=false -e MUTE_LOGS=true -e DISPLAY=:99 kartoza/qgis-testing:boundlessgeo-2.14.7
+sleep 10
+docker exec -it qgis-testing-environment sh -c "qgis_setup.sh inasafe"
+docker exec -it qgis-testing-environment sh -c "pip install --upgrade pep257"
+docker exec -it qgis-testing-environment sh -c "pip install --upgrade flake8"


### PR DESCRIPTION
### What does it fix?
* Ticket: #
* Funded by: DFAT
* Description: While my test environment is broken, I'm using docker.

Running all tests in local, I have one failing test, in 4 mins 30 seconds:
```
======================================================================
FAIL: test_minimum_needs_outputs (report.test.test_impact_report.TestImpactReport)
Test generate minimum needs section.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tests_directory/safe/report/test/test_impact_report.py", line 1035, in test_minimum_needs_outputs
    expected_context.strip(), actual_context.strip(), message)
AssertionError: For this analysis, the following displacement rates were used: Wet - 90%, Dry - 0%
For this analysis, the following displacement rates were used: X - 100%, IX - 100%, VIII - 100%, VII - 100%, VI - 100%, V - 0%, IV - 0%, III - 0%, II - 0%, I - 0%

----------------------------------------------------------------------
Ran 324 tests in 276.267s

FAILED (failures=1, skipped=13, expected failures=10)
Finished running test test_suite.test_package.
```


### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR