### PR TITLE
Use generic as key and special case for land cover exposure.

### DIFF
--- a/safe/utilities/metadata.py
+++ b/safe/utilities/metadata.py
@@ -28,11 +28,12 @@ from safe.definitions.layer_purposes import (
 from safe.definitions.layer_geometry import (
     layer_geometry_raster, layer_geometry_polygon
 )
-from safe.definitions.hazard import hazard_volcano
+from safe.definitions.hazard import hazard_volcano, hazard_generic
 from safe.definitions.exposure import (
     exposure_structure,
     exposure_road,
-    exposure_population
+    exposure_population,
+    exposure_land_cover
 )
 from safe.definitions.versions import inasafe_keyword_version
 from safe.metadata import (
@@ -400,6 +401,10 @@ def convert_metadata(keywords, **converter_parameters):
     for same_property in same_properties:
         if keywords.get(same_property):
             new_keywords[same_property] = keywords.get(same_property)
+            if same_property == layer_purpose_hazard['key']:
+                if keywords.get(same_property) == hazard_generic['key']:
+                    # We use hazard_generic as key for generic hazard
+                    new_keywords[same_property] = 'hazard_generic'
 
     # Mandatory keywords
     try:
@@ -423,7 +428,11 @@ def convert_metadata(keywords, **converter_parameters):
             elif exposure == exposure_road['key']:
                 new_keywords['road_class_field'] = exposure_class_field
             else:
-                new_keywords['field'] = exposure_class_field
+                if exposure == exposure_land_cover['key']:
+                    new_keywords['field'] = exposure_class_field
+                else:
+                    new_keywords['structure_class_field'] = (
+                        exposure_class_field)
         # Data type is only used in population exposure and in v4.x it is
         # always count
         if (exposure == exposure_population['key'] and layer_geometry ==

--- a/safe/utilities/test/test_metadata.py
+++ b/safe/utilities/test/test_metadata.py
@@ -572,7 +572,7 @@ class TestMetadataUtilities(unittest.TestCase):
         }
         expected_keyword = {
             'exposure': u'place',
-            'field': u'Type',
+            'structure_class_field': u'Type',
             'keyword_version': '3.5',
             'layer_geometry': u'point',
             'layer_mode': u'classified',


### PR DESCRIPTION
### What does it fix?
* Ticket: #4625 
* Funded by: DFAT
* Description: 
   - 3.5 use `generic` keyword for hazard key, but in 4.x we use `hazard_generic`, so I need to put an if.
   - Based on my diagram https://docs.google.com/spreadsheets/d/1AhfYz5ynpmnsibTiACILDc-l5GK7SVsG_0ueByyds2g/edit#gid=0 the land_cover put the field in `structure_class_field`, so I need to put another if.

### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR