### PR TITLE
Use percentage spinbox for demographic default.

### DIFF
--- a/safe/common/parameters/percentage_parameter_widget.py
+++ b/safe/common/parameters/percentage_parameter_widget.py
@@ -28,6 +28,10 @@ class PercentageParameterWidget(FloatParameterWidget):
 
         self._input = PercentageSpinBox(self)
         self._input.setValue(self._parameter.value)
+        if 1 > self._parameter.minimum_allowed_value > 0:
+            self._input.setMinimum(self._parameter.minimum_allowed_value)
+        if 1 > self._parameter.maximum_allowed_value > 0:
+            self._input.setMaximum(self._parameter.maximum_allowed_value)
         self._input.setSizePolicy(self._spin_box_size_policy)
 
         self.inner_input_layout.addWidget(self._input)

--- a/safe/common/parameters/percentage_parameter_widget.py
+++ b/safe/common/parameters/percentage_parameter_widget.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+"""Percentage Parameter Widget."""
+from PyQt4.QtGui import QDoubleSpinBox
+
+from parameters.qt_widgets.float_parameter_widget import FloatParameterWidget
+
+__copyright__ = "Copyright 2017, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
+
+
+class PercentageParameterWidget(FloatParameterWidget):
+
+    """Percentage Parameter Widget."""
+
+    def __init__(self, parameter, parent=None):
+        """Constructor
+
+        :param parameter: A FloatParameter object.
+        :type parameter: FloatParameter
+        """
+        super(FloatParameterWidget, self).__init__(parameter, parent)
+
+        self.inner_input_layout.removeWidget(self._input)
+        self._input.deleteLater()
+        self.inner_input_layout.removeWidget(self._unit_widget)
+
+        self._input = PercentageSpinBox(self)
+        self._input.setValue(self._parameter.value)
+        self._input.setSizePolicy(self._spin_box_size_policy)
+
+        self.inner_input_layout.addWidget(self._input)
+        self.inner_input_layout.addWidget(self._unit_widget)
+
+
+class PercentageSpinBox(QDoubleSpinBox):
+
+    """Custom Spinbox for percentage 0 % - 100 %."""
+
+    def __init__(self, parent):
+        """Constructor."""
+        super(PercentageSpinBox, self).__init__(parent)
+        self.setRange(0.0, 100.0)
+        self.setSingleStep(0.1)
+        self.setDecimals(1)
+        self.setSuffix(' %')
+
+    def setValue(self, p_float):
+        """Override method to set a value to show it as 0 to 100.
+
+        :param p_float: The float number that want to be set.
+        :type p_float: float
+        """
+        p_float = p_float * 100
+
+        super(PercentageSpinBox, self).setValue(p_float)
+
+    def value(self):
+        """Override method to get a value to to 0.0 to 1.0
+
+        :returns: The float number that want to be set.
+        :rtype: float
+        """
+        return super(PercentageSpinBox, self).value() / 100

--- a/safe/common/parameters/test/test_percentage_parameter_widget.py
+++ b/safe/common/parameters/test/test_percentage_parameter_widget.py
@@ -1,0 +1,110 @@
+# coding=utf-8
+"""Test class for percentage_parameter_widget."""
+
+import unittest
+from parameters.float_parameter import FloatParameter
+from safe.common.parameters.percentage_parameter_widget import (
+    PercentageSpinBox,
+    PercentageParameterWidget,
+)
+
+from safe.test.utilities import get_qgis_app
+
+QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
+
+__copyright__ = "Copyright 2016, The InaSAFE Project"
+__license__ = "GPL version 3"
+__email__ = "info@inasafe.org"
+__revision__ = '$Format:%H$'
+
+
+class TestPercentageParameterWidget(unittest.TestCase):
+
+    """Test for PercentageParameterWidget."""
+
+    def test_init(self):
+        """Test init."""
+
+        float_parameter = FloatParameter()
+        float_parameter.name = 'Female Ratio.'
+        float_parameter.is_required = True
+        float_parameter.minimum_allowed_value = 0
+        float_parameter.maximum_allowed_value = 1
+        float_parameter.help_text = 'The percentage of female..'
+        float_parameter.description = (
+            'A <b>test _description</b> that is very long so that you need '
+            'to read it for one minute and you will be tired after read this '
+            'description. You are the best user so far. Even better if you '
+            'read this description loudly so that all of your friends will be '
+            'able to hear you')
+        float_parameter.value = 0.5
+
+        widget = PercentageParameterWidget(float_parameter)
+
+        expected_value = float_parameter.name
+        real_value = widget.label.text()
+        message = 'Expected %s get %s' % (expected_value, real_value)
+        self.assertEqual(expected_value, real_value, message)
+
+        expected_value = float_parameter.value
+        real_value = widget.get_parameter().value
+        message = 'Expected %s get %s' % (expected_value, real_value)
+        self.assertEqual(expected_value, real_value, message)
+
+        widget._input.setValue(1.5)
+
+        expected_value = 1
+        real_value = widget.get_parameter().value
+        message = 'Expected %s get %s' % (expected_value, real_value)
+        self.assertEqual(expected_value, real_value, message)
+
+        widget._input.setValue(0.55555)
+
+        expected_value = 0.556
+        real_value = widget.get_parameter().value
+        message = 'Expected %s get %s' % (expected_value, real_value)
+        self.assertEqual(expected_value, real_value, message)
+
+        widget._input.setValue(-7)
+
+        expected_value = 0
+        real_value = widget.get_parameter().value
+        message = 'Expected %s get %s' % (expected_value, real_value)
+        self.assertEqual(expected_value, real_value, message)
+
+        expected_value = 'PercentageSpinBox'
+        real_value = widget._input.__class__.__name__
+        message = 'Expected %s get %s' % (expected_value, real_value)
+        self.assertEqual(expected_value, real_value, message)
+
+    def test_percentage_spinbox(self):
+        """Test percentage spinbox class."""
+        spin_box = PercentageSpinBox(PARENT)
+        decimal_separator = spin_box.locale().decimalPoint()
+        spin_box.setValue(0.5)
+        expected = '50.0 %'.replace('.', decimal_separator)
+        self.assertEqual(spin_box.text(), expected)
+        self.assertEqual(spin_box.value(), 0.5)
+
+        spin_box.setValue(10)
+        expected = '100.0 %'.replace('.', decimal_separator)
+        self.assertEqual(spin_box.text(), expected)
+        self.assertEqual(spin_box.value(), 1)
+
+        spin_box.setValue(-1)
+        expected = '0.0 %'.replace('.', decimal_separator)
+        self.assertEqual(spin_box.text(), expected)
+        self.assertEqual(spin_box.value(), 0)
+
+        spin_box.setValue(0.112357)
+        expected = '11.2 %'.replace('.', decimal_separator)
+        self.assertEqual(spin_box.text(), expected)
+        self.assertAlmostEqual(spin_box.value(), 0.112)
+
+
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/safe/gui/tools/options_dialog.py
+++ b/safe/gui/tools/options_dialog.py
@@ -43,6 +43,12 @@ from safe.utilities.settings import (
     setting,
     set_setting,
 )
+from safe.common.parameters.percentage_parameter_widget import (
+    PercentageParameterWidget)
+
+extra_parameter = [
+    (FloatParameter, PercentageParameterWidget)
+]
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -694,7 +700,9 @@ class OptionsDialog(QDialog, FORM_CLASS):
                 if parameter:
                     parameters.append(parameter)
             parameter_container = ParameterContainer(
-                parameters, description_text=field_group['description']
+                parameters,
+                description_text=field_group['description'],
+                extra_parameters=extra_parameter
             )
             parameter_container.setup_ui(must_scroll=False)
             group_box_inner_layout = QVBoxLayout()
@@ -716,7 +724,9 @@ class OptionsDialog(QDialog, FORM_CLASS):
                 'these variables.')
             parameter_container = ParameterContainer(
                 self.default_value_parameters,
-                description_text=description_text)
+                description_text=description_text,
+                extra_parameters=extra_parameter
+            )
             parameter_container.setup_ui(must_scroll=False)
             self.other_group_box = QGroupBox(tr('Non-group fields'))
             other_group_inner_layout = QVBoxLayout()

--- a/safe/gui/widgets/profile_widget.py
+++ b/safe/gui/widgets/profile_widget.py
@@ -8,11 +8,12 @@ from PyQt4.QtGui import (
     QTreeWidget,
     QTreeWidgetItem,
     QCheckBox,
-    QDoubleSpinBox,
     QFont,
     QHeaderView,
 )
 
+from safe.common.parameters.percentage_parameter_widget import (
+    PercentageSpinBox)
 from safe.definitions.utilities import get_name, get_class_name
 from safe.utilities.i18n import tr
 
@@ -141,34 +142,3 @@ class ProfileWidget(QTreeWidget, object):
         """Clear method to clear the widget items and the tree widget."""
         super(ProfileWidget, self).clear()
         self.widget_items = []
-
-
-class PercentageSpinBox(QDoubleSpinBox):
-
-    """Custom Spinbox for percentage 0 % - 100 %."""
-
-    def __init__(self, parent):
-        """Constructor."""
-        super(PercentageSpinBox, self).__init__(parent)
-        self.setRange(0.0, 100.0)
-        self.setSingleStep(0.1)
-        self.setDecimals(1)
-        self.setSuffix(' %')
-
-    def setValue(self, p_float):
-        """Override method to set a value to show it as 0 to 100.
-
-        :param p_float: The float number that want to be set.
-        :type p_float: float
-        """
-        p_float = p_float * 100
-
-        super(PercentageSpinBox, self).setValue(p_float)
-
-    def value(self):
-        """Override method to get a value to to 0.0 to 1.0
-
-        :returns: The float number that want to be set.
-        :rtype: float
-        """
-        return super(PercentageSpinBox, self).value() / 100


### PR DESCRIPTION
### What does it fix?
* Ticket: #4682 #4145 #4508 
* Funded by: DFAT
* Description: 
   - Use percentage widget for demographic default.

    <img width="1195" alt="screen shot 2017-11-28 at 08 32 47" src="https://user-images.githubusercontent.com/1421861/33298103-192935fe-d417-11e7-9dbb-c43437d8ca30.png">


### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [x] Unit test for new code added
- [x] Request someone to review or test your PR
