### PR TITLE
use our internal settings class instead of QSettings

### DIFF
--- a/safe/common/custom_logging.py
+++ b/safe/common/custom_logging.py
@@ -21,8 +21,10 @@ safe_extras_dir = os.path.abspath(
 if safe_extras_dir not in sys.path:
     sys.path.append(safe_extras_dir)
 
+# We add "# NOQA" because imports are not done at top of file.
+
 from qgis.core import QgsMessageLog  # NOQA
-from PyQt4.QtCore import QSettings  # NOQA
+from PyQt4.QtCore import QSettings  # NOQA We can't move to our settings class.
 # pylint: disable=F0401
 # noinspection PyUnresolvedReferences,PyPackageRequirements
 from raven.handlers.logging import SentryHandler  # NOQA
@@ -151,8 +153,7 @@ def setup_logger(logger_name, log_file=None, sentry_url=None):
     # We will log exceptions only there. You need to either:
     #  * Set env var 'INASAFE_SENTRY=1' present (value can be anything)
     # before this will be enabled or sentry is enabled in QSettings
-    settings = QSettings()
-    flag = settings.value('inasafe/useSentry', False, type=bool)
+    flag = QSettings().value('inasafe/useSentry', False, type=bool)
     env_inasafe_sentry = 'INASAFE_SENTRY' in os.environ
 
     if env_inasafe_sentry or flag:

--- a/safe/gui/tools/batch/batch_dialog.py
+++ b/safe/gui/tools/batch/batch_dialog.py
@@ -26,7 +26,7 @@ from StringIO import StringIO
 from datetime import datetime
 
 from PyQt4 import QtGui, QtCore
-from PyQt4.QtCore import pyqtSignature, pyqtSlot, QSettings, Qt
+from PyQt4.QtCore import pyqtSignature, pyqtSlot, Qt
 from PyQt4.QtGui import (
     QAbstractItemView,
     QDialog,
@@ -67,6 +67,7 @@ from safe.utilities.gis import extent_string_to_array
 from safe.utilities.qgis_utilities import display_critical_message_box
 from safe.utilities.resources import (
     html_footer, html_header, get_ui_class)
+from safe.utilities.settings import setting, set_setting
 
 INFO_STYLE = styles.BLUE_LEVEL_4_STYLE
 LOGGER = logging.getLogger('InaSAFE')
@@ -88,9 +89,7 @@ class BatchDialog(QDialog, FORM_CLASS):
         :param dock: A Dock widget needed to run the scenarios with. On
             our road map is to figure out how to get rid of this parameter.
         :type dock: Dock
-
         """
-
         QDialog.__init__(self, parent)
         self.setupUi(self)
         self.setWindowModality(Qt.ApplicationModal)
@@ -161,37 +160,28 @@ class BatchDialog(QDialog, FORM_CLASS):
 
     def restore_state(self):
         """Restore GUI state from configuration file."""
-
-        settings = QSettings()
-
         # restore last source path
-        last_source_path = settings.value(
-            'inasafe/lastSourceDir', self.default_directory, type=str)
+        last_source_path = setting(
+            'lastSourceDir', self.default_directory, expected_type=str)
         self.source_directory.setText(last_source_path)
 
         # restore path pdf output
-        last_output_dir = settings.value(
-            'inasafe/lastOutputDir', self.default_directory, type=str)
+        last_output_dir = setting(
+            'lastOutputDir', self.default_directory, expected_type=str)
         self.output_directory.setText(last_output_dir)
 
         # restore default output dir combo box
-        use_default_output_dir = bool(settings.value(
-            'inasafe/useDefaultOutputDir', True, type=bool))
+        use_default_output_dir = bool(setting(
+            'useDefaultOutputDir', True, expected_type=bool))
         self.scenario_directory_radio.setChecked(
             use_default_output_dir)
 
     def save_state(self):
         """Save current state of GUI to configuration file."""
-
-        settings = QSettings()
-
-        settings.setValue(
-            'inasafe/lastSourceDir', self.source_directory.text())
-        settings.setValue(
-            'inasafe/lastOutputDir', self.output_directory.text())
-        settings.setValue(
-            'inasafe/useDefaultOutputDir',
-            self.scenario_directory_radio.isChecked())
+        set_setting('lastSourceDir', self.source_directory.text())
+        set_setting('lastOutputDir', self.output_directory.text())
+        set_setting(
+            'useDefaultOutputDir', self.scenario_directory_radio.isChecked())
 
     def choose_directory(self, line_edit, title):
         """ Show a directory selection dialog.
@@ -761,7 +751,6 @@ class BatchDialog(QDialog, FORM_CLASS):
     @pyqtSignature('')  # prevents actions being handled twice
     def on_output_directory_chooser_clicked(self):
         """Auto  connect slot activated when tbOutputDiris clicked ."""
-
         title = self.tr('Set the output directory for pdf report files')
         self.choose_directory(self.output_directory, title)
 
@@ -813,7 +802,7 @@ class BatchDialog(QDialog, FORM_CLASS):
 
 
 def read_scenarios(filename):
-    """Read keywords dictionary from file
+    """Read keywords dictionary from file.
 
     :param filename: Name of file holding scenarios .
 

--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -35,7 +35,7 @@ from qgis.gui import QgsMapToolPan
 # noinspection PyPackageRequirements
 from PyQt4 import QtGui
 # noinspection PyPackageRequirements
-from PyQt4.QtCore import QSettings, pyqtSignature, QRegExp, pyqtSlot
+from PyQt4.QtCore import pyqtSignature, QRegExp, pyqtSlot
 # noinspection PyPackageRequirements
 from PyQt4.QtGui import (
     QDialog, QProgressDialog, QMessageBox, QFileDialog, QRegExpValidator)
@@ -59,6 +59,7 @@ from safe.utilities.qgis_utilities import (
     display_warning_message_bar)
 from safe.gui.tools.rectangle_map_tool import RectangleMapTool
 from safe.gui.tools.help.osm_downloader_help import osm_downloader_help
+from safe.utilities.settings import setting, set_setting
 
 
 LOGGER = logging.getLogger('InaSAFE')
@@ -218,18 +219,13 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         self.help_web_view.setHtml(string)
 
     def restore_state(self):
-        """ Read last state of GUI from configuration file."""
-        settings = QSettings()
-        try:
-            last_path = settings.value('directory', type=str)
-        except TypeError:
-            last_path = ''
+        """Read last state of GUI from configuration file."""
+        last_path = setting('directory', '', expected_type=str)
         self.output_directory.setText(last_path)
 
     def save_state(self):
         """ Store current state of GUI to configuration file ."""
-        settings = QSettings()
-        settings.setValue('directory', self.output_directory.text())
+        set_setting('directory', self.output_directory.text())
 
     def update_extent(self, extent):
         """Update extent value in GUI based from an extent.

--- a/safe/gui/widgets/message_viewer.py
+++ b/safe/gui/widgets/message_viewer.py
@@ -29,8 +29,9 @@ from safe.common.exceptions import InvalidParameterError
 from safe.messaging.message import MessageElement
 from safe.utilities.qt import qt_at_least
 from safe.utilities.resources import html_footer, html_header, resources_path
-from safe.utilities.utilities import html_to_file, open_in_browser
-from safe.utilities.utilities import unique_filename
+from safe.utilities.utilities import (
+    html_to_file, open_in_browser, unique_filename)
+from safe.utilities.settings import setting
 
 DYNAMIC_MESSAGE_SIGNAL = 'ImpactFunctionMessage'
 STATIC_MESSAGE_SIGNAL = 'ApplicationMessage'
@@ -55,8 +56,7 @@ class MessageViewer(QtWebKit.QWebView):
         self.last_id = 0
 
         # whether to show or not dev only options
-        self.dev_mode = QtCore.QSettings().value(
-            'inasafe/developer_mode', False, type=bool)
+        self.dev_mode = setting('developer_mode', False, expected_type=bool)
 
         if self.dev_mode:
             self.settings().globalSettings().setAttribute(

--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -1499,9 +1499,8 @@ class ImpactFunction(object):
             # Users are free to set their own datastore with the setter.
             self.callback(1, step_count, analysis_steps['data_store'])
 
-            settings = QSettings()
-            default_user_directory = settings.value(
-                'inasafe/defaultUserDirectory', defaultValue='')
+            default_user_directory = setting(
+                'defaultUserDirectory', default='')
             if default_user_directory:
                 path = join(default_user_directory, self._unique_name)
                 if not exists(path):

--- a/safe/plugin.py
+++ b/safe/plugin.py
@@ -20,7 +20,7 @@ from qgis.core import (
 from PyQt4.QtCore import (
     QCoreApplication,
     Qt,
-    QSettings)
+)
 # noinspection PyPackageRequirements
 from PyQt4.QtGui import (
     QAction,
@@ -44,6 +44,7 @@ from safe.definitions.layer_purposes import (
 )
 from safe.definitions.utilities import get_field_groups
 from safe.utilities.keyword_io import KeywordIO
+from safe.utilities.settings import setting, set_setting
 LOGGER = logging.getLogger('InaSAFE')
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
@@ -425,9 +426,7 @@ class Plugin(object):
         self.action_toggle_rubberbands.setWhatsThis(message)
         # Set initial state
         self.action_toggle_rubberbands.setCheckable(True)
-        settings = QSettings()
-        flag = bool(settings.value(
-            'inasafe/showRubberBands', False, type=bool))
+        flag = setting('showRubberBands', False, expected_type=bool)
         self.action_toggle_rubberbands.setChecked(flag)
         # noinspection PyUnresolvedReferences
         self.action_toggle_rubberbands.triggered.connect(
@@ -452,9 +451,8 @@ class Plugin(object):
     def _create_test_layers_action(self):
         """Create action for adding layers (developer mode, non final only)."""
         final_release = inasafe_release_status == 'final'
-        settings = QSettings()
-        self.developer_mode = settings.value(
-            'inasafe/developer_mode', False, type=bool)
+        self.developer_mode = setting(
+            'developer_mode', False, expected_type=bool)
         if not final_release and self.developer_mode:
             icon = resources_path('img', 'icons', 'add-test-layers.svg')
             self.action_add_layers = QAction(
@@ -473,13 +471,12 @@ class Plugin(object):
     def _create_run_test_action(self):
         """Create action for running tests (developer mode, non final only)."""
         final_release = inasafe_release_status == 'final'
-        settings = QSettings()
-        self.developer_mode = settings.value(
-            'inasafe/developer_mode', False, type=bool)
+        self.developer_mode = setting(
+            'developer_mode', False, expected_type=bool)
         if not final_release and self.developer_mode:
 
-            default_package = unicode(settings.value(
-                'inasafe/testPackage', 'safe', type=str))
+            default_package = unicode(
+                setting('testPackage', 'safe', expected_type=str))
             msg = self.tr('Run tests in %s' % default_package)
 
             self.test_button = QToolButton()
@@ -678,10 +675,9 @@ class Plugin(object):
 
     def select_test_package(self):
         """Select the test package."""
-        settings = QSettings()
         default_package = 'safe'
-        user_package = unicode(settings.value(
-            'inasafe/testPackage', default_package, type=str))
+        user_package = unicode(
+            setting('testPackage', default_package, expected_type=str))
 
         test_package, _ = QInputDialog.getText(
             self.iface.mainWindow(),
@@ -693,7 +689,7 @@ class Plugin(object):
         if test_package == '':
             test_package = default_package
 
-        settings.setValue('inasafe/testPackage', test_package)
+        set_setting('testPackage', test_package)
         msg = self.tr('Run tests in %s' % test_package)
         self.action_run_tests.setWhatsThis(msg)
         self.action_run_tests.setText(msg)
@@ -704,9 +700,7 @@ class Plugin(object):
         main_window = self.iface.mainWindow()
         action = main_window.findChild(QAction, 'mActionShowPythonDialog')
         action.trigger()
-        settings = QSettings()
-        package = unicode(settings.value(
-            'inasafe/testPackage', 'safe', type=str))
+        package = unicode(setting('testPackage', 'safe', expected_type=str))
         for child in main_window.findChildren(QDockWidget, 'PythonConsole'):
             if child.objectName() == 'PythonConsole':
                 child.show()

--- a/safe/utilities/i18n.py
+++ b/safe/utilities/i18n.py
@@ -8,7 +8,8 @@ import logging
 # noinspection PyUnresolvedReferences
 import qgis  # NOQA pylint: disable=unused-import
 # noinspection PyPackageRequirements
-from PyQt4.QtCore import QCoreApplication, QSettings, QLocale
+from PyQt4.QtCore import QCoreApplication, QSettings, QLocale  # QSettings
+# can't be moved to our internal class
 
 from safe.utilities.unicode import get_unicode
 

--- a/safe/utilities/osm_downloader.py
+++ b/safe/utilities/osm_downloader.py
@@ -6,7 +6,6 @@ import os
 import tempfile
 import zipfile
 
-from PyQt4.QtCore import QSettings
 from PyQt4.QtGui import QDialog
 from PyQt4.QtNetwork import QNetworkReply
 
@@ -16,6 +15,7 @@ from safe.definitions.versions import inasafe_release_status
 from safe.utilities.file_downloader import FileDownloader
 from safe.utilities.gis import qgis_version
 from safe.utilities.i18n import tr, locale
+from safe.utilities.settings import setting
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -25,8 +25,7 @@ __revision__ = '$Format:%H$'
 # If it's not a final release and the developer mode is ON, we use the staging
 # version for OSM-Reporter.
 final_release = inasafe_release_status == 'final'
-settings = QSettings()
-developer_mode = settings.value('inasafe/developer_mode', False, type=bool)
+developer_mode = setting('developer_mode', False, expected_type=bool)
 if not final_release and developer_mode:
     URL_OSM_PREFIX = 'http://staging.osm.kartoza.com/'
 else:


### PR DESCRIPTION
### What does it fix?
* Ticket: #
* Funded by: DFAT
* Description: One step forward to QGIS 3 as we will have to switch to QgsSettings. So we can do this change in our class to switch them all ;-)

@ismailsunni There is still a few. And some are using the QSettings for testing. I will let them or you can help. I was doing this as a break

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
