### PR TITLE
Add customizability for impact report generation

### DIFF
--- a/safe/gis/test/test_tools.py
+++ b/safe/gis/test/test_tools.py
@@ -59,6 +59,19 @@ class GisToolsTest(unittest.TestCase):
         self.assertEqual(purpose, 'undefined')
         self.assertEqual(len(layer.fields()), 4)
 
+        # QLR
+        # This QLR contains a file based reference layer to
+        # small_grid.geojson, and it should work the same way
+        # as if we load small_grid.geojson
+        # In practice we could put the non file-based layer (PostGIS/WFS)
+        # and load it from QLR
+        path = standard_data_path(
+            'gisv4', 'aggregation', 'small_grid.qlr')
+        layer, purpose = load_layer(path)
+        self.assertTrue(layer.isValid())
+        self.assertEqual(layer.name(), 'small_grid')
+        self.assertEqual(purpose, 'aggregation')
+
     @unittest.skipIf(True, 'You need a PostGIS database and edit the URI.')
     def test_load_layer_from_uri_with_postgis(self):
         """Test we can load a layer with different parameters in POSTGIS."""

--- a/safe/gis/tools.py
+++ b/safe/gis/tools.py
@@ -11,6 +11,7 @@ from qgis.core import (
     QgsVectorLayer,
     QgsMapLayerRegistry,
     QgsDataSourceURI,
+    QgsMapLayer
 )
 
 from safe.common.exceptions import InvalidLayerError
@@ -297,6 +298,15 @@ def load_layer_without_provider(layer_uri, layer_name='tmp'):
     layer = QgsRasterLayer(layer_uri, layer_name, RASTER_DRIVERS[0])
     if layer.isValid():
         return layer
+
+    # Let's try QLR
+    _, extension = os.path.splitext(layer_uri)
+    if extension.lower() == '.qlr':
+        layer = QgsMapLayer.fromLayerDefinitionFile(layer_uri)
+        if layer:
+            layer = layer[0]
+        if layer.isValid():
+            return layer
 
     # Then try all other drivers
     for driver in VECTOR_DRIVERS[1:]:

--- a/safe/impact_function/impact_function.py
+++ b/safe/impact_function/impact_function.py
@@ -2882,7 +2882,8 @@ class ImpactFunction(object):
             iface=None,
             ordered_layers_uri=None,
             legend_layers_uri=None,
-            use_template_extent=False):
+            use_template_extent=False,
+            pre_process_callback=None):
         """Generate Impact Report independently by the Impact Function.
 
         :param components: Report components to be generated.
@@ -2902,6 +2903,12 @@ class ImpactFunction(object):
 
         :param use_template_extent: A condition for using template extent.
         :type use_template_extent: bool
+
+        :param pre_process_callback: A callback that will be executed before
+            running process_component.
+            An instance of impact_report will be passed down to this callback
+            function.
+        :type pre_process_callback: func(impact_report)
 
         :returns: Tuple of error code and message
         :type: tuple
@@ -3008,6 +3015,11 @@ class ImpactFunction(object):
                 self._impact_report.output_folder = output_folder
             else:
                 self._impact_report.output_folder = join(layer_dir, 'output')
+
+            # Run preprocess if any
+            if pre_process_callback and callable(pre_process_callback):
+                self._impact_report = pre_process_callback(
+                    impact_report=self.impact_report)
 
             error_code, message = self._impact_report.process_components()
             if error_code == ImpactReport.REPORT_GENERATION_FAILED:

--- a/safe/impact_function/multi_exposure_wrapper.py
+++ b/safe/impact_function/multi_exposure_wrapper.py
@@ -1131,7 +1131,8 @@ class MultiExposureImpactFunction(object):
             iface=None,
             ordered_layers_uri=None,
             legend_layers_uri=None,
-            use_template_extent=False):
+            use_template_extent=False,
+            pre_process_callback=None):
         """Generate Impact Report independently by the Impact Function.
 
         :param components: Report components to be generated.
@@ -1154,6 +1155,12 @@ class MultiExposureImpactFunction(object):
 
         :param use_template_extent: A condition for using template extent.
         :type use_template_extent: bool
+
+        :param pre_process_callback: A callback that will be executed before
+            running process_component.
+            An instance of impact_report will be passed down to this callback
+            function.
+        :type pre_process_callback: func(impact_report)
 
         :returns: Tuple of error code and message
         :type: tuple
@@ -1347,6 +1354,11 @@ class MultiExposureImpactFunction(object):
                 self._impact_report.output_folder = output_folder
             else:
                 self._impact_report.output_folder = join(layer_dir, 'output')
+
+            # Run preprocess if any
+            if pre_process_callback and callable(pre_process_callback):
+                self._impact_report = pre_process_callback(
+                    impact_report=self.impact_report)
 
             error_code, message = self._impact_report.process_components()
             if error_code == ImpactReport.REPORT_GENERATION_FAILED:

--- a/safe/report/impact_report.py
+++ b/safe/report/impact_report.py
@@ -249,6 +249,15 @@ class QGISCompositionContext(object):
         """
         return self._save_as_raster
 
+    @save_as_raster.setter
+    def save_as_raster(self, value):
+        """Boolean that indicates the composition will be saved as Raster.
+
+        :param value: bool value. Set true for raster.
+        :type value: bool
+        """
+        self._save_as_raster = value
+
 
 class ImpactReport(object):
 

--- a/safe/test/data/gisv4/aggregation/small_grid.qlr
+++ b/safe/test/data/gisv4/aggregation/small_grid.qlr
@@ -1,0 +1,316 @@
+<!DOCTYPE qgis-layer-definition>
+<qlr>
+  <layer-tree-group expanded="1" checked="Qt::Checked" name="">
+    <customproperties/>
+    <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="small_grid20181113205831516" source="./small_grid.geojson" name="small grid">
+      <customproperties/>
+    </layer-tree-layer>
+  </layer-tree-group>
+  <maplayers>
+    <maplayer simplifyAlgorithm="0" minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+      <id>small_grid20181113205831516</id>
+      <datasource>./small_grid.geojson</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>small grid</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="">
+        <map-layer-style name=""/>
+      </map-layer-style-manager>
+      <edittypes>
+        <edittype widgetv2type="TextEdit" name="area_name">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="area_id">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="fake_field">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="ratio_female">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+      </edittypes>
+      <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" type="fill" name="0">
+            <layer pass="0" class="SimpleFill" locked="0">
+              <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="color" v="59,85,134,255"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="0,0,0,255"/>
+              <prop k="outline_style" v="solid"/>
+              <prop k="outline_width" v="0.26"/>
+              <prop k="outline_width_unit" v="MM"/>
+              <prop k="style" v="no"/>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale scalemethod="diameter"/>
+      </renderer-v2>
+      <labeling type="simple"/>
+      <customproperties>
+        <property key="labeling" value="pal"/>
+        <property key="labeling/addDirectionSymbol" value="false"/>
+        <property key="labeling/angleOffset" value="0"/>
+        <property key="labeling/blendMode" value="0"/>
+        <property key="labeling/bufferBlendMode" value="0"/>
+        <property key="labeling/bufferColorA" value="255"/>
+        <property key="labeling/bufferColorB" value="255"/>
+        <property key="labeling/bufferColorG" value="255"/>
+        <property key="labeling/bufferColorR" value="255"/>
+        <property key="labeling/bufferDraw" value="false"/>
+        <property key="labeling/bufferJoinStyle" value="64"/>
+        <property key="labeling/bufferNoFill" value="false"/>
+        <property key="labeling/bufferSize" value="1"/>
+        <property key="labeling/bufferSizeInMapUnits" value="false"/>
+        <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/bufferTransp" value="0"/>
+        <property key="labeling/centroidInside" value="false"/>
+        <property key="labeling/centroidWhole" value="false"/>
+        <property key="labeling/decimals" value="3"/>
+        <property key="labeling/displayAll" value="false"/>
+        <property key="labeling/dist" value="0"/>
+        <property key="labeling/distInMapUnits" value="false"/>
+        <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/drawLabels" value="true"/>
+        <property key="labeling/enabled" value="true"/>
+        <property key="labeling/fieldName" value="area_id"/>
+        <property key="labeling/fitInPolygonOnly" value="false"/>
+        <property key="labeling/fontCapitals" value="0"/>
+        <property key="labeling/fontFamily" value=".SF NS Text"/>
+        <property key="labeling/fontItalic" value="false"/>
+        <property key="labeling/fontLetterSpacing" value="0"/>
+        <property key="labeling/fontLimitPixelSize" value="false"/>
+        <property key="labeling/fontMaxPixelSize" value="10000"/>
+        <property key="labeling/fontMinPixelSize" value="3"/>
+        <property key="labeling/fontSize" value="13"/>
+        <property key="labeling/fontSizeInMapUnits" value="false"/>
+        <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/fontStrikeout" value="false"/>
+        <property key="labeling/fontUnderline" value="false"/>
+        <property key="labeling/fontWeight" value="50"/>
+        <property key="labeling/fontWordSpacing" value="0"/>
+        <property key="labeling/formatNumbers" value="false"/>
+        <property key="labeling/isExpression" value="false"/>
+        <property key="labeling/labelOffsetInMapUnits" value="true"/>
+        <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/labelPerPart" value="false"/>
+        <property key="labeling/leftDirectionSymbol" value="&lt;"/>
+        <property key="labeling/limitNumLabels" value="false"/>
+        <property key="labeling/maxCurvedCharAngleIn" value="20"/>
+        <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
+        <property key="labeling/maxNumLabels" value="2000"/>
+        <property key="labeling/mergeLines" value="false"/>
+        <property key="labeling/minFeatureSize" value="0"/>
+        <property key="labeling/multilineAlign" value="0"/>
+        <property key="labeling/multilineHeight" value="1"/>
+        <property key="labeling/namedStyle" value=""/>
+        <property key="labeling/obstacle" value="true"/>
+        <property key="labeling/obstacleFactor" value="1"/>
+        <property key="labeling/obstacleType" value="0"/>
+        <property key="labeling/offsetType" value="0"/>
+        <property key="labeling/placeDirectionSymbol" value="0"/>
+        <property key="labeling/placement" value="1"/>
+        <property key="labeling/placementFlags" value="10"/>
+        <property key="labeling/plussign" value="false"/>
+        <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
+        <property key="labeling/preserveRotation" value="true"/>
+        <property key="labeling/previewBkgrdColor" value="#ffffff"/>
+        <property key="labeling/priority" value="5"/>
+        <property key="labeling/quadOffset" value="4"/>
+        <property key="labeling/repeatDistance" value="0"/>
+        <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/repeatDistanceUnit" value="1"/>
+        <property key="labeling/reverseDirectionSymbol" value="false"/>
+        <property key="labeling/rightDirectionSymbol" value=">"/>
+        <property key="labeling/scaleMax" value="10000000"/>
+        <property key="labeling/scaleMin" value="1"/>
+        <property key="labeling/scaleVisibility" value="false"/>
+        <property key="labeling/shadowBlendMode" value="6"/>
+        <property key="labeling/shadowColorB" value="0"/>
+        <property key="labeling/shadowColorG" value="0"/>
+        <property key="labeling/shadowColorR" value="0"/>
+        <property key="labeling/shadowDraw" value="false"/>
+        <property key="labeling/shadowOffsetAngle" value="135"/>
+        <property key="labeling/shadowOffsetDist" value="1"/>
+        <property key="labeling/shadowOffsetGlobal" value="true"/>
+        <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shadowOffsetUnits" value="1"/>
+        <property key="labeling/shadowRadius" value="1.5"/>
+        <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
+        <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shadowRadiusUnits" value="1"/>
+        <property key="labeling/shadowScale" value="100"/>
+        <property key="labeling/shadowTransparency" value="30"/>
+        <property key="labeling/shadowUnder" value="0"/>
+        <property key="labeling/shapeBlendMode" value="0"/>
+        <property key="labeling/shapeBorderColorA" value="255"/>
+        <property key="labeling/shapeBorderColorB" value="128"/>
+        <property key="labeling/shapeBorderColorG" value="128"/>
+        <property key="labeling/shapeBorderColorR" value="128"/>
+        <property key="labeling/shapeBorderWidth" value="0"/>
+        <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shapeBorderWidthUnits" value="1"/>
+        <property key="labeling/shapeDraw" value="false"/>
+        <property key="labeling/shapeFillColorA" value="255"/>
+        <property key="labeling/shapeFillColorB" value="255"/>
+        <property key="labeling/shapeFillColorG" value="255"/>
+        <property key="labeling/shapeFillColorR" value="255"/>
+        <property key="labeling/shapeJoinStyle" value="64"/>
+        <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shapeOffsetUnits" value="1"/>
+        <property key="labeling/shapeOffsetX" value="0"/>
+        <property key="labeling/shapeOffsetY" value="0"/>
+        <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shapeRadiiUnits" value="1"/>
+        <property key="labeling/shapeRadiiX" value="0"/>
+        <property key="labeling/shapeRadiiY" value="0"/>
+        <property key="labeling/shapeRotation" value="0"/>
+        <property key="labeling/shapeRotationType" value="0"/>
+        <property key="labeling/shapeSVGFile" value=""/>
+        <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shapeSizeType" value="0"/>
+        <property key="labeling/shapeSizeUnits" value="1"/>
+        <property key="labeling/shapeSizeX" value="0"/>
+        <property key="labeling/shapeSizeY" value="0"/>
+        <property key="labeling/shapeTransparency" value="0"/>
+        <property key="labeling/shapeType" value="0"/>
+        <property key="labeling/textColorA" value="255"/>
+        <property key="labeling/textColorB" value="0"/>
+        <property key="labeling/textColorG" value="0"/>
+        <property key="labeling/textColorR" value="0"/>
+        <property key="labeling/textTransp" value="0"/>
+        <property key="labeling/upsidedownLabels" value="0"/>
+        <property key="labeling/wrapChar" value=""/>
+        <property key="labeling/xOffset" value="0"/>
+        <property key="labeling/yOffset" value="0"/>
+        <property key="labeling/zIndex" value="0"/>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerTransparency>0</layerTransparency>
+      <displayfield>area_name</displayfield>
+      <label>0</label>
+      <labelattributes>
+        <label fieldname="" text="Label"/>
+        <family fieldname="" name=".SF NS Text"/>
+        <size fieldname="" units="pt" value="12"/>
+        <bold fieldname="" on="0"/>
+        <italic fieldname="" on="0"/>
+        <underline fieldname="" on="0"/>
+        <strikeout fieldname="" on="0"/>
+        <color fieldname="" red="0" blue="0" green="0"/>
+        <x fieldname=""/>
+        <y fieldname=""/>
+        <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
+        <angle fieldname="" value="0" auto="0"/>
+        <alignment fieldname="" value="center"/>
+        <buffercolor fieldname="" red="255" blue="255" green="255"/>
+        <buffersize fieldname="" units="pt" value="1"/>
+        <bufferenabled fieldname="" on=""/>
+        <multilineenabled fieldname="" on=""/>
+        <selectedonly on=""/>
+      </labelattributes>
+      <SingleCategoryDiagramRenderer diagramType="Pie" sizeLegend="0" attributeLegend="1">
+        <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="-4.65661e-10">
+          <fontProperties description=".SF NS Text,13,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
+        </DiagramCategory>
+        <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
+          <layer pass="0" class="SimpleMarker" locked="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="255,0,0,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="circle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="0,0,0,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0"/>
+            <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="2"/>
+            <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+          </layer>
+        </symbol>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings yPosColumn="-1" showColumn="0" linePlacementFlags="10" placement="0" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
+      <annotationform>.</annotationform>
+      <aliases>
+        <alias field="area_name" index="0" name=""/>
+        <alias field="area_id" index="1" name=""/>
+        <alias field="fake_field" index="2" name=""/>
+        <alias field="ratio_female" index="3" name=""/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <attributeactions default="-1"/>
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+        <columns/>
+      </attributetableconfig>
+      <editform>.</editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath>.</editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from PyQt4.QtGui import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <widgets/>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <defaults>
+        <default field="area_name" expression=""/>
+        <default field="area_id" expression=""/>
+        <default field="fake_field" expression=""/>
+        <default field="ratio_female" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
+    </maplayer>
+  </maplayers>
+</qlr>

--- a/safe/test/test_python_pep.py
+++ b/safe/test/test_python_pep.py
@@ -19,18 +19,15 @@ class TestPythonPep(unittest.TestCase):
         'We can use make flake8 separately')
     def test_flake8(self):
         """Test if the code is Flake8 compliant."""
-        if os.environ.get('ON_TRAVIS', False):
-            root = './'
-            command = ['make', 'flake8']
-            output = Popen(command, stdout=PIPE, cwd=root).communicate()[0]
-            default_number_lines = 5
-        elif sys.platform.startswith('win'):
+        # Root is the root path of the repo
+        root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '../../'))
+        if sys.platform.startswith('win'):
             # ET I don't know on windows.
             pass
 
         else:
             # OSX and linux just delegate to make
-            root = '../../'
             command = ['make', 'flake8']
             output = Popen(command, stdout=PIPE, cwd=root).communicate()[0]
             default_number_lines = 5
@@ -46,13 +43,14 @@ class TestPythonPep(unittest.TestCase):
         'We can use make pep257 separately')
     def test_pep257(self):
         """Test if docstrings are PEP257 compliant."""
+        # Root is the root path of the repo
+        root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '../../'))
         if os.environ.get('ON_TRAVIS', False):
-            root = './'
             command = ['make', 'pep257']
             output = Popen(command, stderr=PIPE, cwd=root).communicate()[1]
             default_number_lines = 0
         elif sys.platform.startswith('win'):
-            root = '../../'
             command = [
                 'pep257',
                 '--ignore=D102,D103,D104,D105,D200,D201,D202,D203,'
@@ -71,7 +69,6 @@ class TestPythonPep(unittest.TestCase):
 
         else:
             # OSX and linux just delegate to make
-            root = '../../'
             command = ['make', 'pep257']
             output = Popen(command, stderr=PIPE, cwd=root).communicate()[1]
             default_number_lines = 0


### PR DESCRIPTION
### Add callback option for impact report preproces

In some cases, we might want to have a pre process exactly before the report generated. E.g, change QGIS composition context, change settings, etc.

Also handle QLR layer input for Impact Report.

### Checklist:
<!--- Replace the space between square brackets by a `x` to make it checked -->
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [x] Unit test for new code added
- [x] Request someone to review or test your PR
