### PR TITLE
add rounding flag if dev mode

### DIFF
--- a/safe/definitions/provenance.py
+++ b/safe/definitions/provenance.py
@@ -204,6 +204,12 @@ provenance_crs = {
     'provenance_key': 'crs'
 }
 
+provenance_use_rounding = {
+    'key': 'provenance_use_rounding',
+    'name': tr('Use Rounding'),
+    'provenance_key': 'use_rounding'
+}
+
 provenance_debug_mode = {
     'key': 'provenance_debug_mode',
     'name': tr('Debug Mode'),

--- a/safe/gis/generic_expressions.py
+++ b/safe/gis/generic_expressions.py
@@ -96,7 +96,7 @@ def inasafe_place_value_name(number, feature, parent):
         return None
     rounded_number = round_affected_number(
         number,
-        enable_rounding=True,
+        use_rounding=True,
         use_population_rounding=True
     )
     value, unit = denomination(rounded_number, 1000)
@@ -133,7 +133,7 @@ def inasafe_place_value_coefficient(number, feature, parent):
     if number >= 0:
         rounded_number = round_affected_number(
             number,
-            enable_rounding=True,
+            use_rounding=True,
             use_population_rounding=True
         )
         min_number = 1000

--- a/safe/gui/ui/dock_base.ui
+++ b/safe/gui/ui/dock_base.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>422</width>
+    <width>426</width>
     <height>657</height>
    </rect>
   </property>
@@ -228,9 +228,15 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="debug_mode">
+       <widget class="QToolButton" name="debug_group_button">
         <property name="text">
          <string>Debug</string>
+        </property>
+        <property name="popupMode">
+         <enum>QToolButton::MenuButtonPopup</enum>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonTextOnly</enum>
         </property>
        </widget>
       </item>

--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -122,6 +122,7 @@ from safe.definitions.provenance import (
     provenance_layer_analysis_impacted_id,
     provenance_layer_exposure_summary_id,
     provenance_crs,
+    provenance_use_rounding,
     provenance_debug_mode)
 from safe.definitions.reports.components import (
     infographic_report,
@@ -251,6 +252,7 @@ class ImpactFunction(object):
 
         # Use debug to store intermediate results
         self.debug_mode = False
+        self.use_rounding = True
 
         # Requested extent to use (according to the CRS property).
         self._requested_extent = None
@@ -338,6 +340,7 @@ class ImpactFunction(object):
         """
         properties = [
             'debug_mode',
+            'use_rounding',
             'requested_extent',
             'crs',
             'analysis_extent',
@@ -2455,6 +2458,7 @@ class ImpactFunction(object):
             self.analysis_impacted,
             self.exposure,
             self.hazard,
+            self.use_rounding,
             self.debug_mode)
 
         # Let's style layers which have a geometry and have hazard_class
@@ -2559,6 +2563,10 @@ class ImpactFunction(object):
         # CRS
         set_provenance(
             self._provenance, provenance_crs, self._crs.authid())
+
+        # Rounding
+        set_provenance(
+            self._provenance, provenance_use_rounding, self.use_rounding)
 
         # Debug mode
         set_provenance(
@@ -2750,6 +2758,10 @@ class ImpactFunction(object):
         earthquake_function = get_provenance(
             provenance, provenance_earthquake_function)
         impact_function._earthquake_function = earthquake_function
+
+        # Use rounding
+        impact_function.use_rounding = get_provenance(
+            provenance, provenance_use_rounding)
 
         # Debug mode
         debug_mode = get_provenance(provenance, provenance_debug_mode)

--- a/safe/impact_function/style.py
+++ b/safe/impact_function/style.py
@@ -100,6 +100,7 @@ def generate_classified_legend(
         analysis,
         exposure,
         hazard,
+        use_rounding,
         debug_mode):
     """Generate an ordered python structure with the classified symbology.
 
@@ -112,7 +113,10 @@ def generate_classified_legend(
     :param hazard: The hazard layer.
     :type hazard: QgsVectorLayer
 
-    :param debug_mode: Boolean if run in debug mode.
+    :param use_rounding: Boolean if we round number in the legend.
+    :type use_rounding: bool
+
+    :param debug_mode: Boolean if run in debug mode,to display the not exposed.
     :type debug_mode: bool
 
     :return: The ordered dictionary to use to build the classified style.
@@ -165,9 +169,6 @@ def generate_classified_legend(
 
     classes = OrderedDict()
 
-    # In debug mode we don't round number.
-    enable_rounding = not debug_mode
-
     for i, hazard_class in enumerate(hazard_classification['classes']):
         # Get the hazard class name.
         field_name = hazard_count_field['field_name'] % hazard_class['key']
@@ -181,7 +182,7 @@ def generate_classified_legend(
             value = 0
         value = format_number(
             value,
-            enable_rounding,
+            use_rounding,
             exposure_definitions['use_population_rounding'],
             coefficient)
 
@@ -211,7 +212,7 @@ def generate_classified_legend(
     if exposure_definitions['display_not_exposed'] or debug_mode:
         classes[not_exposed_class['key']] = _add_not_exposed(
             analysis_row,
-            enable_rounding,
+            use_rounding,
             exposure_definitions['use_population_rounding'],
             exposure_unit['abbreviation'],
             coefficient)

--- a/safe/report/extractors/aggregate_postprocessors.py
+++ b/safe/report/extractors/aggregate_postprocessors.py
@@ -63,7 +63,7 @@ def aggregation_postprocessors_extractor(impact_report, component_metadata):
     aggregation_summary = impact_report.aggregation_summary
     analysis_layer = impact_report.analysis
     analysis_layer_fields = impact_report.analysis.keywords['inasafe_fields']
-    debug_mode = impact_report.impact_function.debug_mode
+    use_rounding = impact_report.impact_function.use_rounding
     use_aggregation = bool(impact_report.impact_function.provenance[
         'aggregation_layer'])
     provenance = impact_report.impact_function.provenance
@@ -149,7 +149,7 @@ def aggregation_postprocessors_extractor(impact_report, component_metadata):
                 age_items,
                 age_section_header,
                 use_aggregation=use_aggregation,
-                debug_mode=debug_mode,
+                use_rounding=use_rounding,
                 extra_component_args=extra_args)
         )
 
@@ -199,7 +199,7 @@ def aggregation_postprocessors_extractor(impact_report, component_metadata):
                 gender_items,
                 gender_section_header,
                 use_aggregation=use_aggregation,
-                debug_mode=debug_mode,
+                use_rounding=use_rounding,
                 extra_component_args=extra_args)
         )
 
@@ -250,7 +250,7 @@ def aggregation_postprocessors_extractor(impact_report, component_metadata):
                     vulnerability_items,
                     vulnerability_section_header,
                     use_aggregation=use_aggregation,
-                    debug_mode=debug_mode,
+                    use_rounding=use_rounding,
                     extra_component_args=extra_args)
             )
 
@@ -300,7 +300,7 @@ def aggregation_postprocessors_extractor(impact_report, component_metadata):
                 minimum_needs_items,
                 minimum_needs_section_header,
                 units_label=units_label,
-                debug_mode=debug_mode,
+                use_rounding=use_rounding,
                 extra_component_args=extra_args)
         )
     else:
@@ -322,7 +322,7 @@ def create_section(
         section_header,
         use_aggregation=True,
         units_label=None,
-        debug_mode=False,
+        use_rounding=True,
         extra_component_args=None):
     """Create demographic section context.
 
@@ -344,8 +344,8 @@ def create_section(
     :param units_label: Unit label for each column
     :type units_label: list[str]
 
-    :param debug_mode: flag for debug_mode, affect number representations
-    :type debug_mode: bool
+    :param use_rounding: flag for rounding, affect number representations
+    :type use_rounding: bool
 
     :param extra_component_args: extra_args passed from report component
         metadata
@@ -361,14 +361,14 @@ def create_section(
             aggregation_summary, analysis_layer, postprocessor_fields,
             section_header,
             units_label=units_label,
-            debug_mode=debug_mode,
+            use_rounding=use_rounding,
             extra_component_args=extra_component_args)
     else:
         return create_section_without_aggregation(
             aggregation_summary, analysis_layer, postprocessor_fields,
             section_header,
             units_label=units_label,
-            debug_mode=debug_mode,
+            use_rounding=use_rounding,
             extra_component_args=extra_component_args)
 
 
@@ -376,7 +376,7 @@ def create_section_with_aggregation(
         aggregation_summary, analysis_layer, postprocessor_fields,
         section_header,
         units_label=None,
-        debug_mode=False,
+        use_rounding=True,
         extra_component_args=None):
     """Create demographic section context with aggregation breakdown.
 
@@ -395,8 +395,8 @@ def create_section_with_aggregation(
     :param units_label: Unit label for each column
     :type units_label: list[str]
 
-    :param debug_mode: flag for debug_mode, affect number representations
-    :type debug_mode: bool
+    :param use_rounding: flag for rounding, affect number representations
+    :type use_rounding: bool
 
     :param extra_component_args: extra_args passed from report component
         metadata
@@ -411,7 +411,6 @@ def create_section_with_aggregation(
         'inasafe_fields']
     analysis_layer_fields = analysis_layer.keywords[
         'inasafe_fields']
-    enable_rounding = not debug_mode
 
     # retrieving postprocessor
     postprocessors_fields_found = []
@@ -516,7 +515,7 @@ def create_section_with_aggregation(
 
         total_displaced = format_number(
             feature[displaced_field_index],
-            enable_rounding=enable_rounding,
+            use_rounding=use_rounding,
             is_population=True)
 
         row = [
@@ -524,7 +523,7 @@ def create_section_with_aggregation(
             total_displaced,
         ]
 
-        if total_displaced == '0' and not debug_mode:
+        if total_displaced == '0' and not use_rounding:
             continue
 
         for output_field in postprocessors_fields_found:
@@ -534,7 +533,7 @@ def create_section_with_aggregation(
 
             value = format_number(
                 value,
-                enable_rounding=enable_rounding,
+                use_rounding=use_rounding,
                 is_population=True)
             row.append(value)
 
@@ -548,7 +547,7 @@ def create_section_with_aggregation(
         total_displaced_field_name, analysis_layer)
     value = format_number(
         value,
-        enable_rounding=enable_rounding,
+        use_rounding=use_rounding,
         is_population=True)
     total_header = resolve_from_dictionary(
         extra_component_args, ['defaults', 'total_header'])
@@ -561,7 +560,7 @@ def create_section_with_aggregation(
         value = value_from_field_name(field_name, analysis_layer)
         value = format_number(
             value,
-            enable_rounding=enable_rounding,
+            use_rounding=use_rounding,
             is_population=True)
         totals.append(value)
 
@@ -591,7 +590,7 @@ def create_section_without_aggregation(
         aggregation_summary, analysis_layer, postprocessor_fields,
         section_header,
         units_label=None,
-        debug_mode=False,
+        use_rounding=True,
         extra_component_args=None):
     """Create demographic section context without aggregation.
 
@@ -610,8 +609,8 @@ def create_section_without_aggregation(
     :param units_label: Unit label for each column
     :type units_label: list[str]
 
-    :param debug_mode: flag for debug_mode, affect number representations
-    :type debug_mode: bool
+    :param use_rounding: flag for rounding, affect number representations
+    :type use_rounding: bool
 
     :param extra_component_args: extra_args passed from report component
         metadata
@@ -624,7 +623,6 @@ def create_section_without_aggregation(
         'inasafe_fields']
     analysis_layer_fields = analysis_layer.keywords[
         'inasafe_fields']
-    enable_rounding = not debug_mode
 
     # retrieving postprocessor
     postprocessors_fields_found = []
@@ -692,7 +690,7 @@ def create_section_without_aggregation(
             analysis_layer)
         value = format_number(
             value,
-            enable_rounding=enable_rounding,
+            use_rounding=use_rounding,
             is_population=True)
         row.append(value)
 

--- a/safe/report/extractors/aggregate_result.py
+++ b/safe/report/extractors/aggregate_result.py
@@ -56,7 +56,7 @@ def aggregation_result_extractor(impact_report, component_metadata):
     aggregation_summary = impact_report.aggregation_summary
     aggregation_summary_fields = aggregation_summary.keywords[
         'inasafe_fields']
-    debug_mode = impact_report.impact_function.debug_mode
+    use_rounding = impact_report.impact_function.use_rounding
     use_aggregation = bool(
         impact_report.impact_function.provenance['aggregation_layer'])
     if not use_aggregation:
@@ -67,9 +67,7 @@ def aggregation_result_extractor(impact_report, component_metadata):
     # Only process for applicable exposure types
     # Get exposure type definition
     exposure_type = definition(exposure_keywords['exposure'])
-    # Only round the number when it is population exposure and it is not
-    # in debug mode
-    is_rounded = not debug_mode
+    # Only round the number when it is population exposure and we use rounding
     is_population = exposure_type is exposure_population
 
     # For now aggregation report only applicable for breakable exposure types:
@@ -133,7 +131,7 @@ def aggregation_result_extractor(impact_report, component_metadata):
     for feat in aggregation_summary.getFeatures():
         total_affected_value = format_number(
             feat[total_field_index],
-            enable_rounding=is_rounded,
+            use_rounding=use_rounding,
             is_population=is_population)
         if total_affected_value == '0':
             # skip aggregation type if the total affected is zero
@@ -149,7 +147,7 @@ def aggregation_result_extractor(impact_report, component_metadata):
         for idx in type_field_index:
             affected_value = format_number(
                 feat[idx],
-                enable_rounding=is_rounded)
+                use_rounding=use_rounding)
             type_values.append(affected_value)
         item['type_values'] = type_values
         rows.append(item)
@@ -187,7 +185,7 @@ def aggregation_result_extractor(impact_report, component_metadata):
         affected_value = int(float(feat[affected_field_index]))
         affected_value = format_number(
             affected_value,
-            enable_rounding=is_rounded,
+            use_rounding=use_rounding,
             is_population=is_population)
         value_dict[feat[breakdown_field_index]] = affected_value
 
@@ -219,7 +217,7 @@ def aggregation_result_extractor(impact_report, component_metadata):
         total_affected_field['field_name'])
     total_all = format_number(
         analysis_feature[field_index],
-        enable_rounding=is_rounded)
+        use_rounding=use_rounding)
 
     """Generate and format the context."""
     aggregation_area_default_header = resolve_from_dictionary(

--- a/safe/report/extractors/analysis_detail.py
+++ b/safe/report/extractors/analysis_detail.py
@@ -65,7 +65,7 @@ def analysis_detail_extractor(impact_report, component_metadata):
         exposure_summary_table_fields = exposure_summary_table.keywords[
             'inasafe_fields']
     provenance = impact_report.impact_function.provenance
-    debug_mode = impact_report.impact_function.debug_mode
+    use_rounding = impact_report.impact_function.use_rounding
     hazard_keywords = provenance['hazard_keywords']
     exposure_keywords = provenance['exposure_keywords']
 
@@ -77,9 +77,7 @@ def analysis_detail_extractor(impact_report, component_metadata):
 
     # Get exposure type definition
     exposure_type = definition(exposure_keywords['exposure'])
-    # Only round the number when it is population exposure and it is not
-    # in debug mode
-    is_rounding = not debug_mode
+    # Only round the number when it is population exposure and we use rounding
     is_population = exposure_type is exposure_population
 
     # action for places with poopulation exposure
@@ -248,7 +246,7 @@ def analysis_detail_extractor(impact_report, component_metadata):
                 count_value = int(float(feat[field_index]))
                 count_value = format_number(
                     count_value,
-                    enable_rounding=is_rounding,
+                    use_rounding=use_rounding,
                     is_population=is_population)
                 row.append({
                     'value': count_value,
@@ -276,7 +274,7 @@ def analysis_detail_extractor(impact_report, component_metadata):
             total_count = int(float(feat[field_index]))
             total_count = format_number(
                 total_count,
-                enable_rounding=is_rounding,
+                use_rounding=use_rounding,
                 is_population=is_population)
 
             # we comment below code because now we want to show all rows,
@@ -377,7 +375,7 @@ def analysis_detail_extractor(impact_report, component_metadata):
             field_index = analysis_layer.fieldNameIndex(field_name)
             count_value = format_number(
                 analysis_feature[field_index],
-                enable_rounding=is_rounding,
+                use_rounding=use_rounding,
                 is_population=is_population)
         except KeyError:
             # in case the field was not found
@@ -426,7 +424,7 @@ def analysis_detail_extractor(impact_report, component_metadata):
 
         total_count = format_number(
             total_count,
-            enable_rounding=is_rounding,
+            use_rounding=use_rounding,
             is_population=is_population)
         if group_key:
             if field == total_affected_field:
@@ -598,7 +596,7 @@ def analysis_detail_extractor(impact_report, component_metadata):
                     continue
                 total_count = format_number(
                     total_count,
-                    enable_rounding=is_rounding,
+                    use_rounding=use_rounding,
                     is_population=is_population)
                 row.append(total_count)
 

--- a/safe/report/extractors/analysis_provenance_details.py
+++ b/safe/report/extractors/analysis_provenance_details.py
@@ -9,6 +9,7 @@ from safe.definitions.provenance import (
     provenance_exposure_layer,
     provenance_hazard_layer,
     provenance_aggregation_layer,
+    provenance_use_rounding,
 )
 from safe.gis.tools import decode_full_layer_uri
 from safe.report.extractors.composer import QGISComposerContext
@@ -69,6 +70,7 @@ def analysis_provenance_details_extractor(impact_report, component_metadata):
         'aggregation_layer',
         'keywords_version']
 
+    use_rounding = impact_report.impact_function.use_rounding
     debug_mode = impact_report.impact_function.debug_mode
 
     # we define dict here to create a different object of keyword
@@ -166,10 +168,10 @@ def analysis_provenance_details_extractor(impact_report, component_metadata):
     all_provenance_keywords = dict(impact_report.impact_function.provenance)
 
     # we add debug mode information to the provenance
-    if debug_mode:
-        all_provenance_keywords['debug_mode'] = 'On'
-    else:
-        all_provenance_keywords['debug_mode'] = 'Off'
+    all_provenance_keywords[
+        provenance_use_rounding['provenance_key']] = (
+        'On' if use_rounding else 'Off')
+    all_provenance_keywords['debug_mode'] = 'On' if debug_mode else 'Off'
 
     header = resolve_from_dictionary(
         provenance_format_args, 'analysis_environment_header')
@@ -177,6 +179,7 @@ def analysis_provenance_details_extractor(impact_report, component_metadata):
     analysis_environment_provenance_keys = [
         'os',
         'inasafe_version',
+        provenance_use_rounding['provenance_key'],
         'debug_mode',
         'qgis_version',
         'qt_version',

--- a/safe/report/extractors/general_report.py
+++ b/safe/report/extractors/general_report.py
@@ -49,14 +49,12 @@ def general_report_extractor(impact_report, component_metadata):
     # figure out analysis report type
     analysis_layer = impact_report.analysis
     provenance = impact_report.impact_function.provenance
-    debug_mode = impact_report.impact_function.debug_mode
+    use_rounding = impact_report.impact_function.use_rounding
     hazard_keywords = provenance['hazard_keywords']
     exposure_keywords = provenance['exposure_keywords']
 
     exposure_type = definition(exposure_keywords['exposure'])
-    # Only round the number when it is population exposure and it is not
-    # in debug mode
-    is_rounded = not debug_mode
+    # Only round the number when it is population exposure and we use rounding
     is_population = exposure_type is exposure_population
 
     # find hazard class
@@ -98,7 +96,7 @@ def general_report_extractor(impact_report, component_metadata):
 
                 hazard_value = format_number(
                     analysis_feature[field_index],
-                    enable_rounding=is_rounded,
+                    use_rounding=use_rounding,
                     is_population=is_population)
                 stats = {
                     'key': hazard_class['key'],
@@ -121,7 +119,7 @@ def general_report_extractor(impact_report, component_metadata):
             field_name = analysis_inasafe_fields[total_exposed_field['key']]
             total = value_from_field_name(field_name, analysis_layer)
             total = format_number(
-                total, enable_rounding=is_rounded, is_population=is_population)
+                total, use_rounding=use_rounding, is_population=is_population)
             stats = {
                 'key': total_exposed_field['key'],
                 'name': total_exposed_field['name'],
@@ -156,7 +154,7 @@ def general_report_extractor(impact_report, component_metadata):
             else:
                 row_value = format_number(
                     analysis_feature[field_index],
-                    enable_rounding=is_rounded,
+                    use_rounding=use_rounding,
                     is_population=is_population)
             row_stats = {
                 'key': field['key'],
@@ -293,7 +291,7 @@ def multi_exposure_general_report_extractor(impact_report, component_metadata):
                     field_index = analysis_layer.fieldNameIndex(field_name)
                     hazard_value = format_number(
                         analysis_feature[field_index],
-                        enable_rounding=is_rounded,
+                        use_rounding=is_rounded,
                         is_population=is_population)
                 except KeyError:
                     # in case the field was not found
@@ -308,7 +306,7 @@ def multi_exposure_general_report_extractor(impact_report, component_metadata):
                 field_name = analysis_inasafe_fields[field_key_name]
                 total = value_from_field_name(field_name, analysis_layer)
                 total = format_number(
-                    total, enable_rounding=is_rounded,
+                    total, use_rounding=is_rounded,
                     is_population=is_population)
                 classification_result[total_exposed_field['key']] = total
             except KeyError:
@@ -331,7 +329,7 @@ def multi_exposure_general_report_extractor(impact_report, component_metadata):
                     field_index = analysis_layer.fieldNameIndex(field_name)
                     row_value = format_number(
                         analysis_feature[field_index],
-                        enable_rounding=is_rounded,
+                        use_rounding=is_rounded,
                         is_population=is_population)
 
             elif field in [displaced_field, fatalities_field]:
@@ -347,7 +345,7 @@ def multi_exposure_general_report_extractor(impact_report, component_metadata):
                     else:
                         row_value = format_number(
                             analysis_feature[field_index],
-                            enable_rounding=is_rounded,
+                            use_rounding=is_rounded,
                             is_population=is_population)
 
             reported_fields_result[field['key']] = row_value

--- a/safe/report/extractors/impact_table.py
+++ b/safe/report/extractors/impact_table.py
@@ -38,13 +38,12 @@ def impact_table_extractor(impact_report, component_metadata):
     """
     context = {}
     extra_args = component_metadata.extra_args
-    debug_mode = impact_report.impact_function.debug_mode
 
     components_list = resolve_from_dictionary(
         extra_args, 'components_list')
 
     # TODO: Decide either to use it or not
-    if not debug_mode:
+    if not impact_report.impact_function.debug_mode:
         # only show experimental MMI Detail when in debug mode
         components_list.pop('mmi_detail', None)
 

--- a/safe/report/extractors/minimum_needs.py
+++ b/safe/report/extractors/minimum_needs.py
@@ -38,8 +38,7 @@ def minimum_needs_extractor(impact_report, component_metadata):
     extra_args = component_metadata.extra_args
     analysis_layer = impact_report.analysis
     analysis_keywords = analysis_layer.keywords['inasafe_fields']
-    debug_mode = impact_report.impact_function.debug_mode
-    is_rounding = not debug_mode
+    use_rounding = impact_report.impact_function.use_rounding
 
     header = resolve_from_dictionary(extra_args, 'header')
     context['header'] = header
@@ -109,7 +108,7 @@ def minimum_needs_extractor(impact_report, component_metadata):
                 continue
             value = format_number(
                 analysis_feature[field_idx],
-                enable_rounding=is_rounding,
+                use_rounding=use_rounding,
                 is_population=True)
 
             unit_abbreviation = ''

--- a/safe/report/extractors/mmi_detail.py
+++ b/safe/report/extractors/mmi_detail.py
@@ -40,7 +40,7 @@ def mmi_detail_extractor(impact_report, component_metadata):
     analysis_layer = impact_report.analysis
     analysis_layer_keywords = analysis_layer.keywords
     extra_args = component_metadata.extra_args
-    enable_rounding = not impact_report.impact_function.debug_mode
+    use_rounding = impact_report.impact_function.use_rounding
     provenance = impact_report.impact_function.provenance
     hazard_keywords = provenance['hazard_keywords']
     exposure_keywords = provenance['exposure_keywords']
@@ -100,7 +100,7 @@ def mmi_detail_extractor(impact_report, component_metadata):
                 count = 0
             count = format_number(
                 count,
-                enable_rounding=enable_rounding,
+                use_rounding=use_rounding,
                 is_population=True)
             columns.append(count)
 
@@ -122,7 +122,7 @@ def mmi_detail_extractor(impact_report, component_metadata):
             total = 0
         total = format_number(
             total,
-            enable_rounding=enable_rounding,
+            use_rounding=use_rounding,
             is_population=True)
         total_footer.append(total)
 

--- a/safe/report/extractors/population_chart.py
+++ b/safe/report/extractors/population_chart.py
@@ -80,7 +80,7 @@ def population_chart_extractor(impact_report, component_metadata):
             hazard_value = value_from_field_name(field_name, analysis_layer)
             hazard_value = round_affected_number(
                 hazard_value,
-                enable_rounding=True,
+                use_rounding=True,
                 use_population_rounding=True)
         except KeyError:
             # in case the field was not found
@@ -96,7 +96,7 @@ def population_chart_extractor(impact_report, component_metadata):
         hazard_value = value_from_field_name(field_name, analysis_layer)
         hazard_value = round_affected_number(
             hazard_value,
-            enable_rounding=True,
+            use_rounding=True,
             use_population_rounding=True)
 
         data.append(hazard_value)

--- a/safe/report/impact_report.py
+++ b/safe/report/impact_report.py
@@ -712,7 +712,7 @@ class ImpactReport(object):
             except Exception as e:  # pylint: disable=broad-except
                 generation_error_code = self.REPORT_GENERATION_FAILED
                 LOGGER.info(e)
-                if self.impact_function.debug_mode:
+                if not self.impact_function.use_rounding:
                     raise
                 else:
                     message.add(failed_find_extractor)
@@ -732,7 +732,7 @@ class ImpactReport(object):
             except Exception as e:  # pylint: disable=broad-except
                 generation_error_code = self.REPORT_GENERATION_FAILED
                 LOGGER.info(e)
-                if self.impact_function.debug_mode:
+                if not self.impact_function.use_rounding:
                     raise
                 else:
                     message.add(failed_extract_context)
@@ -760,7 +760,7 @@ class ImpactReport(object):
             except Exception as e:  # pylint: disable=broad-except
                 generation_error_code = self.REPORT_GENERATION_FAILED
                 LOGGER.info(e)
-                if self.impact_function.debug_mode:
+                if not self.impact_function.use_rounding:
                     raise
                 else:
                     message.add(failed_find_renderer)
@@ -796,7 +796,7 @@ class ImpactReport(object):
                 except Exception as e:  # pylint: disable=broad-except
                     generation_error_code = self.REPORT_GENERATION_FAILED
                     LOGGER.info(e)
-                    if self.impact_function.debug_mode:
+                    if not self.impact_function.use_rounding:
                         raise
                     else:
                         message.add(failed_render_context)

--- a/safe/report/test/test_impact_report.py
+++ b/safe/report/test/test_impact_report.py
@@ -27,6 +27,7 @@ from safe.definitions.field_groups import (
     gender_displaced_count_group)
 from safe.definitions.hazard_classifications import flood_hazard_classes
 from safe.definitions.hazard import hazard_flood
+from safe.definitions.provenance import provenance_use_rounding
 from safe.impact_function.impact_function import ImpactFunction
 from safe.impact_function.multi_exposure_wrapper import \
     MultiExposureImpactFunction
@@ -1010,6 +1011,9 @@ class TestImpactReport(unittest.TestCase):
                 }), ('inasafe_version', {
                     'content': get_version(),
                     'header': 'InaSAFE Version '
+                }), (provenance_use_rounding['provenance_key'], {
+                    'content': 'On',
+                    'header': provenance_use_rounding['name'] + ' '
                 }), ('debug_mode', {
                     'content': 'Off',
                     'header': 'Debug Mode '

--- a/safe/utilities/rounding.py
+++ b/safe/utilities/rounding.py
@@ -17,14 +17,14 @@ __revision__ = '$Format:%H$'
 
 
 def format_number(
-        x, enable_rounding=True, is_population=False, coefficient=1):
+        x, use_rounding=True, is_population=False, coefficient=1):
     """Format a number according to the standards.
 
     :param x: A number to be formatted in a locale friendly way.
     :type x: int
 
-    :param enable_rounding: Flag to enable a rounding.
-    :type enable_rounding: bool
+    :param use_rounding: Flag to enable a rounding.
+    :type use_rounding: bool
 
     :param is_population: Flag if the number is population. It needs to be
         used with enable_rounding.
@@ -38,7 +38,7 @@ def format_number(
         x is simply returned.
     :rtype: basestring
     """
-    if enable_rounding:
+    if use_rounding:
         x = rounding(x, is_population)
 
     x /= coefficient
@@ -113,7 +113,7 @@ def thousand_separator():
 
 def round_affected_number(
         number,
-        enable_rounding=False,
+        use_rounding=False,
         use_population_rounding=False):
     """Tries to convert and round the number.
 
@@ -122,8 +122,8 @@ def round_affected_number(
     :param number: number represented as string or float
     :type number: str, float
 
-    :param enable_rounding: flag to enable rounding
-    :type enable_rounding: bool
+    :param use_rounding: flag to enable rounding
+    :type use_rounding: bool
 
     :param use_population_rounding: flag to enable population rounding scheme
     :type use_population_rounding: bool
@@ -132,10 +132,10 @@ def round_affected_number(
     """
     decimal_number = float(number)
     rounded_number = int(ceil(decimal_number))
-    if enable_rounding and use_population_rounding:
+    if use_rounding and use_population_rounding:
         # if uses population rounding
         return rounding(rounded_number, use_population_rounding)
-    elif enable_rounding:
+    elif use_rounding:
         return rounded_number
 
     return decimal_number


### PR DESCRIPTION
### What does it fix?
* Ticket: Working for #4828
* Funded by: DFAT
* Description: 
Debug mode is very strict by running more tests and saving to disk all intermediate layers. By adding this new flag, we can run the impact function quickly without the rounding

<img width="619" alt="screen shot 2018-01-09 at 11 11 17" src="https://user-images.githubusercontent.com/1609292/34710834-df4fa588-f52d-11e7-9c5a-8be794afa6a9.png">


### Checklist:
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR