### PR TITLE
allow population exposure to be point dataset

### DIFF
--- a/safe/definitions/exposure.py
+++ b/safe/definitions/exposure.py
@@ -161,6 +161,7 @@ exposure_population = {
         }
     ],
     'allowed_geometries': [
+        'point',  # See feature request #4592
         'polygon',
         'raster'
     ],


### PR DESCRIPTION
### What does it fix?
* Ticket: #4592 
* Funded by: DFAT
* Description: allow population exposure to be point dataset

I tested locally with a point datatset, it works.

@Charlotte-Morgan Is-it all fine?

### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR