### PR TITLE
Fix timezone conversion for shake_grid

### DIFF
--- a/safe/gui/tools/shake_grid/shake_grid.py
+++ b/safe/gui/tools/shake_grid/shake_grid.py
@@ -216,9 +216,9 @@ class ShakeGrid(object):
             self.day,
             self.hour,
             self.minute,
-            self.second,
-            # For now realtime always uses Indonesia Time
-            tzinfo=tzinfo)
+            self.second)
+        # For now realtime always uses Western Indonesia Time
+        self.time = tzinfo.localize(self.time)
 
     def parse_grid_xml(self):
         """Parse the grid xyz and calculate the bounding box of the event.


### PR DESCRIPTION
# Problem

The old shake grid code directly uses tzinfo to replace timezone information.
However in pytz, the timezone offset being used depends on the actual datetime it applies to.
For example, in the old code:
2018-01-01 07:07:00 Waktu Indonesia Barat if applied with timezone Asia/Jakarta directly using tzinfo, will have timezone offset +0707 (Batavia timezone in the old days), which means the previous datetime means 2018-01-01 00:00:00 in UTC.

# Solution

Apply the timezone using pytz localize method. With the following fix, the timezone offset will be correct: +0700 (Jakarta, modern times). Which means, the previous datetime will be correctly converted to UTC as 2018-01-01 00:07:00.

# Notes

Needed for PR: https://github.com/inasafe/inasafe-realtime/pull/194