### PR TITLE
Fix raster classification issue

### DIFF
--- a/safe/gis/raster/clip_bounding_box.py
+++ b/safe/gis/raster/clip_bounding_box.py
@@ -83,7 +83,7 @@ def clip_by_extent(layer, extent):
         parameters['INPUT'] = layer.source()
         parameters['NO_DATA'] = ''
         parameters['PROJWIN'] = ','.join(bbox)
-        parameters['DATA_TYPE'] = 5
+        parameters['DATA_TYPE'] = 0
         parameters['COMPRESS'] = 4
         parameters['JPEGCOMPRESSION'] = 75
         parameters['ZLEVEL'] = 6


### PR DESCRIPTION
### What does it fix?
* Ticket: fix #5056
* Funded by: NERC NE/R014361/1
* Description: 
  * The bounding box clipping of the raster changed its type to integer, messing up the classification
  * Clipping now keeps the raster data type

<!-- screenshot if it's UI related -->

### Checklist:
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Add to the changelog in metadata.txt if it's a new feature
- [x] Unit test for new code added
- [ ] Request someone to review or test your PR
