### PR TITLE
Add summarizer in analysis summary.

### DIFF
--- a/safe/test/data/gisv4/intermediate/aggregate_classified_hazard_summary.xml
+++ b/safe/test/data/gisv4/intermediate/aggregate_classified_hazard_summary.xml
@@ -199,7 +199,21 @@
             <gco:CharacterString/>
           </report>
           <inasafe_fields>
-            <gco:Dictionary>{&quot;education_exposure_count_field&quot;: &quot;education_count&quot;, &quot;health_exposure_count_field&quot;: &quot;health_count&quot;, &quot;government_exposure_count_field&quot;: &quot;government_count&quot;, &quot;total_field&quot;: &quot;total&quot;, &quot;residential_exposure_count_field&quot;: &quot;residential_count&quot;, &quot;hazard_class_field&quot;: &quot;hazard_class&quot;, &quot;hazard_id_field&quot;: &quot;hazard_id&quot;, &quot;aggregation_name_field&quot;: &quot;aggregation_name&quot;, &quot;commercial_exposure_count_field&quot;: &quot;commercial_count&quot;, &quot;aggregation_id_field&quot;: &quot;aggregation_id&quot;, &quot;affected_field&quot;: &quot;affected&quot;}</gco:Dictionary>
+            <gco:Dictionary>
+              {
+                &quot;education_exposure_count_field&quot;: &quot;education_count&quot;, 
+                &quot;health_exposure_count_field&quot;: &quot;health_count&quot;, 
+                &quot;government_exposure_count_field&quot;: &quot;government_count&quot;, 
+                &quot;total_field&quot;: &quot;total&quot;, 
+                &quot;residential_exposure_count_field&quot;: &quot;residential_count&quot;, 
+                &quot;hazard_class_field&quot;: &quot;hazard_class&quot;, 
+                &quot;hazard_id_field&quot;: &quot;hazard_id&quot;, 
+                &quot;aggregation_name_field&quot;: &quot;aggregation_name&quot;, 
+                &quot;commercial_exposure_count_field&quot;: &quot;commercial_count&quot;, 
+                &quot;aggregation_id_field&quot;: &quot;aggregation_id&quot;, 
+                &quot;affected_field&quot;: &quot;affected&quot;
+              }
+            </gco:Dictionary>
           </inasafe_fields>
           <inasafe_default_values>
             <gco:Dictionary/>


### PR DESCRIPTION
### What does it fix?
* Ticket: #4483 
* Funded by: DFAT
* Description: 
   - Add summarizer for extra attribute in for the analysis summary. This will make the report show correct number for total exposed for population in place.
     <img width="604" alt="screen shot 2018-01-02 at 09 25 58" src="https://user-images.githubusercontent.com/1421861/34472980-4914968e-ef9f-11e7-8217-b11e68ecf12b.png">


### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR
