### PR TITLE
trying to remove "message" from exception

### DIFF
--- a/safe/common/exceptions.py
+++ b/safe/common/exceptions.py
@@ -31,36 +31,28 @@ class InaSAFEError(RuntimeError):
     suggestion = 'An unspecified error occurred.'
 
     def __init__(self, message=None):
-        """"General constructor.
+        """General constructor.
 
         :param message: The optional error message.
         :type message: str, unicode, MessageElement
-        """""
+        """
         if isinstance(message, unicode):
             super(InaSAFEError, self).__init__(get_string(message))
-            self.message = message
 
         elif isinstance(message, str):
             super(InaSAFEError, self).__init__(message)
-            self.message = get_unicode(message)
 
         elif isinstance(message, MessageElement):
             super(InaSAFEError, self).__init__(message.to_text())
-            self.message = get_unicode(message.to_text())
 
         elif message is None:
             pass
 
         elif isinstance(message, BaseException):
-            super(InaSAFEError, self).__init__(unicode(message))
-            self.message = unicode(message)
+            super(InaSAFEError, self).__init__(get_unicode(message))
         # This shouldn't happen...
         else:
             raise TypeError
-
-    def __unicode__(self):
-        """Get the error message as unicode."""
-        return self.message
 
 
 class ReadLayerError(InaSAFEError):

--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -390,7 +390,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
                     display_warning_message_box(
                         self,
                         error_dialog_title,
-                        exception.message)
+                        unicode(exception))
             self.done(QDialog.Accepted)
             self.rectangle_map_tool.reset()
 
@@ -401,7 +401,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         except Exception as exception:  # pylint: disable=broad-except
             # noinspection PyCallByClass,PyTypeChecker,PyArgumentList
             display_warning_message_box(
-                self, error_dialog_title, exception.message)
+                self, error_dialog_title, unicode(exception))
 
             self.progress_dialog.cancel()
 

--- a/sideci.yml
+++ b/sideci.yml
@@ -1,0 +1,2 @@
+flake8:
+  version: 2


### PR DESCRIPTION
https://stackoverflow.com/questions/1272138/baseexception-message-deprecated-in-python-2-6

### What does it fix?
* Ticket: #
* Funded by: DFAT
* Description: A little step forward to Python 3 maybe

While I'm debugging, I have some python warnings.

We still have some `exception.message` where we write on our `Message` object. I guess it's not so good but I'm not sure how to remove these.

it seems the message is already included in the constructor.

I'm not sure about this.

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
