### PR TITLE
Clean one line docstrings

### DIFF
--- a/safe/gui/tools/batch/batch_dialog.py
+++ b/safe/gui/tools/batch/batch_dialog.py
@@ -743,14 +743,14 @@ class BatchDialog(QDialog, FORM_CLASS):
 
     @pyqtSignature('')  # prevents actions being handled twice
     def on_source_directory_chooser_clicked(self):
-        """Autoconnect slot activated when tbSourceDir is clicked ."""
+        """Autoconnect slot activated when tbSourceDir is clicked."""
 
         title = self.tr('Set the source directory for script and scenario')
         self.choose_directory(self.source_directory, title)
 
     @pyqtSignature('')  # prevents actions being handled twice
     def on_output_directory_chooser_clicked(self):
-        """Auto  connect slot activated when tbOutputDiris clicked ."""
+        """Auto  connect slot activated when tbOutputDiris clicked."""
         title = self.tr('Set the output directory for pdf report files')
         self.choose_directory(self.output_directory, title)
 

--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -224,7 +224,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         self.output_directory.setText(last_path)
 
     def save_state(self):
-        """ Store current state of GUI to configuration file ."""
+        """Store current state of GUI to configuration file."""
         set_setting('directory', self.output_directory.text())
 
     def update_extent(self, extent):

--- a/safe/gui/widgets/profile_widget.py
+++ b/safe/gui/widgets/profile_widget.py
@@ -16,10 +16,10 @@ __revision__ = '$Format:%H$'
 
 class ProfileWidget(QTreeWidget, object):
 
-    """Profile Widget"""
+    """Profile Widget."""
 
     def __init__(self, parent, data):
-        """Constructor"""
+        """Constructor."""
         super(ProfileWidget, self).__init__(parent)
 
         # Attributes

--- a/safe/gui/widgets/test/test_profile_widget.py
+++ b/safe/gui/widgets/test/test_profile_widget.py
@@ -12,7 +12,7 @@ from safe.gui.widgets.profile_widget import ProfileWidget
 
 
 class TestProfileWidget(unittest.TestCase):
-    """Test Profile Widget"""
+    """Test Profile Widget."""
 
     maxDiff = None
 

--- a/safe/messaging/item/abstract_list.py
+++ b/safe/messaging/item/abstract_list.py
@@ -26,7 +26,7 @@ from text import PlainText
 
 
 class AbstractList(MessageElement):
-    """A class to model free text in the messaging system ."""
+    """A class to model free text in the messaging system."""
 
     def __init__(self, *args, **kwargs):
         """Creates a Text object to contain a list of Text objects

--- a/safe/messaging/item/bulleted_list.py
+++ b/safe/messaging/item/bulleted_list.py
@@ -22,7 +22,7 @@ from abstract_list import AbstractList
 
 
 class BulletedList(AbstractList):
-    """A class to model free text in the messaging system ."""
+    """A class to model free text in the messaging system."""
 
     def __init__(self, bullet_style=None, *args, **kwargs):
         """Creates a Text object to contain a list of Text objects

--- a/safe/messaging/item/cell.py
+++ b/safe/messaging/item/cell.py
@@ -24,7 +24,7 @@ from text import Text
 
 
 class Cell(MessageElement):
-    """A class to model table cells in the messaging system ."""
+    """A class to model table cells in the messaging system."""
 
     def __init__(self, *args, **kwargs):
         """Creates a cell object

--- a/safe/messaging/item/emphasized_text.py
+++ b/safe/messaging/item/emphasized_text.py
@@ -22,7 +22,7 @@ from text import Text
 
 
 class EmphasizedText(Text):
-    """A class to model emphasized text in the messaging system ."""
+    """A class to model emphasized text in the messaging system."""
 
     def __init__(self, text, **kwargs):
         """Creates a Emphasized Text Text object

--- a/safe/messaging/item/horizontal_rule.py
+++ b/safe/messaging/item/horizontal_rule.py
@@ -22,7 +22,7 @@ from text import Text
 
 
 class HorizontalRule(Text):
