### PR TITLE
Accept line layers for structures

### DIFF
--- a/safe/definitions/exposure.py
+++ b/safe/definitions/exposure.py
@@ -260,8 +260,8 @@ exposure_structure = {
     'description': tr(
         'A <b>structure</b> can be any relatively permanent man '
         'made feature such as a building (an enclosed structure '
-        'with walls and a roof), telecommunications facility or '
-        'bridge.'),
+        'with walls and a roof), telecommunications facility, power '
+        'lines or bridge.'),
     'notes': [
         {
             'item_category': 'structure_general',
@@ -312,7 +312,8 @@ exposure_structure = {
     ],
     'allowed_geometries': [
         'polygon',
-        'point'
+        'point',
+        'line'
     ],
     'size_unit': unit_square_metres,
     'units': [count_exposure_unit],

--- a/safe/definitions/test/test_utilities.py
+++ b/safe/definitions/test/test_utilities.py
@@ -199,7 +199,10 @@ class TestDefinitionsUtilities(unittest.TestCase):
                          dict_values_sorted(expected))
 
         exposures = exposures_for_layer('line')
-        expected = [exposure_road]
+        expected = [
+            exposure_road,
+            exposure_structure,
+        ]
         self.assertEqual(exposures, expected)
 
     def test_hazard_categories_for_layer(self):


### PR DESCRIPTION
To represents things like powerlines...

### What does it fix?
* Ticket: #
* Funded by: 
* Description: 
  * Accept lines layers for structure, which can be used to represent power lines (and probably some other structures as well, as bridges, pipelines, etc...).


### Checklist:
<!--- Replace the space between square brackets by a `x` to make it checked -->
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature => to small to be in changelog
- [ ] Unit test for new code added => no new logic
- [x] Request someone to review or test your PR
