### PR TITLE
Visible layers only flag default set to false

### DIFF
--- a/safe/definitions/default_settings.py
+++ b/safe/definitions/default_settings.py
@@ -9,7 +9,7 @@ from safe.definitions.currencies import idr
 from safe.definitions.messages import disclaimer
 
 inasafe_default_settings = {
-    'visibleLayersOnlyFlag': True,
+    'visibleLayersOnlyFlag': False,
     'set_layer_from_title_flag': True,
     'setZoomToImpactFlag': True,
     'set_show_only_impact_on_report': False,


### PR DESCRIPTION
Fix #5121 
* Ticket: #5121 
* Funded by: 
* Description: This changes the "Only show visible layers in the InaSAFE dock and in the wizard" default to be disabled.

Reasoning for this change:
- A user (especially a user new to QGIS or InaSAFE) will not always know that their layer (which has a keyword assigned) not showing as an option for an event, “how many” or aggregate area is caused by the layer being disabled in the QGIS layers list;
- If a user wants to disable the layer in the layers list to look at underlying layers (e.g. disable a layer which contains 100000s of buildings to look at a hazard layer), the layer will be removed from the selected event, “how many” and aggregate selection – this will not happen if this option is disabled;
- This might even result in another layer being selected (which is still active in the QGIS layers list), unknowingly to the user;
- Some data also loads extremely long, so a user might want to disable such a layer in the QGIS layers list for performance reasons, but with this option enabled they are forced to leave the layer active; and
- The option in the settings has NOT been removed. Its only the default which is changed to disable it to make it more user friendly for someone new to QGIS or InaSAFE. A user can still change this setting if they prefer it as such.

![image](https://github.com/inasafe/inasafe/assets/79740955/ec3ec104-c017-46ed-b57f-5f76016fb7fe)

### Checklist:
<!--- Replace the space between square brackets by a `x` to make it checked -->
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Add to the changelog in metadata.txt if it's a new feature
- [ ] Unit test for new code added
- [x] Request someone to review or test your PR