-    """A class to model horizontal rules in text the messaging system ."""
+    """A class to model horizontal rules in text the messaging system."""
 
     def to_markdown(self):
         """Render as markdown

--- a/safe/messaging/item/image.py
+++ b/safe/messaging/item/image.py
@@ -22,7 +22,7 @@ from text import Text
 
 
 class Image(Text):
-    """A class to model emphasized text in the messaging system ."""
+    """A class to model emphasized text in the messaging system."""
 
     def __init__(self, uri, text=None, **kwargs):
         """Creates a Emphasized Text Text object

--- a/safe/messaging/item/important_text.py
+++ b/safe/messaging/item/important_text.py
@@ -22,7 +22,7 @@ from text import Text
 
 
 class ImportantText(Text):
-    """A class to model free text in the messaging system ."""
+    """A class to model free text in the messaging system."""
 
     def __init__(self, text, **kwargs):
         """Creates a Bold Text object

--- a/safe/messaging/item/line_break.py
+++ b/safe/messaging/item/line_break.py
@@ -22,7 +22,7 @@ from text import Text
 
 
 class LineBreak(Text):
-    """A class to model line breaks in text the messaging system ."""
+    """A class to model line breaks in text the messaging system."""
 
     def to_html(self, **kwargs):
         """Render as html

--- a/safe/messaging/item/link.py
+++ b/safe/messaging/item/link.py
@@ -22,7 +22,7 @@ from text import Text
 
 
 class Link(Text):
-    """A class to model emphasized text in the messaging system ."""
+    """A class to model emphasized text in the messaging system."""
 
     def __init__(self, uri, text=None, **kwargs):
         """Creates a Emphasized Text Text object

--- a/safe/messaging/item/numbered_list.py
+++ b/safe/messaging/item/numbered_list.py
@@ -22,7 +22,7 @@ from abstract_list import AbstractList
 
 
 class NumberedList(AbstractList):
-    """A class to model free text in the messaging system ."""
+    """A class to model free text in the messaging system."""
 
     def __init__(self, *args, **kwargs):
         """Creates a Text object to contain a list of Text objects

--- a/safe/messaging/item/row.py
+++ b/safe/messaging/item/row.py
@@ -28,7 +28,7 @@ from message_element import MessageElement
 
 
 class Row(MessageElement):
-    """A class to model table rows in the messaging system ."""
+    """A class to model table rows in the messaging system."""
 
     def __init__(self, *args, **kwargs):
         """Creates a row object

--- a/safe/report/extractors/aggregate_postprocessors.py
+++ b/safe/report/extractors/aggregate_postprocessors.py
@@ -540,7 +540,7 @@ def create_section_with_aggregation(
 
         row_values.append(row)
 
-    """Generating total rows ."""
+    """Generating total rows."""
 
     total_displaced_field_name = analysis_layer_fields[
         displaced_field['key']]

--- a/safe/utilities/i18n.py
+++ b/safe/utilities/i18n.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-"""Functions to translate a word or to get the locale   ."""
+"""Functions to translate a word or to get the locale."""
 
 import logging
 

--- a/safe/utilities/pivot_table.py
+++ b/safe/utilities/pivot_table.py
@@ -305,7 +305,7 @@ class PivotTable(object):
             self.total_percent_affected = None
 
     def __repr__(self):
-        """ Dump object content in a readable format ."""
+        """Dump object content in a readable format."""
         pivot = '<PivotTable ' \
                 'total=%f\n ' \
                 'total_rows=%s\n ' \

--- a/safe/utilities/test/test_osm_downloader.py
+++ b/safe/utilities/test/test_osm_downloader.py
@@ -58,7 +58,7 @@ class MockQNetworkReply(QObject):
 
     # noinspection PyDocstring,PyPep8Naming
     def isFinished(self):
-        """ simulate download progress ."""
+        """simulate download progress."""
         self.progress += 1
         # noinspection PyUnresolvedReferences
         self.readyRead.emit()


### PR DESCRIPTION
From `""" ([a-zA-Z .]*)"""` to `"""$1"""`
From `"""([a-zA-Z ]*) ."""` to `"""$1."""`
From `"""([a-zA-Z ]*)"""` to `"""$1."""`

### What does it fix?
* Ticket: #
* Funded by: DFAT
* Description: Cleaning docstrings with regexp

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
