### PR TITLE
Keep extra keywords fix #4601.

### DIFF
--- a/safe/gui/tools/wizard/test/test_keyword_wizard.py
+++ b/safe/gui/tools/wizard/test/test_keyword_wizard.py
@@ -556,6 +556,10 @@ class TestKeywordWizard(unittest.TestCase):
                         u'classes': default_classes
                     }
                 }
+            },
+            'extra_keywords': {
+                'depth': 10,
+                'magnitude': 7.8
             }
         }
 
@@ -563,7 +567,7 @@ class TestKeywordWizard(unittest.TestCase):
 
         # noinspection PyTypeChecker
         dialog = WizardDialog(iface=IFACE)
-        dialog.set_keywords_creation_mode(layer)
+        dialog.set_keywords_creation_mode(layer, keywords)
 
         # Check if in select purpose step
         self.check_current_step(dialog.step_kw_purpose)
@@ -682,6 +686,8 @@ class TestKeywordWizard(unittest.TestCase):
 
         self.assertDictEqual(
             keywords['value_maps'], dialog.get_keywords()['value_maps'])
+
+        self.assertDictEqual(keywords, dialog.get_keywords())
 
     def test_exposure_structure_polygon_keyword(self):
         """Test keyword wizard for exposure structure polygon."""

--- a/safe/gui/tools/wizard/wizard_dialog.py
+++ b/safe/gui/tools/wizard/wizard_dialog.py
@@ -286,7 +286,7 @@ class WizardDialog(QDialog, FORM_CLASS):
                     InvalidParameterError,
                     UnsupportedProviderError,
                     MetadataReadError):
-                self.existing_keywords = None
+                self.existing_keywords = {}
         self.set_mode_label_to_keywords_creation()
 
         step = self.step_kw_purpose
@@ -832,6 +832,11 @@ class WizardDialog(QDialog, FORM_CLASS):
 
         if inasafe_default_values:
             keywords['inasafe_default_values'] = inasafe_default_values
+
+        # Do not update extra keywords
+        extra_keywords = self.existing_keywords.get('extra_keywords')
+        if extra_keywords:
+            keywords['extra_keywords'] = extra_keywords
 
         return keywords
 


### PR DESCRIPTION
### What does it fix?
* Ticket: #4601 
* Funded by: DFAT
* Description: 
   - Keep extra keywords when assigning keywords with wizard
   - (Note) Perhaps we need another step to add extra keywords in the wizard. Not for current release of course.

### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR
