### PR TITLE
Fix shrink text in print dialog in MacOS.

### DIFF
--- a/safe/gui/ui/print_report_dialog.ui
+++ b/safe/gui/ui/print_report_dialog.ui
@@ -10,8 +10,14 @@
     <x>0</x>
     <y>0</y>
     <width>551</width>
-    <height>533</height>
+    <height>690</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Impact report</string>
@@ -24,7 +30,16 @@
      </property>
      <widget class="QWidget" name="page">
       <layout class="QGridLayout" name="gridLayout_2">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item row="0" column="0">
@@ -40,7 +55,16 @@
      </widget>
      <widget class="QWidget" name="page_1">
       <layout class="QGridLayout" name="gridLayout_3">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item row="0" column="0">
@@ -51,6 +75,12 @@
          <layout class="QGridLayout" name="gridLayout">
           <item row="1" column="0">
            <widget class="QGroupBox" name="map_report_group">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="title">
              <string>Custom and map report</string>
             </property>
@@ -222,6 +252,12 @@
           </item>
           <item row="0" column="0">
            <widget class="QGroupBox" name="groupBox_3">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="title">
              <string>Tabular reports</string>
             </property>


### PR DESCRIPTION
### What does it fix?
* Ticket: No ticket
* Funded by: DFAT
* Description: 
  Before:
   <img width="637" alt="screen shot 2018-01-03 at 22 29 50" src="https://user-images.githubusercontent.com/1421861/34526633-a4f8ea2c-f0d5-11e7-8d1d-07e9d1d06816.png">
   After:
  <img width="667" alt="screen shot 2018-01-03 at 22 10 26" src="https://user-images.githubusercontent.com/1421861/34526516-4073222a-f0d5-11e7-8d33-9f3b9219b35e.png">


Please check how is it in Windows (@ivanbusthomi @samnawi @felix-yew @timlinux  ) and Ubuntu @myarjunar 

### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR