### PR TITLE
enable earthquake_mmi_scale on place

### DIFF
--- a/safe/definitions/hazard_classifications.py
+++ b/safe/definitions/hazard_classifications.py
@@ -400,6 +400,7 @@ earthquake_mmi_scale = {
         }
     ],
     'exposures': [
+        exposure_place,
         exposure_population,
         exposure_road,
         exposure_structure


### PR DESCRIPTION
### What does it fix?

* Ticket: #4875 
* Funded by: 
* Description: 
  * Enable Earthquake MMI scale hazard classification to be used for place exposure.

<!-- screenshot if it's UI related -->

### Checklist:
<!--- Replace the space between square brackets by a `x` to make it checked -->
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
