### PR TITLE
avoid duplicate label in print dialog

### DIFF
--- a/safe/gui/ui/print_report_dialog.ui
+++ b/safe/gui/ui/print_report_dialog.ui
@@ -25,8 +25,8 @@
         <number>0</number>
        </property>
        <item row="0" column="0">
-        <widget class="QWebView" name="help_web_view" native="true">
-         <property name="url" stdset="0">
+        <widget class="QWebView" name="help_web_view">
+         <property name="url">
           <url>
            <string>about:blank</string>
           </url>
@@ -164,7 +164,7 @@
                 <bool>true</bool>
                </property>
                <property name="text">
-                <string>Do not print a map report</string>
+                <string>Do not print a map report.</string>
                </property>
               </widget>
              </item>
@@ -223,31 +223,38 @@
              <string>Tabular reports</string>
             </property>
             <layout class="QGridLayout" name="gridLayout_5">
-             <item row="0" column="0">
+             <item row="1" column="0">
               <widget class="QCheckBox" name="impact_summary_checkbox">
                <property name="text">
-                <string>Print impact summary report as PDF</string>
+                <string>Impact summary</string>
                </property>
               </widget>
              </item>
-             <item row="1" column="0">
+             <item row="2" column="0">
               <widget class="QCheckBox" name="action_checklist_checkbox">
                <property name="text">
-                <string>Print action-checklist report as PDF</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QCheckBox" name="provenance_checkbox">
-               <property name="text">
-                <string>Print provenance report as PDF</string>
+                <string>Action-checklist</string>
                </property>
               </widget>
              </item>
              <item row="4" column="0">
+              <widget class="QCheckBox" name="provenance_checkbox">
+               <property name="text">
+                <string>Provenance</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0">
               <widget class="QCheckBox" name="infographic_checkbox">
                <property name="text">
-                <string>Print infographic report as PDF</string>
+                <string>Infographic</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>Print report as PDF:</string>
                </property>
               </widget>
              </item>
@@ -283,7 +290,7 @@
   <customwidget>
    <class>QWebView</class>
    <extends>QWidget</extends>
-   <header>PyQt4.QtWebKit</header>
+   <header>QtWebKit/QWebView</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
### What does it fix?
* Ticket: #
* Funded by: DFAT
* Description: Remove the `print report as PDF`. I'm not a UX designer, but it's less words in the UI

Before:
![screen shot 2017-12-13 at 10 01 55](https://user-images.githubusercontent.com/1609292/33930425-2b92b440-dfed-11e7-8972-b7375ef9dd76.png)

After:
![screen shot 2017-12-13 at 10 03 38](https://user-images.githubusercontent.com/1609292/33930438-367714c8-dfed-11e7-8240-2791df2c34c3.png)


### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR