### PR TITLE
Another Profile Polishing

### DIFF
--- a/safe/definitions/test/test_utilities.py
+++ b/safe/definitions/test/test_utilities.py
@@ -568,7 +568,7 @@ class TestDefinitionsUtilities(unittest.TestCase):
         qsettings.clear()
         # Save the default profile to qsettings
         default_profile = generate_default_profile()
-        set_setting('profile', default_profile, qsettings)
+        set_setting('population_preference', default_profile, qsettings)
 
         # Check the default one first
         default_profile = generate_default_profile()
@@ -598,7 +598,7 @@ class TestDefinitionsUtilities(unittest.TestCase):
         default_profile[
             hazard_flood['key']][flood_hazard_classes['key']][class_key][
             'displacement_rate'] = 1
-        set_setting('profile', default_profile, qsettings)
+        set_setting('population_preference', default_profile, qsettings)
         value = get_displacement_rate(
             hazard_flood['key'],
             flood_hazard_classes['key'],
@@ -611,7 +611,7 @@ class TestDefinitionsUtilities(unittest.TestCase):
         default_profile[
             hazard_flood['key']][flood_hazard_classes['key']][class_key][
             'affected'] = new_affected
-        set_setting('profile', default_profile, qsettings)
+        set_setting('population_preference', default_profile, qsettings)
         value = is_affected(
             hazard_flood['key'],
             flood_hazard_classes['key'],

--- a/safe/definitions/utilities.py
+++ b/safe/definitions/utilities.py
@@ -665,7 +665,9 @@ def get_displacement_rate(
     if not is_affected(hazard, classification, hazard_class, qsettings):
         return 0
     preference_data = setting(
-        'profile', default=generate_default_profile(), qsettings=qsettings)
+        'population_preference',
+        default=generate_default_profile(),
+        qsettings=qsettings)
     # noinspection PyUnresolvedReferences
     return preference_data.get(hazard, {}).get(classification, {}).get(
         hazard_class, {}).get('displacement_rate', 0)
@@ -691,7 +693,9 @@ def is_affected(hazard, classification, hazard_class, qsettings=None):
     :rtype: bool
     """
     preference_data = setting(
-        'profile', default=generate_default_profile(), qsettings=qsettings)
+        'population_preference',
+        default=generate_default_profile(),
+        qsettings=qsettings)
     # noinspection PyUnresolvedReferences
     return preference_data.get(hazard, {}).get(classification, {}).get(
         hazard_class, {}).get('affected', False)

--- a/safe/gui/tools/options_dialog.py
+++ b/safe/gui/tools/options_dialog.py
@@ -713,7 +713,7 @@ class OptionsDialog(QDialog, FORM_CLASS):
         if global_default:
             data = generate_default_profile()
         else:
-            data = setting('profile', generate_default_profile())
+            data = setting('population_preference', generate_default_profile())
         self.profile_widget.data = data
 
     @staticmethod
@@ -836,7 +836,7 @@ class OptionsDialog(QDialog, FORM_CLASS):
     def save_profile_preference(self):
         """Helper to save profile to QSettings."""
         profile_data = self.profile_widget.data
-        set_setting('profile', profile_data)
+        set_setting('population_preference', profile_data)
 
     def set_welcome_message(self):
         """Create and insert welcome message."""

--- a/safe/gui/ui/options_dialog_base.ui
+++ b/safe/gui/ui/options_dialog_base.ui
@@ -188,35 +188,52 @@
             </layout>
            </item>
            <item>
-            <widget class="QLabel" name="organisation_logo_label">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>358</width>
-               <height>85</height>
-              </size>
-             </property>
-             <property name="baseSize">
-              <size>
-               <width>358</width>
-               <height>83</height>
-              </size>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::Box</enum>
-             </property>
-             <property name="text">
-              <string>Logo</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignCenter</set>
-             </property>
-            </widget>
+            <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <item>
+              <widget class="QLabel" name="logo_preview_label">
+               <property name="minimumSize">
+                <size>
+                 <width>210</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Logo Preview</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="organisation_logo_label">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>358</width>
+                 <height>85</height>
+                </size>
+               </property>
+               <property name="baseSize">
+                <size>
+                 <width>358</width>
+                 <height>83</height>
+                </size>
+               </property>
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="text">
+                <string>Logo</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item>
             <layout class="QHBoxLayout" name="horizontalLayoutOrganisationProfile_2">

--- a/safe/gui/widgets/profile_widget.py
+++ b/safe/gui/widgets/profile_widget.py
@@ -141,17 +141,25 @@ class PercentageSpinBox(QDoubleSpinBox):
     def __init__(self, parent):
         """Constructor."""
         super(PercentageSpinBox, self).__init__(parent)
-        self.setRange(0.0, 1.0)
-        self.setSingleStep(0.01)
-        # noinspection PyUnresolvedReferences
+        self.setRange(0.0, 100.0)
+        self.setSingleStep(0.1)
+        self.setDecimals(1)
+        self.setSuffix(' %')
 
-    def textFromValue(self, value):
-        """Modify text representation to get percentage representation.
+    def setValue(self, p_float):
+        """Override method to set a value to show it as 0 to 100.
 
-        :param value: The real value.
-        :type value: float
-
-        :returns: The percentage representation.
-        :rtype: str
+        :param p_float: The float number that want to be set.
+        :type p_float: float
         """
-        return '%d %%' % (value * 100)
+        p_float = p_float * 100
+
+        super(PercentageSpinBox, self).setValue(p_float)
+
+    def value(self):
+        """Override method to get a value to to 0.0 to 1.0
+
+        :returns: The float number that want to be set.
+        :rtype: float
+        """
+        return super(PercentageSpinBox, self).value() / 100

--- a/safe/gui/widgets/test/profile_widget_example.py
+++ b/safe/gui/widgets/test/profile_widget_example.py
@@ -19,24 +19,25 @@ __email__ = "info@inasafe.org"
 __revision__ = '$Format:%H$'
 
 
+# noinspection PyUnresolvedReferences
 def main():
     """Main function to run the example."""
-    def print_values(profile_widget):
-        data = profile_widget.data
+    def print_values(the_profile_widget):
+        data = the_profile_widget.data
         from pprint import pprint
         pprint(data)
 
-    def clear_widget(profile_widget):
-        profile_widget.clear()
+    def clear_widget(the_profile_widget):
+        the_profile_widget.clear()
 
-    def restore_data(profile_widget):
-        profile_widget.clear()
-        profile_widget.data = generate_default_profile()
+    def restore_data(the_profile_widget):
+        the_profile_widget.clear()
+        the_profile_widget.data = generate_default_profile()
 
     app = QApplication([])
 
     default_profile = generate_default_profile()
-    profile_widget = ProfileWidget(parent=PARENT)
+    profile_widget = ProfileWidget(parent=PARENT, data=default_profile)
 
     get_result_button = QPushButton('Get result...')
     get_result_button.clicked.connect(

--- a/safe/report/test/test_impact_report.py
+++ b/safe/report/test/test_impact_report.py
@@ -106,10 +106,10 @@ class TestImpactReport(unittest.TestCase):
             'displacement_rate'] = self.custom_displacement_rate
 
         # Preserve profile from setting
-        self.original_profile = setting(key='profile', default='NO_PROFILE')
+        self.original_profile = setting(key='population_preference', default='NO_PROFILE')
         # Set new profile in the QSettings
         current_profile = generate_default_profile()
-        set_setting(key='profile', value=current_profile)
+        set_setting(key='population_preference', value=current_profile)
 
     def tearDown(self):
         """Executed after test method."""
@@ -119,9 +119,9 @@ class TestImpactReport(unittest.TestCase):
 
         # Set the profile to the original one
         if self.original_profile == 'NO_PROFILE':
-            delete_setting('profile')
+            delete_setting('population_preference')
         else:
-            set_setting('profile', self.original_profile)
+            set_setting('population_preference', self.original_profile)
 
     def run_impact_report_scenario(
             self, output_folder,

--- a/safe/utilities/test/test_settings.py
+++ b/safe/utilities/test/test_settings.py
@@ -105,17 +105,17 @@ class TestSettings(unittest.TestCase):
         self.assertDictEqual(dictionary, value)
 
         profile_dictionary = generate_default_profile()
-        set_setting('profile', profile_dictionary, self.qsettings)
-        value = setting('profile', qsettings=self.qsettings)
+        set_setting('population_preference', profile_dictionary, self.qsettings)
+        value = setting('population_preference', qsettings=self.qsettings)
         self.assertDictEqual(profile_dictionary, value)
 
     def test_export_import_setting(self):
         """Test for export_setting method."""
-        profile_file = unique_filename(suffix='.json', dir='profile')
+        profile_file = unique_filename(suffix='.json', dir='population_preference')
         original_settings = {
             'key': 'value',
             'key_bool': True,
-            'profile': generate_default_profile(),
+            'population_preference': generate_default_profile(),
             'key_int': 1,
             'key_float': 2.0
         }
@@ -128,7 +128,7 @@ class TestSettings(unittest.TestCase):
         self.assertTrue(os.path.exists(profile_file))
         self.assertEqual(inasafe_settings['key'], 'value')
         self.assertEqual(
-            inasafe_settings['profile'], generate_default_profile())
+            inasafe_settings['population_preference'], generate_default_profile())
         # Import
         read_setting = import_setting(profile_file, self.qsettings)
         self.assertDictEqual(inasafe_settings, read_setting)


### PR DESCRIPTION
### What does it fix?
* Ticket: #4482 
* Funded by: DFAT
* Description: 
  - Move logo preview
     <img width="1000" alt="screen shot 2017-11-01 at 22 07 49" src="https://user-images.githubusercontent.com/1421861/32281698-2f87ced4-bf52-11e7-80c4-f13d52e98186.png">
  - Use percentage properly in preference spin box
     <img width="1010" alt="screen shot 2017-11-01 at 22 04 21" src="https://user-images.githubusercontent.com/1421861/32281697-2f4f24d0-bf52-11e7-9a92-ff3469531624.png">
  - Use `population_preference` to make it explicit in the QSetting (previously only `profile`)

### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR
