### PR TITLE
avoid two prepare steps in multiIF, use selected areas when we clone a layer

### DIFF
--- a/safe/impact_function/multi_exposure_wrapper.py
+++ b/safe/impact_function/multi_exposure_wrapper.py
@@ -472,12 +472,8 @@ class MultiExposureImpactFunction(object):
             self.datastore.uri_path)
 
         # CRS
-        if self._crs:
-            set_provenance(
-                self._provenance, provenance_crs, self._crs.authid())
-        else:
-            set_provenance(
-                self._provenance, provenance_crs, None)
+        set_provenance(
+            self._provenance, provenance_crs, self._crs.authid())
 
         # Debug mode
         set_provenance(

--- a/safe/impact_function/multi_exposure_wrapper.py
+++ b/safe/impact_function/multi_exposure_wrapper.py
@@ -92,7 +92,7 @@ from safe.impact_function.impact_function_utilities import check_input_layer
 from safe.impact_function.style import simple_polygon_without_brush
 from safe.report.impact_report import ImpactReport
 from safe.report.report_metadata import ReportMetadata
-from safe.utilities.gis import deep_duplicate_layer
+from safe.utilities.gis import clone_layer
 from safe.utilities.i18n import tr
 from safe.utilities.gis import qgis_version
 from safe.utilities.metadata import (
@@ -712,13 +712,13 @@ class MultiExposureImpactFunction(object):
         for exposure in self._exposures:
             impact_function = ImpactFunction()
             impact_function.debug_mode = self.debug_mode
-            impact_function.hazard = deep_duplicate_layer(self._hazard)
+            impact_function.hazard = clone_layer(self._hazard)
             impact_function.exposure = exposure
             impact_function.debug_mode = self.debug
             if self.callback:
                 impact_function.callback = self.callback
             if self._aggregation:
-                impact_function.aggregation = deep_duplicate_layer(
+                impact_function.aggregation = clone_layer(
                     self._aggregation)
                 impact_function.use_selected_features_only = (
                     self.use_selected_features_only)

--- a/safe/impact_function/test/test_impact_function.py
+++ b/safe/impact_function/test/test_impact_function.py
@@ -704,6 +704,9 @@ class TestImpactFunction(unittest.TestCase):
         # counted in the JSON file.
         self.assertEqual(len(outputs) - 1, expected_outputs['count'])
         self.assertEqual(len(outputs), computed_nb_outputs)
+        self.assertEqual(
+            impact_function.crs.authid(),
+            impact_function.impact.crs().authid())
 
         # Test deserialization
         if test_loader:

--- a/safe/test/data/scenario/earthquake_raster_on_raster_population.json
+++ b/safe/test/data/scenario/earthquake_raster_on_raster_population.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:4326"
+      },
       "process":[
         "Zonal stats between exposure and aggregate hazard",
         "Add default values",

--- a/safe/test/data/scenario/earthquake_raster_on_vector_places.json
+++ b/safe/test/data/scenario/earthquake_raster_on_vector_places.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:4326"
+      },
       "process":[
         "Highest class of hazard is assigned to the exposure",
         "Aggregate the impact summary",

--- a/safe/test/data/scenario/earthquake_raster_on_vector_population.json
+++ b/safe/test/data/scenario/earthquake_raster_on_vector_population.json
@@ -12,7 +12,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:4326"
+      },
       "process":[
         "Make aggregate hazard layer valid",
         "Intersect divisible features with the aggregate hazard",

--- a/safe/test/data/scenario/polygon_classified_on_line.json
+++ b/safe/test/data/scenario/polygon_classified_on_line.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:4326"
+      },
       "process":[
         "Make aggregate hazard layer valid",
         "Intersect divisible features with the aggregate hazard",

--- a/safe/test/data/scenario/polygon_classified_on_point.json
+++ b/safe/test/data/scenario/polygon_classified_on_point.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:4326"
+      },
       "process":[
         "Highest class of hazard is assigned to the exposure",
         "Aggregate the impact summary",

--- a/safe/test/data/scenario/polygon_classified_on_vector_population.json
+++ b/safe/test/data/scenario/polygon_classified_on_vector_population.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:4326"
+      },
       "process":[
         "Make aggregate hazard layer valid",
         "Intersect divisible features with the aggregate hazard",

--- a/safe/test/data/scenario/polygon_classified_on_vector_population_multi_fields.json
+++ b/safe/test/data/scenario/polygon_classified_on_vector_population_multi_fields.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:4326"
+      },
       "process":[
         "Make aggregate hazard layer valid",
         "Intersect divisible features with the aggregate hazard",

--- a/safe/test/data/scenario/polygon_continuous_on_line.json
+++ b/safe/test/data/scenario/polygon_continuous_on_line.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:4326"
+      },
       "process":[
         "Make aggregate hazard layer valid",
         "Intersect divisible features with the aggregate hazard",

--- a/safe/test/data/scenario/raster_classified_on_classified_raster.json
+++ b/safe/test/data/scenario/raster_classified_on_classified_raster.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:4326"
+      },
       "process":[
         "Make aggregate hazard layer valid",
         "Intersect divisible features with the aggregate hazard",

--- a/safe/test/data/scenario/raster_classified_on_indivisible_polygons_with_grid.json
+++ b/safe/test/data/scenario/raster_classified_on_indivisible_polygons_with_grid.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:3857"
+      },
       "process":[
         "Highest class of hazard is assigned to the exposure",
         "Aggregate the impact summary",

--- a/safe/test/data/scenario/raster_classified_on_line_with_grid.json
+++ b/safe/test/data/scenario/raster_classified_on_line_with_grid.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:3857"
+      },
       "process":[
         "Make aggregate hazard layer valid",
         "Intersect divisible features with the aggregate hazard",

--- a/safe/test/data/scenario/raster_classified_on_vector_population_multi_fields.json
+++ b/safe/test/data/scenario/raster_classified_on_vector_population_multi_fields.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:4326"
+      },
       "process":[
         "Make aggregate hazard layer valid",
         "Intersect divisible features with the aggregate hazard",

--- a/safe/test/data/scenario/raster_continuous_on_divisible_polygons_with_grid.json
+++ b/safe/test/data/scenario/raster_continuous_on_divisible_polygons_with_grid.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:3857"
+      },
       "process":[
         "Make aggregate hazard layer valid",
         "Intersect divisible features with the aggregate hazard",

--- a/safe/test/data/scenario/raster_continuous_on_line.json
+++ b/safe/test/data/scenario/raster_continuous_on_line.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:4326"
+      },
       "process":[
         "Make aggregate hazard layer valid",
         "Intersect divisible features with the aggregate hazard",

--- a/safe/test/data/scenario/raster_continuous_on_raster_population.json
+++ b/safe/test/data/scenario/raster_continuous_on_raster_population.json
@@ -11,7 +11,9 @@
   },
   "expected_steps":{
     "impact function":{
-      "info": {},
+      "info": {
+        "crs": "EPSG:3857"
+      },
       "process":[
         "Zonal stats between exposure and aggregate hazard",
         "Add default values",


### PR DESCRIPTION
### What does it fix?
* Ticket: #4638
* Funded by: DFAT
* Description: 
  * avoid two prepare steps in multi exposure
  * use selected areas when we clone a layer
  * improve output CRS in impact function

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR