### PR TITLE
Fix #4714 use default file for north arrow and logo expression.

### DIFF
--- a/safe/report/expressions/map_report.py
+++ b/safe/report/expressions/map_report.py
@@ -508,7 +508,9 @@ def inasafe_logo_white_path(feature, parent):
 
 
 description = tr(
-    'Retrieve the full path of default north arrow logo.')
+    'Retrieve the full path of user specified north arrow image. If the '
+    'custom north arrow logo is not found, it will return the default north '
+    'arrow image.')
 examples = {
     'north_arrow_path()': None
 }
@@ -528,13 +530,15 @@ def north_arrow_path(feature, parent):
     else:
         LOGGER.info(
             'The custom north arrow is not found in {north_arrow_file}. '
-            'Default organisation logo will be used.').format(
+            'Default north arrow will be used.').format(
             north_arrow_file=north_arrow_file)
         return inasafe_default_settings['north_arrow_path']
 
 
 description = tr(
-    'Retrieve the full path of used specified organisation logo.')
+    'Retrieve the full path of user specified organisation logo. If the '
+    'custom organisation logo is not found, it will return the default '
+    'organisation logo.')
 examples = {
     'organisation_logo_path()': None
 }

--- a/safe/report/expressions/map_report.py
+++ b/safe/report/expressions/map_report.py
@@ -2,6 +2,7 @@
 
 """QGIS Expressions which are available in the QGIS GUI interface."""
 
+import os
 from qgis.core import (
     qgsfunction,
     QgsCoordinateReferenceSystem,
@@ -35,9 +36,11 @@ from safe.definitions.reports.map_report import (
     inasafe_north_arrow_path,
     inasafe_organisation_logo_path,
     crs_text)
+from safe.definitions.default_settings import inasafe_default_settings
 from safe.utilities.i18n import tr
 from safe.utilities.utilities import generate_expression_help
 from safe.utilities.settings import setting
+from safe.common.custom_logging import LOGGER
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
 __license__ = "GPL version 3"
@@ -518,7 +521,16 @@ help_message = generate_expression_help(description, examples)
 def north_arrow_path(feature, parent):
     """Retrieve the full path of default north arrow logo."""
     _ = feature, parent  # NOQA
-    return setting(inasafe_north_arrow_path['setting_key'])
+
+    north_arrow_file = setting(inasafe_north_arrow_path['setting_key'])
+    if os.path.exists(north_arrow_file):
+        return north_arrow_file
+    else:
+        LOGGER.info(
+            'The custom north arrow is not found in {north_arrow_file}. '
+            'Default organisation logo will be used.').format(
+            north_arrow_file=north_arrow_file)
+        return inasafe_default_settings['north_arrow_path']
 
 
 description = tr(
@@ -535,4 +547,13 @@ help_message = generate_expression_help(description, examples)
 def organisation_logo_path(feature, parent):
     """Retrieve the full path of used specified organisation logo."""
     _ = feature, parent  # NOQA
-    return setting(inasafe_organisation_logo_path['setting_key'])
+    organisation_logo_file = setting(
+        inasafe_organisation_logo_path['setting_key'])
+    if os.path.exists(organisation_logo_file):
+        return organisation_logo_file
+    else:
+        LOGGER.info(
+            'The custom organisation logo is not found in {logo_path}. '
+            'Default organisation logo will be used.').format(
+            logo_path=organisation_logo_file)
+        return inasafe_default_settings['organisation_logo_path']


### PR DESCRIPTION
### What does it fix?
* Ticket: #4714 
* Funded by: DFAT
* Description: 
   - Use default north arrow and logo if the expression give not exist logo

### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR
