### PR TITLE
add setting for inasafe output directory

### DIFF
--- a/safe/test/utilities.py
+++ b/safe/test/utilities.py
@@ -28,7 +28,7 @@ from safe.definitions.constants import HAZARD_EXPOSURE
 from safe.gis.tools import load_layer
 from safe.gis.vector.tools import create_memory_layer, copy_layer
 from safe.utilities.settings import (
-    general_setting, set_general_setting, set_setting)
+    general_setting, set_general_setting, set_setting, setting)
 from safe.utilities.utilities import (
     monkey_patch_keywords, reload_inasafe_modules)
 
@@ -86,6 +86,7 @@ def get_qgis_app(requested_locale='en_US', qsetting=''):
     else:
         settings = QSettings()
 
+    default_user_directory = setting('defaultUserDirectory')
     current_locale = general_setting(
         'locale/userLocale', default='en_US', qsettings=settings)
     locale_match = current_locale == requested_locale
@@ -131,6 +132,9 @@ def get_qgis_app(requested_locale='en_US', qsetting=''):
         set_setting('showRubberBands', True, settings)
         set_setting('show_extent_confirmations', False, settings)
         set_setting('analysis_extents_mode', HAZARD_EXPOSURE, settings)
+        if default_user_directory:
+            set_setting(
+                'defaultUserDirectory', default_user_directory, settings)
 
         # noinspection PyPep8Naming
         if 'argv' in dir(sys):


### PR DESCRIPTION
### What does it fix?
<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
If your PR doesn't fix entirely the ticket number, just add the ticket reference.
-->
* Ticket: #
* Funded by: DFAT
* Description: 
  * add setting for inasafe default output directory when reinstantiating qgis application

<!-- screenshot if it's UI related -->

### Checklist:
<!--- Replace the space between square brackets by a `x` to make it checked -->
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [ ] Request someone to review or test your PR
