### PR TITLE
add function to know layers provided by a multiexposure analysis

### DIFF
--- a/safe/definitions/layer_purposes.py
+++ b/safe/definitions/layer_purposes.py
@@ -161,7 +161,7 @@ layer_purpose_exposure_summary_table = {
         'includes totals for affected and not affected status. It is used '
         'to generate reports and can be exported to a spreadsheet for '
         'further analysis.'),
-    'allowed_geometries': [],
+    'allowed_geometries': [],  # It's a table.
     'citations': [
         {
             'text': None,
@@ -179,7 +179,7 @@ layer_purpose_profiling = {
         'sent to the developers of InaSAFE if you encounter long processing '
         'times. They will use the information to identify processing '
         'bottlenecks.'),
-    'allowed_geometries': [],
+    'allowed_geometries': [],  # It's a table.
     'citations': [
         {
             'text': None,

--- a/safe/impact_function/test/test_multi_exposure_impact_function.py
+++ b/safe/impact_function/test/test_multi_exposure_impact_function.py
@@ -10,6 +10,14 @@ from safe.definitions.constants import (
     PREPARE_SUCCESS,
     ANALYSIS_SUCCESS,
 )
+from safe.definitions.layer_purposes import (
+    layer_purpose_analysis_impacted,
+    layer_purpose_aggregation_summary,
+    layer_purpose_aggregate_hazard_impacted,
+    layer_purpose_exposure_summary,
+    layer_purpose_exposure_summary_table,
+    layer_purpose_profiling,
+)
 from safe.test.utilities import qgis_iface, load_test_vector_layer
 from safe.impact_function.multi_exposure_wrapper import (
     MultiExposureImpactFunction)
@@ -50,6 +58,7 @@ class TestMultiExposureImpactFunction(unittest.TestCase):
         impact_function.aggregation = aggregation_layer
         self.assertTrue(
             impact_function.prepare()[0] == PREPARE_FAILED_BAD_INPUT)
+        self.assertDictEqual({}, impact_function.output_layers_expected())
 
         # Missing exposure layer
         impact_function = MultiExposureImpactFunction()
@@ -58,6 +67,7 @@ class TestMultiExposureImpactFunction(unittest.TestCase):
         impact_function.aggregation = aggregation_layer
         self.assertTrue(
             impact_function.prepare()[0] == PREPARE_FAILED_BAD_INPUT)
+        self.assertDictEqual({}, impact_function.output_layers_expected())
 
         # Normal multi exposure
         impact_function = MultiExposureImpactFunction()
@@ -66,6 +76,30 @@ class TestMultiExposureImpactFunction(unittest.TestCase):
         impact_function.aggregation = aggregation_layer
         self.assertTrue(
             impact_function.prepare()[0] == PREPARE_SUCCESS)
+
+        expected_layers = {
+            u'Generic Hazard Polygon On Population Polygon': [
+                layer_purpose_exposure_summary['key'],
+                layer_purpose_aggregate_hazard_impacted['key'],
+                layer_purpose_aggregation_summary['key'],
+                layer_purpose_analysis_impacted['key'],
+                layer_purpose_profiling['key']
+            ],
+            impact_function.name: [
+                layer_purpose_aggregation_summary['key'],
+                layer_purpose_analysis_impacted['key']
+            ],
+            u'Generic Hazard Polygon On Roads Line': [
+                layer_purpose_exposure_summary['key'],
+                layer_purpose_aggregate_hazard_impacted['key'],
+                layer_purpose_aggregation_summary['key'],
+                layer_purpose_analysis_impacted['key'],
+                layer_purpose_exposure_summary_table['key'],
+                layer_purpose_profiling['key']
+            ]
+        }
+        self.assertDictEqual(
+            expected_layers, impact_function.output_layers_expected())
 
     def test_multi_exposure(self):
         """Test we can run a multi exposure analysis."""


### PR DESCRIPTION
### What does it fix?
* Ticket: #4495 
* Funded by: DFAT
* Description: To be able to know how many layers a multi exposure analysis will produce

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
