### PR TITLE
Fix #4778 also put missing hazard classification for all exposure.

### DIFF
--- a/safe/gui/widgets/profile_widget.py
+++ b/safe/gui/widgets/profile_widget.py
@@ -109,8 +109,10 @@ class ProfileWidget(QTreeWidget, object):
                 classification_definition = definition(classification)
                 supported_exposures = classification_definition.get(
                     'exposures', [])
-                if exposure_population not in supported_exposures:
-                    continue
+                # Empty list means support all exposure
+                if supported_exposures != []:
+                    if exposure_population not in supported_exposures:
+                        continue
                 classes = classifications[classification]
                 classification_widget_item = QTreeWidgetItem()
                 classification_widget_item.setData(


### PR DESCRIPTION
### What does it fix?
* Ticket: #4778 
* Funded by: DFAT
* Description: 
   - The population parameter doesn't show the hazard classification that doesn't `exposure` (it means it supports all exposures). So, it gets the wrong affected calculation.
   - You need to restore default classification to fix this error first @felix-yew 
   - Result:
<img width="502" alt="screen shot 2017-12-13 at 17 22 11" src="https://user-images.githubusercontent.com/1421861/33934002-309f8da4-e02a-11e7-80dc-0ce02435d8b6.png">

Future works (perhaps):
- Make sure all hazard classification write the supported exposure
- Get the default from the default one (currently set to False)
- Make a button to "Add" missing classification to avoid removing current profile.

### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR