### PR TITLE
switch from pep8 to pycodestyle

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,4 +4,4 @@ max-line-length = 79
 
 # E12x continuation line indentation
 
-ignore = E121
+ignore = E121,E722

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,12 +52,13 @@ before_install:
 
 install:
   - pip install --upgrade pip
-  - pip install --upgrade pep8
+  - pip install --upgrade pycodestyle
   - pip install --upgrade pep257
   - pip install --upgrade flake8
   - docker run -d --name qgis-testing-environment -v ${TRAVIS_BUILD_DIR}:/tests_directory -e WITH_PYTHON_PEP=${WITH_PYTHON_PEP} -e ON_TRAVIS=${ON_TRAVIS} -e MUTE_LOGS=${MUTE_LOGS} -e DISPLAY=:99 ${IMAGE}:${QGIS_VERSION_TAG}
   - sleep 10
   - docker exec -it qgis-testing-environment sh -c "qgis_setup.sh inasafe"
+  - docker exec -it qgis-testing-environment sh -c "pip install --upgrade pycodestyle"
   - docker exec -it qgis-testing-environment sh -c "pip install --upgrade pep257"
   - docker exec -it qgis-testing-environment sh -c "pip install --upgrade flake8"
 

--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,10 @@ test_suite_all:
 pep8:
 	@echo
 	@echo "-----------"
-	@echo "PEP8 issues"
+	@echo "PEP8 issues, using pycodestyle"
 	@echo "-----------"
-	@pep8 --version
-	@pep8 --repeat --ignore=E121,E402 --exclude venv,pydev,safe_extras,extras,test_*.py  . || true
+	@pycodestyle --version
+	@pycodestyle --repeat --ignore=E121,E402,E722 --exclude venv,pydev,safe_extras,extras,test_*.py  . || true
 
 # Run pep257 style checking
 #http://pypi.python.org/pypi/pep257

--- a/safe/test/test_python_pep.py
+++ b/safe/test/test_python_pep.py
@@ -84,9 +84,7 @@ class TestPythonPep(unittest.TestCase):
         # make pep8 produces some extra lines by default.
         lines = len(output.splitlines()) - default_number_lines
         print output
-        message = (
-            'Hey mate, go back to your keyboard :) (expected %s, got %s '
-            'lines from PEP8.)' % (default_number_lines, lines))
+        message = 'Hey mate, go back to your keyboard :)'
         self.assertEquals(lines, 0, message)
 
     @unittest.skipIf(


### PR DESCRIPTION
### What does it fix?
* Ticket: #
* Funded by: DFAT
* Description: We got a warning since a few days saying that pep8 is going to be removed and need to be replaced by pycodestyle.

I saw that already one year ago. Time to switch

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
