### PR TITLE
Allow running postprocessors only for certain hazard and exposures

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -29,6 +29,7 @@ changelog=
     - QGIS3 port with Python 3 and Qt 5
     - Enable line for structure exposure
     - Add Tonga and Fiji currency and administration boundary definition
+    - Possibility to simply add postprocessors only for a certain combination of hazard and exposure
     Version 4.4.0:
     - Add Geonode uploader
     - Add back Sentry configuration (need to be enabled in your settings)

--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -187,7 +187,7 @@ from safe.impact_function.impact_function_utilities import (
     check_input_layer, report_urls)
 from safe.impact_function.postprocessors import (
     run_single_post_processor, enough_input, should_run,
-    )
+)
 from safe.impact_function.provenance_utilities import (
     get_map_title, get_analysis_question)
 from safe.impact_function.style import (

--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -2428,12 +2428,12 @@ class ImpactFunction():
                         LOGGER.info(message)
 
                 else:
-                    message = u'{name} : Could not run : {reason}'.format(
-                        name=name, reason=message)
-                    LOGGER.info(message)
+                    # message = u'{name} : Could not run : {reason}'.format(
+                    #     name=name, reason=message)
+                    # LOGGER.info(message)
                     pass
             else:
-                LOGGER.info(run_message)
+                # LOGGER.info(run_message)
                 pass
 
         self.debug_layer(layer, add_to_datastore=False)

--- a/safe/impact_function/postprocessors.py
+++ b/safe/impact_function/postprocessors.py
@@ -270,6 +270,13 @@ def run_single_post_processor(layer, post_processor):
 
 
 def should_run(keywords, post_processor):
+    """
+    Check if the postprocessor should run for the current hazard and exposure
+    :param keywords: impact layer keywords
+    :param post_processor: the post processor instance to check
+    :returns: Tuple with True if success, else False with an error message.
+    :rtype: (bool, str)
+    """
     exposure = keywords['exposure_keywords']['exposure']
     hazard = keywords['hazard_keywords']['hazard']
     try:
@@ -278,13 +285,13 @@ def should_run(keywords, post_processor):
         # if no run_filter is defined we run the postprocessor
         return True, None
 
-    msg = 'Postprocessor "{name}" did not run because hazard ' \
-          '"{hazard}" and exposure "{exposure}" are not in its ' \
-          'run_filter "{run_filter}"'.format(
-            name=post_processor['name'],
-            hazard=hazard,
-            exposure=exposure,
-            run_filter=run_filter)
+    msg = tr('Postprocessor "{name}" did not run because hazard "{hazard}" '
+             'and exposure "{exposure}" are not in its run_filter '
+             '"{run_filter}"'.format(
+                name=post_processor['name'],
+                hazard=hazard,
+                exposure=exposure,
+                run_filter=run_filter))
 
     # if an hazard filter is defined the current hazard needs to be defined in
     # there

--- a/safe/impact_function/postprocessors.py
+++ b/safe/impact_function/postprocessors.py
@@ -290,7 +290,6 @@ def should_run(keywords, post_processor):
         return True, None
 
 
-
 def enough_input(layer, post_processor_input):
     """Check if the input from impact_fields in enough.
 

--- a/safe/impact_function/postprocessors.py
+++ b/safe/impact_function/postprocessors.py
@@ -281,8 +281,10 @@ def should_run(keywords, post_processor):
     msg = 'Postprocessor "{name}" did not run because hazard ' \
           '"{hazard}" and exposure "{exposure}" are not in its ' \
           'run_filter "{run_filter}"'.format(
-        name=post_processor['name'], hazard=hazard,
-        exposure=exposure, run_filter=run_filter)
+            name=post_processor['name'],
+            hazard=hazard,
+            exposure=exposure,
+            run_filter=run_filter)
 
     # if an hazard filter is defined the current hazard needs to be defined in
     # there

--- a/safe/impact_function/postprocessors.py
+++ b/safe/impact_function/postprocessors.py
@@ -269,6 +269,28 @@ def run_single_post_processor(layer, post_processor):
     return True, None
 
 
+def should_run(keywords, post_processor):
+    exposure = keywords['exposure_keywords']['exposure']
+    hazard = keywords['hazard_keywords']['hazard']
+
+    try:
+        run_filter = post_processor['run_filter']
+        if (hazard in run_filter['hazard'] and
+                exposure in run_filter['exposure']):
+            return True, None
+        else:
+            msg = 'Postprocessor "{name}" did not run because hazard ' \
+                  '"{hazard}" and exposure "{exposure}" are not in its ' \
+                  'run_filter "{run_filter}"'.format(
+                    name=post_processor['name'], hazard=hazard,
+                    exposure=exposure, run_filter=run_filter)
+            return False, msg
+    except KeyError:
+        # if no should_run is defined we run the postprocessor
+        return True, None
+
+
+
 def enough_input(layer, post_processor_input):
     """Check if the input from impact_fields in enough.
 

--- a/safe/impact_function/postprocessors.py
+++ b/safe/impact_function/postprocessors.py
@@ -272,22 +272,29 @@ def run_single_post_processor(layer, post_processor):
 def should_run(keywords, post_processor):
     exposure = keywords['exposure_keywords']['exposure']
     hazard = keywords['hazard_keywords']['hazard']
-
     try:
         run_filter = post_processor['run_filter']
-        if (hazard in run_filter['hazard'] and
-                exposure in run_filter['exposure']):
-            return True, None
-        else:
-            msg = 'Postprocessor "{name}" did not run because hazard ' \
-                  '"{hazard}" and exposure "{exposure}" are not in its ' \
-                  'run_filter "{run_filter}"'.format(
-                    name=post_processor['name'], hazard=hazard,
-                    exposure=exposure, run_filter=run_filter)
-            return False, msg
     except KeyError:
-        # if no should_run is defined we run the postprocessor
+        # if no run_filter is defined we run the postprocessor
         return True, None
+
+    msg = 'Postprocessor "{name}" did not run because hazard ' \
+          '"{hazard}" and exposure "{exposure}" are not in its ' \
+          'run_filter "{run_filter}"'.format(
+        name=post_processor['name'], hazard=hazard,
+        exposure=exposure, run_filter=run_filter)
+
+    # if an hazard filter is defined the current hazard needs to be defined in
+    # there
+    if 'hazard' in run_filter and hazard not in run_filter['hazard']:
+        return False, msg
+
+    # if an exposure filter is defined the current exposure needs to be
+    # defined in there
+    if 'exposure' in run_filter and exposure not in run_filter['exposure']:
+        return False, msg
+
+    return True, None
 
 
 def enough_input(layer, post_processor_input):

--- a/safe/impact_function/postprocessors.py
+++ b/safe/impact_function/postprocessors.py
@@ -273,7 +273,9 @@ def should_run(keywords, post_processor):
     """
     Check if the postprocessor should run for the current hazard and exposure
     :param keywords: impact layer keywords
+    :type keywords: dict
     :param post_processor: the post processor instance to check
+    :type post_processor: dict
     :returns: Tuple with True if success, else False with an error message.
     :rtype: (bool, str)
     """

--- a/safe/impact_function/test/test_impact_function.py
+++ b/safe/impact_function/test/test_impact_function.py
@@ -861,7 +861,6 @@ class TestImpactFunction(unittest.TestCase):
         impact_layer.keywords['hazard_keywords'] = {
             'classification': 'flood_hazard_classes',
             'hazard': 'flood',
-
             }
         impact_layer.keywords['exposure_keywords'] = {
             'exposure': exposure_population['key'],

--- a/safe/impact_function/test/test_impact_function.py
+++ b/safe/impact_function/test/test_impact_function.py
@@ -859,8 +859,10 @@ class TestImpactFunction(unittest.TestCase):
             clone_to_memory=True)
 
         impact_layer.keywords['hazard_keywords'] = {
-            'classification': 'flood_hazard_classes'
-        }
+            'classification': 'flood_hazard_classes',
+            'hazard': 'flood',
+
+            }
         impact_layer.keywords['exposure_keywords'] = {
             'exposure': exposure_population['key'],
         }

--- a/safe/impact_function/test/test_postprocessors.py
+++ b/safe/impact_function/test/test_postprocessors.py
@@ -352,7 +352,7 @@ class TestPostProcessors(unittest.TestCase):
         # ###
         # Part 1 tests full run_filter defined (hazard and exposure)
         # ###
-        # Layer keywords
+        # Impact Layer fake keywords
         keywords = {
             'hazard_keywords': {
                 'hazard': 'flood',

--- a/safe/impact_function/test/test_postprocessors.py
+++ b/safe/impact_function/test/test_postprocessors.py
@@ -59,7 +59,8 @@ from safe.test.utilities import load_test_vector_layer
 from safe.impact_function.postprocessors import (
     run_single_post_processor,
     evaluate_formula,
-    enough_input, should_run,
+    enough_input,
+    should_run,
     )
 
 

--- a/safe/impact_function/test/test_postprocessors.py
+++ b/safe/impact_function/test/test_postprocessors.py
@@ -10,8 +10,14 @@ from safe.test.utilities import get_qgis_app
 
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app(qsetting=INASAFE_TEST)
 
-from safe.definitions.exposure import exposure_population
-from safe.definitions.hazard import hazard_generic
+from safe.definitions.exposure import (exposure_population,
+                                       exposure_structure,
+)
+from safe.definitions.hazard import (hazard_generic,
+                                     hazard_cyclone,
+                                     hazard_flood,
+                                     hazard_earthquake,
+)
 from safe.definitions.hazard_classifications import generic_hazard_classes
 from safe.definitions.fields import (
     male_displaced_count_field,
@@ -213,7 +219,7 @@ class TestPostProcessors(unittest.TestCase):
             'indivisible_polygon_impact.geojson',
             clone_to_memory=True)
         impact_layer.keywords['exposure_keywords'] = {
-            'exposure': 'population'
+            'exposure': exposure_population['key']
         }
         self.assertIsNotNone(impact_layer)
 
@@ -244,7 +250,7 @@ class TestPostProcessors(unittest.TestCase):
             'indivisible_polygon_impact.geojson',
             clone_to_memory=True)
         impact_layer.keywords['exposure_keywords'] = {
-            'exposure': 'population'
+            'exposure': exposure_population['key']
         }
         self.assertIsNotNone(impact_layer)
 
@@ -325,11 +331,11 @@ class TestPostProcessors(unittest.TestCase):
 
         # Need to add keywords on the fly.
         impact_layer.keywords['hazard_keywords'] = {
-            'hazard': 'flood',
+            'hazard': hazard_flood['key'],
             'classification': 'flood_hazard_classes'
         }
         impact_layer.keywords['exposure_keywords'] = {
-            'exposure': 'structure'
+            'exposure': exposure_structure['key']
         }
 
         result, message = run_single_post_processor(
@@ -346,8 +352,8 @@ class TestPostProcessors(unittest.TestCase):
 
         post_processor_fake = copy.deepcopy(post_processor_affected)
         post_processor_fake['run_filter'] = {
-            'hazard': ['flood', 'cyclone'],
-            'exposure': ['structure']
+            'hazard': [hazard_flood['key'], hazard_cyclone['key']],
+            'exposure': [exposure_structure['key']]
             }
 
         # ###
@@ -356,22 +362,22 @@ class TestPostProcessors(unittest.TestCase):
         # Impact Layer fake keywords
         keywords = {
             'hazard_keywords': {
-                'hazard': 'flood',
+                'hazard': hazard_flood['key'],
                 },
             'exposure_keywords': {
-                'exposure': 'structure'
+                'exposure': exposure_structure['key']
                 }
             }
         run, _ = should_run(keywords, post_processor_fake)
         self.assertTrue(run)
 
-        keywords['hazard_keywords']['hazard'] = 'cyclone'
-        keywords['exposure_keywords']['exposure'] = 'population'
+        keywords['hazard_keywords']['hazard'] = hazard_cyclone['key']
+        keywords['exposure_keywords']['exposure'] = exposure_population['key']
         run, _ = should_run(keywords, post_processor_fake)
         self.assertFalse(run)
 
-        keywords['hazard_keywords']['hazard'] = 'earthquake'
-        keywords['exposure_keywords']['exposure'] = 'structure'
+        keywords['hazard_keywords']['hazard'] = hazard_earthquake['key']
+        keywords['exposure_keywords']['exposure'] = exposure_structure['key']
         run, _ = should_run(keywords, post_processor_fake)
         self.assertFalse(run)
 
@@ -380,33 +386,34 @@ class TestPostProcessors(unittest.TestCase):
         # ###
 
         # no hazard run_filter defined
-        keywords['hazard_keywords']['hazard'] = 'earthquake'
-        keywords['exposure_keywords']['exposure'] = 'structure'
+        keywords['hazard_keywords']['hazard'] = hazard_earthquake['key']
+        keywords['exposure_keywords']['exposure'] = exposure_structure['key']
         del(post_processor_fake['run_filter']['hazard'])
         run, _ = should_run(keywords, post_processor_fake)
         self.assertTrue(run)
         post_processor_fake['run_filter']['hazard'] = [
-            'flood', 'cyclone']
+            hazard_flood['key'], hazard_cyclone['key']]
 
         # no exposure run_filter defined
-        keywords['hazard_keywords']['hazard'] = 'cyclone'
-        keywords['exposure_keywords']['exposure'] = 'population'
+        keywords['hazard_keywords']['hazard'] = hazard_cyclone['key']
+        keywords['exposure_keywords']['exposure'] = exposure_population['key']
         del(post_processor_fake['run_filter']['exposure'])
         run, _ = should_run(keywords, post_processor_fake)
         self.assertTrue(run)
-        post_processor_fake['run_filter']['exposure'] = ['structure']
+        post_processor_fake['run_filter']['exposure'] = [
+            exposure_structure['key']]
 
         # run_filter defined without content
-        keywords['hazard_keywords']['hazard'] = 'earthquake'
-        keywords['exposure_keywords']['exposure'] = 'population'
+        keywords['hazard_keywords']['hazard'] = hazard_earthquake['key']
+        keywords['exposure_keywords']['exposure'] = exposure_population['key']
         del(post_processor_fake['run_filter']['hazard'])
         del(post_processor_fake['run_filter']['exposure'])
         run, _ = should_run(keywords, post_processor_fake)
         self.assertTrue(run)
 
         # no run_filter defined
-        keywords['hazard_keywords']['hazard'] = 'earthquake'
-        keywords['exposure_keywords']['exposure'] = 'structure'
+        keywords['hazard_keywords']['hazard'] = hazard_earthquake['key']
+        keywords['exposure_keywords']['exposure'] = exposure_structure['key']
         del(post_processor_fake['run_filter'])
         run, _ = should_run(keywords, post_processor_fake)
         self.assertTrue(run)

--- a/safe/processors/__init__.py
+++ b/safe/processors/__init__.py
@@ -57,6 +57,7 @@ post_processors = [
      gender_vulnerability_postprocessors +
      productivity_post_processors) + [
     post_processor_additional_rice,
+    post_processor_filter_demo,
 ]
 
 pre_processors = [

--- a/safe/processors/__init__.py
+++ b/safe/processors/__init__.py
@@ -57,7 +57,6 @@ post_processors = [
      gender_vulnerability_postprocessors +
      productivity_post_processors) + [
     post_processor_additional_rice,
-    post_processor_filter_demo,
 ]
 
 pre_processors = [

--- a/safe/processors/population_post_processors.py
+++ b/safe/processors/population_post_processors.py
@@ -54,7 +54,7 @@ from safe.definitions.hazard_classifications import earthquake_mmi_scale
 from safe.processors import (
     function_process,
     formula_process,
-    )
+)
 from safe.processors.post_processor_functions import (
     multiply,
     post_processor_population_displacement_function,
@@ -66,7 +66,7 @@ from safe.processors.post_processor_inputs import (
     keyword_input_type,
     dynamic_field_input_type,
     keyword_value_expected,
-    )
+)
 from safe.utilities.i18n import tr
 
 # A postprocessor can be defined with a formula or with a python function.
@@ -871,8 +871,8 @@ all_population_post_processors = (
 # Adding requirement for exposure = population, beside exposed population
 # post processor
 population_exposure_filter = {
-        'exposure': [exposure_population['key']]
-    }
+    'exposure': [exposure_population['key']]
+}
 for pp in all_population_post_processors:
     try:
         pp['run_filter'].update(population_exposure_filter)

--- a/safe/processors/population_post_processors.py
+++ b/safe/processors/population_post_processors.py
@@ -74,6 +74,9 @@ post_processor_displaced_ratio = {
     'description': tr(
         'A post processor to add the population displacement ratio according '
         'to the hazard class'),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'hazard': {
             'type': keyword_input_type,
@@ -117,6 +120,9 @@ post_processor_displaced = {
         'A post processor to calculate the number of displaced people. '
         '"Displaced" is defined as: {displaced_concept}').format(
         displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         # input as a list means, try to get the input from the
         # listed source. Pick the first available
@@ -162,6 +168,9 @@ post_processor_fatality_ratio = {
         'A post processor to add the population fatality ratio according '
         'to the hazard class. Only the MMI classification has a fatality '
         'model.'),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         # Taking hazard classification
         'classification': {
@@ -204,6 +213,9 @@ post_processor_fatalities = {
     'name': tr('Fatalities Post Processor'),
     'description': tr(
         'A post processor to calculate the number of fatalities. '),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         # input as a list means, try to get the input from the
         # listed source. Pick the first available
@@ -246,6 +258,9 @@ post_processor_child_bearing_age = {
         child_bearing_age_concept=concepts[
             'child_bearing_age']['description'],
         displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -286,6 +301,9 @@ post_processor_pregnant = {
         pregnant_concept=concepts[
             'pregnant']['description'],
         displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -325,6 +343,9 @@ post_processor_lactating = {
         lactating_concept=concepts[
             'lactating']['description'],
         displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -364,6 +385,9 @@ post_processor_male = {
         '{displaced_concept}').format(
         male_concept=concepts['male']['description'],
         displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -403,6 +427,9 @@ post_processor_female = {
         '{displaced_concept}').format(
         female_concept=concepts['female']['description'],
         displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -441,6 +468,9 @@ post_processor_hygiene_packs = {
         'who are displaced. "Displaced" is defined as: '
         '{displaced_concept}').format(
             displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'female_displaced':
             {
@@ -472,6 +502,9 @@ post_processor_infant = {
         '{displaced_concept}').format(
             infant_concept=concepts['infant']['description'],
             displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -510,6 +543,9 @@ post_processor_child = {
         '{displaced_concept}').format(
             child_concept=concepts['child']['description'],
             displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -548,6 +584,9 @@ post_processor_youth = {
         '{displaced_concept}').format(
             youth_concept=concepts['youth']['description'],
             displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -586,6 +625,9 @@ post_processor_adult = {
         '{displaced_concept}').format(
             adult_concept=concepts['adult']['description'],
             displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -624,6 +666,9 @@ post_processor_elderly = {
         'defined as: {displaced_concept}').format(
             elderly_concept=concepts['elderly']['description'],
             displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -662,6 +707,9 @@ post_processor_under_5 = {
         '"Displaced" is defined as: {displaced_concept}').format(
         under_5_concept=concepts['under_5']['description'],
         displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -700,6 +748,9 @@ post_processor_over_60 = {
         '"Displaced" is defined as: {displaced_concept}').format(
         over_60_concept=concepts['over_60']['description'],
         displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -739,6 +790,9 @@ post_processor_disability_vulnerability = {
         '"Displaced" is defined as: {displaced_concept}').format(
         disabled_concept=concepts['disabled']['description'],
         displaced_concept=concepts['displaced_people']['description']),
+    'run_filter': {
+        'exposure': ['population']
+        },
     'input': {
         'population_displaced': {
             'value': displaced_field,

--- a/safe/processors/population_post_processors.py
+++ b/safe/processors/population_post_processors.py
@@ -76,7 +76,7 @@ post_processor_displaced_ratio = {
         'to the hazard class'),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'hazard': {
             'type': keyword_input_type,
@@ -122,7 +122,7 @@ post_processor_displaced = {
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         # input as a list means, try to get the input from the
         # listed source. Pick the first available
@@ -170,7 +170,7 @@ post_processor_fatality_ratio = {
         'model.'),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         # Taking hazard classification
         'classification': {
@@ -215,7 +215,7 @@ post_processor_fatalities = {
         'A post processor to calculate the number of fatalities. '),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         # input as a list means, try to get the input from the
         # listed source. Pick the first available
@@ -260,7 +260,7 @@ post_processor_child_bearing_age = {
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -303,7 +303,7 @@ post_processor_pregnant = {
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -345,7 +345,7 @@ post_processor_lactating = {
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -387,7 +387,7 @@ post_processor_male = {
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -429,7 +429,7 @@ post_processor_female = {
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -470,7 +470,7 @@ post_processor_hygiene_packs = {
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'female_displaced':
             {
@@ -504,7 +504,7 @@ post_processor_infant = {
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -545,7 +545,7 @@ post_processor_child = {
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -586,7 +586,7 @@ post_processor_youth = {
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -627,7 +627,7 @@ post_processor_adult = {
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -668,7 +668,7 @@ post_processor_elderly = {
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -709,7 +709,7 @@ post_processor_under_5 = {
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -750,7 +750,7 @@ post_processor_over_60 = {
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,
@@ -792,7 +792,7 @@ post_processor_disability_vulnerability = {
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
         'exposure': ['population']
-        },
+    },
     'input': {
         'population_displaced': {
             'value': displaced_field,

--- a/safe/processors/population_post_processors.py
+++ b/safe/processors/population_post_processors.py
@@ -75,7 +75,7 @@ post_processor_displaced_ratio = {
         'A post processor to add the population displacement ratio according '
         'to the hazard class'),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'hazard': {
@@ -169,7 +169,7 @@ post_processor_fatality_ratio = {
         'to the hazard class. Only the MMI classification has a fatality '
         'model.'),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         # Taking hazard classification
@@ -259,7 +259,7 @@ post_processor_child_bearing_age = {
             'child_bearing_age']['description'],
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -302,7 +302,7 @@ post_processor_pregnant = {
             'pregnant']['description'],
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -344,7 +344,7 @@ post_processor_lactating = {
             'lactating']['description'],
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -386,7 +386,7 @@ post_processor_male = {
         male_concept=concepts['male']['description'],
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -428,7 +428,7 @@ post_processor_female = {
         female_concept=concepts['female']['description'],
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -469,7 +469,7 @@ post_processor_hygiene_packs = {
         '{displaced_concept}').format(
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'female_displaced':
@@ -503,7 +503,7 @@ post_processor_infant = {
             infant_concept=concepts['infant']['description'],
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -544,7 +544,7 @@ post_processor_child = {
             child_concept=concepts['child']['description'],
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -585,7 +585,7 @@ post_processor_youth = {
             youth_concept=concepts['youth']['description'],
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -626,7 +626,7 @@ post_processor_adult = {
             adult_concept=concepts['adult']['description'],
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -667,7 +667,7 @@ post_processor_elderly = {
             elderly_concept=concepts['elderly']['description'],
             displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -708,7 +708,7 @@ post_processor_under_5 = {
         under_5_concept=concepts['under_5']['description'],
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -749,7 +749,7 @@ post_processor_over_60 = {
         over_60_concept=concepts['over_60']['description'],
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {
@@ -791,7 +791,7 @@ post_processor_disability_vulnerability = {
         disabled_concept=concepts['disabled']['description'],
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         'population_displaced': {

--- a/safe/processors/population_post_processors.py
+++ b/safe/processors/population_post_processors.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 from safe.definitions.concepts import concepts
 from safe.definitions.exposure import exposure_population
+from safe.definitions.hazard import hazard_earthquake
 # Displaced field
 from safe.definitions.fields import (
     child_bearing_age_displaced_count_field,
@@ -52,7 +53,8 @@ from safe.definitions.fields import (
 from safe.definitions.hazard_classifications import earthquake_mmi_scale
 from safe.processors import (
     function_process,
-    formula_process)
+    formula_process,
+    )
 from safe.processors.post_processor_functions import (
     multiply,
     post_processor_population_displacement_function,
@@ -63,7 +65,8 @@ from safe.processors.post_processor_inputs import (
     field_input_type,
     keyword_input_type,
     dynamic_field_input_type,
-    keyword_value_expected)
+    keyword_value_expected,
+    )
 from safe.utilities.i18n import tr
 
 # A postprocessor can be defined with a formula or with a python function.
@@ -169,7 +172,8 @@ post_processor_fatality_ratio = {
         'to the hazard class. Only the MMI classification has a fatality '
         'model.'),
     'run_filter': {
-        'exposure': [exposure_population['key']]
+        'exposure': [exposure_population['key']],
+        'hazard': [hazard_earthquake['key']]
     },
     'input': {
         # Taking hazard classification
@@ -866,12 +870,11 @@ all_population_post_processors = (
 
 # Adding requirement for exposure = population, beside exposed population
 # post processor
-population_exposure_input = {
-    'population_exposure': {
-        'type': keyword_value_expected,
-        'value': ['exposure_keywords', 'exposure'],
-        'expected_value': exposure_population['key']
+population_exposure_filter = {
+        'exposure': [exposure_population['key']]
     }
-}
 for pp in all_population_post_processors:
-    pp['input'].update(population_exposure_input)
+    try:
+        pp['run_filter'].update(population_exposure_filter)
+    except KeyError:
+        pp['run_filter'] = population_exposure_filter

--- a/safe/processors/population_post_processors.py
+++ b/safe/processors/population_post_processors.py
@@ -121,7 +121,7 @@ post_processor_displaced = {
         '"Displaced" is defined as: {displaced_concept}').format(
         displaced_concept=concepts['displaced_people']['description']),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         # input as a list means, try to get the input from the
@@ -214,7 +214,7 @@ post_processor_fatalities = {
     'description': tr(
         'A post processor to calculate the number of fatalities. '),
     'run_filter': {
-        'exposure': ['population']
+        'exposure': [exposure_population['key']]
     },
     'input': {
         # input as a list means, try to get the input from the

--- a/safe/processors/post_processors.py
+++ b/safe/processors/post_processors.py
@@ -288,7 +288,8 @@ post_processor_filter_demo = {
     'key': 'post_processor_filter_demo',
     'name': tr('Should run filter demo Processor'),
     'description': tr(
-        'A post processor to demo how to use the should run filter'
+        'A post processor to demo how to use the should run filter. this '
+        'postrocessor would run only for flood on structure'
     ),
     'run_filter': {
         'hazard': ['flood'],

--- a/safe/processors/post_processors.py
+++ b/safe/processors/post_processors.py
@@ -284,6 +284,12 @@ post_processor_affected = {
     }
 }
 
+# EXEMPLE Usage of a postprocessor with filters
+# from safe.definitions.hazard import (
+#     hazard_flood,
+#     hazard_cyclone,
+#     )
+# from safe.definitions.exposure import exposure_population
 # post_processor_filter_example = {
 #     'key': 'post_processor_filter_test',
 #     'name': tr('Should run filter Processor for tests'),
@@ -295,8 +301,8 @@ post_processor_affected = {
 #         'limitation only the specific field.'
 #     ),
 #     'run_filter': {
-#         'hazard': ['flood', 'cyclone'],
-#         'exposure': ['structure']
+#         'hazard': [hazard_flood['key']', hazard_cyclone['key']],
+#         'exposure': [exposure_structure['key']]
 #         },
 #     'input': {},
 #     'output': {}

--- a/safe/processors/post_processors.py
+++ b/safe/processors/post_processors.py
@@ -37,7 +37,7 @@ from safe.processors.post_processor_inputs import (
     size_calculator_input_value,
     keyword_input_type,
     field_input_type,
-    keyword_value_expected)
+    )
 from safe.utilities.i18n import tr
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
@@ -97,6 +97,10 @@ post_processor_distance = {
     'name': tr('Distance Post Processor'),
     'description': tr(
         'A post processor to calculate the distance between two points.'),
+    'run_filter': {
+         'hazard': [hazard_earthquake['key']],
+         'exposure': [exposure_place['key']]
+         },
     'input': {
         'distance_calculator': {
             'type': layer_property_input_type,
@@ -119,19 +123,9 @@ post_processor_distance = {
                 'hazard_keywords',
                 'extra_keywords',
                 extra_keyword_earthquake_longitude['key']
-            ]
+                ]
+            },
         },
-        'earthquake_hazard': {
-            'type': keyword_value_expected,
-            'value': ['hazard_keywords', 'hazard'],
-            'expected_value': hazard_earthquake['key']
-        },
-        'place_exposure': {
-            'type': keyword_value_expected,
-            'value': ['exposure_keywords', 'exposure'],
-            'expected_value': exposure_place['key']
-        }
-    },
     'output': {
         'size': {
             'value': distance_field,
@@ -147,6 +141,10 @@ post_processor_bearing = {
     'description': tr(
         'A post processor to calculate the bearing angle between two points.'
     ),
+    'run_filter':{
+        'hazard': [hazard_earthquake['key']],
+        'exposure': [exposure_place['key']]
+        },
     'input': {
         'place_geometry': {
             'type': geometry_property_input_type
@@ -167,16 +165,6 @@ post_processor_bearing = {
                 extra_keyword_earthquake_longitude['key']
             ]
         },
-        'earthquake_hazard': {
-            'type': keyword_value_expected,
-            'value': ['hazard_keywords', 'hazard'],
-            'expected_value': hazard_earthquake['key']
-        },
-        'place_exposure': {
-            'type': keyword_value_expected,
-            'value': ['exposure_keywords', 'exposure'],
-            'expected_value': exposure_place['key']
-        }
     },
     'output': {
         'size': {
@@ -193,21 +181,15 @@ post_processor_cardinality = {
     'description': tr(
         'A post processor to calculate the cardinality of an angle.'
     ),
+    'run_filter': {
+        'exposure': [exposure_place['key']],
+        'hazard': [hazard_earthquake['key']]
+    },
     'input': {
         'angle': {
             'type': field_input_type,
             'value': bearing_field
         },
-        'earthquake_hazard': {
-            'type': keyword_value_expected,
-            'value': ['hazard_keywords', 'hazard'],
-            'expected_value': hazard_earthquake['key']
-        },
-        'place_exposure': {
-            'type': keyword_value_expected,
-            'value': ['exposure_keywords', 'exposure'],
-            'expected_value': exposure_place['key']
-        }
     },
     'output': {
         'size': {

--- a/safe/processors/post_processors.py
+++ b/safe/processors/post_processors.py
@@ -284,40 +284,20 @@ post_processor_affected = {
     }
 }
 
-post_processor_filter_demo = {
-    'key': 'post_processor_filter_demo',
-    'name': tr('Should run filter demo Processor'),
-    'description': tr(
-        'A post processor to demo how to use the should run filter. this '
-        'postrocessor would run only for flood on structure'
-    ),
-    'run_filter': {
-        'hazard': ['flood'],
-        'exposure': ['structure']
-        },
-    'input': {
-        'hazard_class': {
-            'value': hazard_class_field,
-            'type': field_input_type,
-        },
-        'exposure': {
-            'type': keyword_input_type,
-            'value': ['exposure_keywords', 'exposure'],
-        },
-        'classification': {
-            'type': keyword_input_type,
-            'value': ['hazard_keywords', 'classification'],
-        },
-        'hazard': {
-            'type': keyword_input_type,
-            'value': ['hazard_keywords', 'hazard'],
-        },
-    },
-    'output': {
-        'affected': {
-            'value': affected_field,
-            'type': function_process,
-            'function': post_processor_affected_function
-        }
-    }
-}
+# post_processor_filter_example = {
+#     'key': 'post_processor_filter_test',
+#     'name': tr('Should run filter Processor for tests'),
+#     'description': tr(
+#         'A post processor to demo how to use the should run filter. this '
+#         'postrocessor would run only for flood or cyclone on structure. The '
+#         'run_filter can be completely omitted to allow the postprocessor to '
+#         'always run. Also only one of the two filters can be defined to put'
+#         'limitation only the specific field.'
+#     ),
+#     'run_filter': {
+#         'hazard': ['flood', 'cyclone'],
+#         'exposure': ['structure']
+#         },
+#     'input': {},
+#     'output': {}
+# }

--- a/safe/processors/post_processors.py
+++ b/safe/processors/post_processors.py
@@ -37,7 +37,7 @@ from safe.processors.post_processor_inputs import (
     size_calculator_input_value,
     keyword_input_type,
     field_input_type,
-    )
+)
 from safe.utilities.i18n import tr
 
 __copyright__ = "Copyright 2016, The InaSAFE Project"
@@ -98,9 +98,9 @@ post_processor_distance = {
     'description': tr(
         'A post processor to calculate the distance between two points.'),
     'run_filter': {
-         'hazard': [hazard_earthquake['key']],
-         'exposure': [exposure_place['key']]
-         },
+        'hazard': [hazard_earthquake['key']],
+        'exposure': [exposure_place['key']]
+    },
     'input': {
         'distance_calculator': {
             'type': layer_property_input_type,
@@ -123,9 +123,9 @@ post_processor_distance = {
                 'hazard_keywords',
                 'extra_keywords',
                 extra_keyword_earthquake_longitude['key']
-                ]
-            },
+            ]
         },
+    },
     'output': {
         'size': {
             'value': distance_field,
@@ -141,10 +141,10 @@ post_processor_bearing = {
     'description': tr(
         'A post processor to calculate the bearing angle between two points.'
     ),
-    'run_filter':{
+    'run_filter': {
         'hazard': [hazard_earthquake['key']],
         'exposure': [exposure_place['key']]
-        },
+    },
     'input': {
         'place_geometry': {
             'type': geometry_property_input_type

--- a/safe/processors/post_processors.py
+++ b/safe/processors/post_processors.py
@@ -283,3 +283,40 @@ post_processor_affected = {
         }
     }
 }
+
+post_processor_filter_demo = {
+    'key': 'post_processor_filter_demo',
+    'name': tr('Should run filter demo Processor'),
+    'description': tr(
+        'A post processor to demo how to use the should run filter'
+    ),
+    'run_filter': {
+        'hazard': ['flood'],
+        'exposure': ['structure']
+        },
+    'input': {
+        'hazard_class': {
+            'value': hazard_class_field,
+            'type': field_input_type,
+        },
+        'exposure': {
+            'type': keyword_input_type,
+            'value': ['exposure_keywords', 'exposure'],
+        },
+        'classification': {
+            'type': keyword_input_type,
+            'value': ['hazard_keywords', 'classification'],
+        },
+        'hazard': {
+            'type': keyword_input_type,
+            'value': ['hazard_keywords', 'hazard'],
+        },
+    },
+    'output': {
+        'affected': {
+            'value': affected_field,
+            'type': function_process,
+            'function': post_processor_affected_function
+        }
+    }
+}


### PR DESCRIPTION
* Funded by: GA
* Description: This PR adds the possibility to allow running a postprocessors only for certain hazard and exposures combination.
The run_filter can be completely omitted to allow the postprocessor to always run. Also only one of the two filters can be defined to put limitation only the specific field.

```post_processor_filter_example = {
    'key': 'post_processor_filter_test',
    'name': tr('Should run filter Processor for tests'),
    'description': tr(
        'A post processor to demo how to use the should run filter. this '
        'postrocessor would run only for flood or cyclone on structure. The '
        'run_filter can be completely omitted to allow the postprocessor to '
        'always run. Also only one of the two filters can be defined to put'
        'limitation only the specific field.'
    ),
    'run_filter': {
        'hazard': ['flood', 'cyclone'],
        'exposure': ['structure']
        },
    'input': {},
    'output': {}
}
```

All population_post_processors have been modified and have now a 
`'run_filter': {'exposure': ['population']}`

we are already implementing some fragility postprocessors that will need this to sun only in the desired cases. 
### Checklist:
<!--- Replace the space between square brackets by a `x` to make it checked -->
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Add to the changelog in metadata.txt if it's a new feature
- [x] Unit test for new code added
- [x] Request someone to review or test your PR
