### PR TITLE
Ensure that clean_layer updates layer with repaired geometries

### DIFF
--- a/safe/gis/vector/clean_geometry.py
+++ b/safe/gis/vector/clean_geometry.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 """Try to make a layer valid."""
+from qgis.core import QgsFeatureRequest
 
 from safe.common.custom_logging import LOGGER
 from safe.definitions.processing_steps import clean_geometry_steps
@@ -31,11 +32,12 @@ def clean_layer(layer):
     count = 0
 
     # iterate through all features
-    for feature in layer.getFeatures():
+    request = QgsFeatureRequest().setSubsetOfAttributes([])
+    for feature in layer.getFeatures(request):
         geom = feature.geometry()
         geometry_cleaned = geometry_checker(geom)
-        if geometry_cleaned:
-            feature.setGeometry(geometry_cleaned)
+        if geometry_cleaned and not geom.equals(geometry_cleaned):
+            layer.changeGeometry(feature.id(), geometry_cleaned, True)
         else:
             count += 1
             layer.deleteFeature(feature.id())
@@ -50,7 +52,6 @@ def clean_layer(layer):
 
     # save changes
     layer.commitChanges()
-
     layer.keywords['title'] = output_layer_name
 
     check_layer(layer)


### PR DESCRIPTION
The current clean_layer implementation checks and repairs the feature's geometries, but never actually writes any repaired geometries back to the layer. Accordingly the method currently:

1. Checks for validity, and attempts to fix invalid geometries
2. If the geometry repair fails, the feature IS correctly removed from the layer
BUT
3. If the geometry repair is successful, the repaired geometry is only set for the local copy of the feature, which is then discarded as it immediately goes out of scope.

With this change we correctly update the layer's stored geometry by calling  QgsVectorLayer.changeGeometry with the repaired geometry.

