### PR TITLE
set requested extent as wkt polygon

### DIFF
--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -2509,7 +2509,7 @@ class ImpactFunction(object):
             set_provenance(
                 self._provenance,
                 provenance_requested_extent,
-                self.requested_extent.asWktCoordinates())
+                self.requested_extent.asWktPolygon())
         else:
             set_provenance(
                 self._provenance,


### PR DESCRIPTION
### What does it fix?
* Ticket: #4652 
* Funded by: DFAT
* Description: previously the requested extent provenance are stored as a wkt coordinates

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
