### PR TITLE
Fix #4734, update dock after updating option.

### DIFF
--- a/safe/plugin.py
+++ b/safe/plugin.py
@@ -789,6 +789,9 @@ class Plugin(object):
             self.dock_widget.read_settings()
             from safe.gui.widgets.message import getting_started_message
             send_static_message(self.dock_widget, getting_started_message())
+            # Issue #4734, make sure to update the combobox after update the
+            # InaSAFE option
+            self.dock_widget.get_layers()
 
     def show_welcome_message(self):
         """Show the welcome message."""


### PR DESCRIPTION
### What does it fix?
* Ticket: #4734
* Funded by: DFAT
* Description: 
   The issue is after updating option for using hiden layer also, the dock is not immediately updated. We need to trigger it manually. This PR triggers it automatically.
  Before applying my PR:
![pre_option_update](https://user-images.githubusercontent.com/1421861/33803163-853b3eba-ddbb-11e7-9762-1cfc414a3a3b.gif)

   After applying my PR:
![after_option_update](https://user-images.githubusercontent.com/1421861/33803304-26ed59f2-ddbf-11e7-96dd-d86a61c0eb9f.gif)

### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR
